### PR TITLE
Add new function to disable certain RTC periodic callbacks

### DIFF
--- a/movement/movement.c
+++ b/movement/movement.c
@@ -155,13 +155,7 @@ void movement_request_tick_frequency(uint8_t freq) {
     if (freq == 128) return; // Movement uses the 128 Hz tick internally
 
     // disable all callbacks except the 128 Hz one
-#if __EMSCRIPTEN__
-    for (int i = 1; i < 128; i = i << 1) {
-        watch_rtc_disable_periodic_callback(i);
-    }
-#else
-    RTC->MODE2.INTENCLR.reg = 0xFE;
-#endif
+    watch_rtc_disable_matching_periodic_callbacks(0b01111111);
 
     movement_state.subsecond = 0;
     movement_state.tick_frequency = freq;

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -155,7 +155,7 @@ void movement_request_tick_frequency(uint8_t freq) {
     if (freq == 128) return; // Movement uses the 128 Hz tick internally
 
     // disable all callbacks except the 128 Hz one
-    watch_rtc_disable_matching_periodic_callbacks(0b01111111);
+    watch_rtc_disable_matching_periodic_callbacks(0xFE);
 
     movement_state.subsecond = 0;
     movement_state.tick_frequency = freq;

--- a/watch-library/hardware/watch/watch_rtc.c
+++ b/watch-library/hardware/watch/watch_rtc.c
@@ -102,8 +102,12 @@ void watch_rtc_disable_periodic_callback(uint8_t frequency) {
     RTC->MODE2.INTENCLR.reg = 1 << per_n;
 }
 
+void watch_rtc_disable_matching_periodic_callbacks(uint8_t mask) {
+    RTC->MODE2.INTENCLR.reg = mask;
+}
+
 void watch_rtc_disable_all_periodic_callbacks(void) {
-    RTC->MODE2.INTENCLR.reg = 0xFF;
+    watch_rtc_disable_matching_periodic_callbacks(0xFF);
 }
 
 void watch_rtc_register_alarm_callback(ext_irq_cb_t callback, watch_date_time alarm_time, watch_rtc_alarm_match mask) {

--- a/watch-library/shared/watch/watch_rtc.h
+++ b/watch-library/shared/watch/watch_rtc.h
@@ -138,7 +138,8 @@ void watch_rtc_register_periodic_callback(ext_irq_cb_t callback, uint8_t frequen
 void watch_rtc_disable_periodic_callback(uint8_t frequency);
 
 /** @brief Disables tick callbacks for the given periods (as a bitmask).
-  * @param mask The frequencies of tick callbacks you wish to disable, in Hz. To disable the 2 and 4 Hz callbacks, pass 0b00000110;
+  * @param mask The frequencies of tick callbacks you wish to disable, in Hz.
+  * The 128 Hz callback is 0b1, the 64 Hz callback is 0b10, the 32 Hz callback is 0b100, etc.
   */
 void watch_rtc_disable_matching_periodic_callbacks(uint8_t mask);
 

--- a/watch-library/shared/watch/watch_rtc.h
+++ b/watch-library/shared/watch/watch_rtc.h
@@ -137,6 +137,11 @@ void watch_rtc_register_periodic_callback(ext_irq_cb_t callback, uint8_t frequen
   */
 void watch_rtc_disable_periodic_callback(uint8_t frequency);
 
+/** @brief Disables tick callbacks for the given periods (as a bitmask).
+  * @param mask The frequencies of tick callbacks you wish to disable, in Hz. To disable the 2 and 4 Hz callbacks, pass 0b00000110;
+  */
+void watch_rtc_disable_matching_periodic_callbacks(uint8_t mask);
+
 /** @brief Disables all periodic callbacks, including the once-per-second tick callback.
   */
 void watch_rtc_disable_all_periodic_callbacks(void);

--- a/watch-library/simulator/watch/watch_rtc.c
+++ b/watch-library/simulator/watch/watch_rtc.c
@@ -115,7 +115,7 @@ void watch_rtc_disable_periodic_callback(uint8_t frequency) {
 
 void watch_rtc_disable_matching_periodic_callbacks(uint8_t mask) {
     for (int i = 0; i < 8; i++) {
-        if (tick_callbacks[i] != -1 && (mask & (1 << i)) != 0) {
+        if (tick_callbacks[i] != -1 && (mask & (1 << (7 - i))) != 0) {
             emscripten_clear_interval(tick_callbacks[i]);
             tick_callbacks[i] = -1;
         }

--- a/watch-library/simulator/watch/watch_rtc.c
+++ b/watch-library/simulator/watch/watch_rtc.c
@@ -113,13 +113,17 @@ void watch_rtc_disable_periodic_callback(uint8_t frequency) {
     }
 }
 
-void watch_rtc_disable_all_periodic_callbacks(void) {
+void watch_rtc_disable_matching_periodic_callbacks(uint8_t mask) {
     for (int i = 0; i < 8; i++) {
-        if (tick_callbacks[i] != -1) {
+        if (tick_callbacks[i] != -1 && (mask & (1 << i)) != 0) {
             emscripten_clear_interval(tick_callbacks[i]);
             tick_callbacks[i] = -1;
         }
     }
+}
+
+void watch_rtc_disable_all_periodic_callbacks(void) {
+    watch_rtc_disable_matching_periodic_callbacks(0xFF);
 }
 
 static void watch_invoke_alarm_interval_callback(void *userData) {


### PR DESCRIPTION
I added a `watch_rtc_disable_matching_periodic_callbacks()` function to remove the explicit Emscripten checks in `movement/movement.c`. This function takes a bit mask of callbacks to disable. For example, to disable the 2 Hz and 4 Hz callbacks, pass a `uint8_t` of `0b01100000`. Note that this is not the same as `2 | 4`. This bit mask encoding works because only powers of 2 are supported.