### PR TITLE
Add GitHub Workflow job to build and archive simulator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,6 @@ jobs:
         run: emmake make
         working-directory: 'movement/make'
       - name: Archive simulator build
-        if: ${{ matrix.target == 'simulator' }}
         working-directory: 'movement/make/build'
         run: |
           cp watch.html index.html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,3 +28,31 @@ jobs:
         with:
           name: watch.uf2
           path: movement/make/build/watch.uf2
+
+  build-simulator:
+    container:
+      image: emscripten/emsdk
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Compile starter-project app
+        run: emmake make
+        working-directory: 'apps/starter-project'
+      - name: Compile accelerometer-test app
+        run: emmake make
+        working-directory: 'apps/accelerometer-test'
+      - name: Compile movement
+        run: emmake make
+        working-directory: 'movement/make'
+      - name: Archive simulator build
+        if: ${{ matrix.target == 'simulator' }}
+        working-directory: 'movement/make/build'
+        run: |
+          cp watch.html index.html
+          tar -czf simulator.tar.gz index.html watch.wasm watch.js
+      - name: Upload simulator build
+        uses: actions/upload-artifact@v2
+        with:
+          name: simulator.tar.gz
+          path: movement/make/build/simulator.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,12 +36,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Compile starter-project app
-        run: emmake make
-        working-directory: 'apps/starter-project'
-      - name: Compile accelerometer-test app
-        run: emmake make
-        working-directory: 'apps/accelerometer-test'
       - name: Compile movement
         run: emmake make
         working-directory: 'movement/make'


### PR DESCRIPTION
I thought it might be useful to add a workflow job that builds & archives the Movement sub-project for the simulator target. At least to make sure everything works correctly before merging.