### PR TITLE
Add stopwatch face to movement

### DIFF
--- a/movement/make/Makefile
+++ b/movement/make/Makefile
@@ -36,6 +36,7 @@ SRCS += \
   ../watch_faces/demos/voltage_face.c \
   ../watch_faces/complications/beats_face.c \
   ../watch_faces/complications/day_one_face.c \
+  ../watch_faces/complications/stopwatch_face.c \
 
 # Leave this line at the bottom of the file; it has all the targets for making your project.
 include $(TOP)/rules.mk

--- a/movement/movement_config.h
+++ b/movement/movement_config.h
@@ -11,6 +11,7 @@
 #include "beats_face.h"
 #include "day_one_face.h"
 #include "voltage_face.h"
+#include "stopwatch_face.h"
 
 const watch_face_t watch_faces[] = {
     simple_clock_face,

--- a/movement/watch_faces/complications/stopwatch_face.c
+++ b/movement/watch_faces/complications/stopwatch_face.c
@@ -1,0 +1,76 @@
+#include <stdlib.h>
+#include <string.h>
+#include "stopwatch_face.h"
+#include "watch.h"
+
+void stopwatch_face_setup(movement_settings_t *settings, void ** context_ptr) {
+    (void) settings;
+    if (*context_ptr == NULL) *context_ptr = malloc(sizeof(stopwatch_state_t));
+}
+
+void stopwatch_face_activate(movement_settings_t *settings, void *context) {
+    (void) settings;
+    memset(context, 0, sizeof(stopwatch_state_t));
+}
+
+bool stopwatch_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
+    (void) settings;
+
+    stopwatch_state_t *stopwatch_state = (stopwatch_state_t *)context;
+    char buf[14];
+
+    switch (event.event_type) {
+        case EVENT_ACTIVATE:
+            watch_set_colon();
+            stopwatch_state->running = false;
+            watch_display_string("st 00000", 0);
+            break;
+        case EVENT_TICK:
+            if (stopwatch_state->running) {
+                stopwatch_state->seconds++;
+                if (stopwatch_state->seconds == 60) {
+                    stopwatch_state->minutes++;
+                    stopwatch_state->seconds = 0;
+                }
+                if (stopwatch_state->minutes == 60) {
+                    stopwatch_state->hours++;
+                    stopwatch_state->minutes = 0;
+                }
+            }
+
+            sprintf(buf, "st%2d%02d%02d", stopwatch_state->hours, stopwatch_state->minutes, stopwatch_state->seconds);
+            watch_display_string(buf, 0);
+            break;
+        case EVENT_MODE_BUTTON_UP:
+            movement_move_to_next_face();
+            break;
+        case EVENT_LIGHT_BUTTON_DOWN:
+            movement_illuminate_led();
+            if (!stopwatch_state->running) {
+                stopwatch_state->seconds = 0;
+                stopwatch_state->minutes = 0;
+                stopwatch_state->hours = 0;
+                watch_display_string("st 00000", 0);
+            }
+            break;
+        case EVENT_ALARM_BUTTON_DOWN:
+            stopwatch_state->running = !stopwatch_state->running;
+            break;
+        case EVENT_TIMEOUT:
+            // explicitly ignore the timeout event so we stay on screen
+            break;
+        case EVENT_LOW_ENERGY_UPDATE:
+            stopwatch_state->running = false;
+            watch_set_indicator(WATCH_INDICATOR_BELL);
+            break;
+        default:
+            break;
+    }
+
+    return true;
+}
+
+void stopwatch_face_resign(movement_settings_t *settings, void *context) {
+    (void) settings;
+    (void) context;
+}

--- a/movement/watch_faces/complications/stopwatch_face.h
+++ b/movement/watch_faces/complications/stopwatch_face.h
@@ -1,0 +1,26 @@
+#ifndef STOPWATCH_FACE_H_
+#define STOPWATCH_FACE_H_
+
+#include "movement.h"
+
+typedef struct {
+    bool running;
+    uint8_t seconds;
+    uint8_t minutes;
+    uint8_t hours;
+} stopwatch_state_t;
+
+void stopwatch_face_setup(movement_settings_t *settings, void ** context_ptr);
+void stopwatch_face_activate(movement_settings_t *settings, void *context);
+bool stopwatch_face_loop(movement_event_t event, movement_settings_t *settings, void *context);
+void stopwatch_face_resign(movement_settings_t *settings, void *context);
+
+static const watch_face_t stopwatch_face = {
+    stopwatch_face_setup,
+    stopwatch_face_activate,
+    stopwatch_face_loop,
+    stopwatch_face_resign,
+    NULL
+};
+
+#endif // STOPWATCH_FACE_H_


### PR DESCRIPTION
Simple stopwatch that only counts seconds (not subseconds), minutes and yes, even hours

Current status: broken because the low energy mode locks me out after a minute! I see there's a `_movement_reset_inactivity_countdown` in `movement.c` I could expose, but I'm wondering if you had a different idea in mind for letting a complication opt out of the low power mode