### PR TITLE
Simple Clock: Update to signal exactly on the hour

### DIFF
--- a/movement/watch_faces/clock/simple_clock_face.c
+++ b/movement/watch_faces/clock/simple_clock_face.c
@@ -143,5 +143,5 @@ bool simple_clock_face_wants_background_task(movement_settings_t *settings, void
 
     watch_date_time date_time = watch_rtc_get_date_time();
 
-    return date_time.unit.minute == 59;
+    return date_time.unit.minute == 0;
 }


### PR DESCRIPTION
I was getting the buzzer at 59 minutes past the hour, not exactly on the hour. This changes to buzzing at exactly HOUR:00:00. Tested this locally.