### PR TITLE
Reset selection to 0 on resign from setting state

### DIFF
--- a/movement/watch_faces/complications/countdown_face.c
+++ b/movement/watch_faces/complications/countdown_face.c
@@ -221,6 +221,7 @@ void countdown_face_resign(movement_settings_t *settings, void *context) {
     (void) settings;
     countdown_state_t *state = (countdown_state_t *)context;
     if (state->mode == cd_setting) {
+        state->selection = 0;
         state->mode = cd_waiting;
     }
 }


### PR DESCRIPTION
I believe this also needs to be set back to 0 so the setting screen will resume at minutes, not potentially at settings on next run.