### PR TITLE
Move out of settings when face is changed

### DIFF
--- a/movement/watch_faces/complications/countdown_face.c
+++ b/movement/watch_faces/complications/countdown_face.c
@@ -158,6 +158,10 @@ bool countdown_face_loop(movement_event_t event, movement_settings_t *settings, 
             draw(state, event.subsecond);
             break;
         case EVENT_MODE_BUTTON_UP:
+            if (state->mode == cd_setting) {
+                state->mode = cd_waiting;
+                movement_request_tick_frequency(1);
+            }
             movement_move_to_next_face();
             break;
         case EVENT_LIGHT_BUTTON_UP:


### PR DESCRIPTION
While using the Countdown Face, I noticed that I would sometimes change the amount of time to countdown from instead of starting the timer. This occurred despite the fact that the numbers were not blinking.

I believe this is due to leaving the settings mode and entering another watch face. The countdown face remains in settings mode, but since the movement tick frequency reverts back to 1, the blink no longer occurs.

This commit moves into waiting mode if the Countdown Face is in settings mode and the user moves to the next face.

The order of operations to reproduce this on the previous versions is as follows.

Move to Countdown Face -> Enter Settings Mode -> Move out of Countdown Face -> Move back to Countdown Face -> Attempt to start the timer with Alarm button, but the timer amount increases instead.

I tested this commit and it does fix the issue for me.