### PR TITLE
Port beats to movement framework

### DIFF
--- a/movement/make/Makefile
+++ b/movement/make/Makefile
@@ -32,6 +32,7 @@ SRCS += \
   ../watch_faces/thermistor/thermistor_driver.c \
   ../watch_faces/thermistor/thermistor_readout_face.c \
   ../watch_faces/demos/character_set_face.c \
+  ../watch_faces/complications/beats_face.c \
 
 # Leave this line at the bottom of the file; it has all the targets for making your project.
 include $(TOP)/rules.mk

--- a/movement/movement_config.h
+++ b/movement/movement_config.h
@@ -7,6 +7,7 @@
 #include "pulsometer_face.h"
 #include "thermistor_readout_face.h"
 #include "character_set_face.h"
+#include "beats_face.h"
 
 const watch_face_t watch_faces[] = {
     simple_clock_face,

--- a/movement/watch_faces/complications/beats_face.c
+++ b/movement/watch_faces/complications/beats_face.c
@@ -1,0 +1,75 @@
+#include <stdlib.h>
+#include <string.h>
+#include "beats_face.h"
+#include "watch.h"
+
+const uint8_t UTC_OFFSET = 4; // set to your current UTC offset to see correct beats time
+const uint8_t BEAT_REFRESH_FREQUENCY = 8;
+
+void beats_face_setup(movement_settings_t *settings, void ** context_ptr) {
+    (void) settings;
+    (void) context_ptr;
+}
+
+void beats_face_activate(movement_settings_t *settings, void *context) {
+    (void) settings;
+    (void) context;
+    movement_request_tick_frequency(BEAT_REFRESH_FREQUENCY);
+}
+
+bool beats_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
+    (void) settings;
+    (void) context;
+
+    char buf[14];
+    float beats;
+
+    watch_date_time date_time;
+    switch (event.event_type) {
+        case EVENT_TICK:
+            date_time = watch_rtc_get_date_time();
+            beats = clock2beats(date_time.unit.hour, date_time.unit.minute, date_time.unit.second, event.subsecond, UTC_OFFSET);
+            sprintf(buf, "bt  %6.0f", beats * 100);
+
+            watch_display_string(buf, 0);
+            break;
+        case EVENT_LOW_ENERGY_UPDATE:
+            date_time = watch_rtc_get_date_time();
+            beats = clock2beats(date_time.unit.hour, date_time.unit.minute, date_time.unit.second, event.subsecond, UTC_OFFSET);
+            sprintf(buf, "bt  %4d  ", (int)beats);
+
+            watch_display_string(buf, 0);
+            break;
+        case EVENT_MODE_BUTTON_UP:
+            movement_move_to_next_face();
+            break;
+        case EVENT_LIGHT_BUTTON_DOWN:
+            movement_illuminate_led();
+            break;
+        case EVENT_ALARM_BUTTON_DOWN:
+        case EVENT_ALARM_BUTTON_UP:
+        case EVENT_ALARM_LONG_PRESS:
+        default:
+            break;
+    }
+
+    return true;
+}
+
+void beats_face_resign(movement_settings_t *settings, void *context) {
+    (void) settings;
+    (void) context;
+    movement_request_tick_frequency(1);
+}
+
+float clock2beats(uint16_t hours, uint16_t minutes, uint16_t seconds, uint16_t subseconds, int16_t utc_offset) {
+    float beats = seconds + ((float)subseconds / (float)BEAT_REFRESH_FREQUENCY);
+    beats += 60 * minutes;
+    beats += (float)hours * 60 * 60;
+    beats += (utc_offset + 1) * 60 * 60; // offset from utc + 1 since beats in in UTC+1
+
+    beats /= 86.4; // convert to beats
+    while(beats > 1000) beats -= 1000; // beats %= 1000 but for a float
+
+    return beats;
+}

--- a/movement/watch_faces/complications/beats_face.h
+++ b/movement/watch_faces/complications/beats_face.h
@@ -1,0 +1,20 @@
+#ifndef BEATS_FACE_H_
+#define BEATS_FACE_H_
+
+#include "movement.h"
+
+float clock2beats(uint16_t, uint16_t, uint16_t, uint16_t, int16_t);
+void beats_face_setup(movement_settings_t *settings, void ** context_ptr);
+void beats_face_activate(movement_settings_t *settings, void *context);
+bool beats_face_loop(movement_event_t event, movement_settings_t *settings, void *context);
+void beats_face_resign(movement_settings_t *settings, void *context);
+
+static const watch_face_t beats_face = {
+    beats_face_setup,
+    beats_face_activate,
+    beats_face_loop,
+    beats_face_resign,
+    NULL
+};
+
+#endif // BEATS_FACE_H_


### PR DESCRIPTION
Try out the new movement framework by porting the beats app to it.

The only bit that was tricky was getting the fractional beats to work properly and I'm not sure this works properly to be honest. I first tried to just change the refresh frequency like the pulsometer app does, but I don't think the `beats_face_loop` gets called with right frequency, so I went back to using `watch_rtc_register_periodic_callback` and some global variables