### PR TITLE
Tomato timer: pomodoro style timer

### DIFF
--- a/movement/make/Makefile
+++ b/movement/make/Makefile
@@ -56,6 +56,7 @@ SRCS += \
   ../watch_faces/complication/moon_phase_face.c \
   ../watch_faces/complication/orrery_face.c \
   ../watch_faces/complication/astronomy_face.c \
+  ../watch_faces/complication/tomato_face.c \
 # New watch faces go above this line.
 
 # Leave this line at the bottom of the file; it has all the targets for making your project.

--- a/movement/watch_faces/complication/countdown_face.c
+++ b/movement/watch_faces/complication/countdown_face.c
@@ -35,14 +35,6 @@
 #define DEFAULT_MINUTES 3
 
 
-static uint32_t offset_date_time(uint32_t now, int8_t hours, int8_t minutes, int8_t seconds) {
-    uint32_t new = now;
-    new += hours * 60 * 60;
-    new += minutes * 60;
-    new += seconds;
-    return new;
-}
-
 static inline int32_t get_tz_offset(movement_settings_t *settings) {
     return movement_timezone_offsets[settings->bit.time_zone] * 60;
 }
@@ -52,7 +44,7 @@ static void start(countdown_state_t *state, movement_settings_t *settings) {
 
     state->mode = cd_running;
     state->now_ts = watch_utility_date_time_to_unix_time(now, get_tz_offset(settings));
-    state->target_ts = offset_date_time(state->now_ts, 0, state->minutes, state->seconds);
+    state->target_ts = watch_utility_offset_timestamp(state->now_ts, 0, state->minutes, state->seconds);
     watch_date_time target_dt = watch_utility_date_time_from_unix_time(state->target_ts, get_tz_offset(settings));
     movement_schedule_background_task(target_dt);
     watch_set_indicator(WATCH_INDICATOR_BELL);

--- a/movement/watch_faces/complication/tomato_face.c
+++ b/movement/watch_faces/complication/tomato_face.c
@@ -1,0 +1,191 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Wesley Ellis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFtomato_ringEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "tomato_face.h"
+#include "watch_utility.h"
+
+static uint8_t focus_min = 25;
+static uint8_t break_min = 5;
+
+static inline int32_t get_tz_offset(movement_settings_t *settings) {
+    return movement_timezone_offsets[settings->bit.time_zone] * 60;
+}
+
+static uint8_t get_length(tomato_state_t *state) {
+    uint8_t length;
+    if (state->kind == tomato_focus) {
+        length = focus_min;
+    } else {
+        length = break_min;
+    }
+
+    return length;
+}
+
+static void tomato_start(tomato_state_t *state, movement_settings_t *settings) {
+    watch_date_time now = watch_rtc_get_date_time();
+    int8_t length = (int8_t) get_length(state);
+
+    state->mode = tomato_run;
+    state->now_ts = watch_utility_date_time_to_unix_time(now, get_tz_offset(settings));
+    state->target_ts = watch_utility_offset_timestamp(state->now_ts, 0, length, 0);
+    watch_date_time target_dt = watch_utility_date_time_from_unix_time(state->target_ts, get_tz_offset(settings));
+    movement_schedule_background_task(target_dt);
+    watch_set_indicator(WATCH_INDICATOR_BELL);
+}
+
+static void tomato_draw(tomato_state_t *state) {
+    char buf[16];
+
+    uint32_t delta;
+    div_t result;
+    uint8_t min = 0;
+    uint8_t sec = 0;
+    char kind;
+
+    if (state->kind == tomato_break) {
+        kind = 'b';
+    } else {
+        kind = 'f';
+    }
+
+    switch (state->mode) {
+        case tomato_run:
+            delta = state->target_ts - state->now_ts;
+            result = div(delta, 60);
+            min = result.quot;
+            sec = result.rem;
+            break;
+        case tomato_ready:
+            min = get_length(state);
+            sec = 0;
+            break;
+    }
+    sprintf(buf, "TO %c%2d%02d%2d", kind, min, sec, state->done_count);
+    watch_display_string(buf, 0);
+}
+
+static void tomato_reset(tomato_state_t *state) {
+    state->mode = tomato_ready;
+    movement_cancel_background_task();
+    watch_clear_indicator(WATCH_INDICATOR_BELL);
+}
+
+static void tomato_ring(tomato_state_t *state) {
+    movement_play_signal();
+    tomato_reset(state);
+    if (state->kind == tomato_focus) {
+        state->kind = tomato_break;
+        state->done_count++;
+    } else {
+        state->kind = tomato_focus;
+    }
+}
+
+void tomato_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {
+    (void) settings;
+    (void) watch_face_index;
+
+    if (*context_ptr == NULL) {
+        *context_ptr = malloc(sizeof(tomato_state_t));
+        tomato_state_t *state = (tomato_state_t*)*context_ptr;
+        memset(*context_ptr, 0, sizeof(tomato_state_t));
+        state->mode=tomato_ready;
+        state->kind= tomato_focus;
+        state->done_count = 0;
+    }
+}
+
+void tomato_face_activate(movement_settings_t *settings, void *context) {
+    tomato_state_t *state = (tomato_state_t *)context;
+    if (state->mode == tomato_run) {
+        watch_date_time now = watch_rtc_get_date_time();
+        state->now_ts = watch_utility_date_time_to_unix_time(now, get_tz_offset(settings));
+    }
+    watch_set_colon();
+}
+
+bool tomato_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
+    tomato_state_t *state = (tomato_state_t *)context;
+
+    switch (event.event_type) {
+        case EVENT_ACTIVATE:
+            tomato_draw(state);
+            break;
+        case EVENT_TICK:
+            if (state->mode == tomato_run) {
+                state->now_ts++;
+            }
+            tomato_draw(state);
+            break;
+        case EVENT_MODE_BUTTON_UP:
+            movement_move_to_next_face();
+            break;
+        case EVENT_LIGHT_BUTTON_UP:
+            movement_illuminate_led();
+            if (state->mode == tomato_ready) {
+                if (state->kind == tomato_break) {
+                    state->kind = tomato_focus;
+                } else {
+                    state->kind = tomato_break;
+                }
+            }
+            tomato_draw(state);
+            break;
+        case EVENT_ALARM_BUTTON_UP:
+            switch(state->mode) {
+                case tomato_run:
+                    tomato_reset(state);
+                    break;
+                case tomato_ready:
+                    tomato_start(state, settings);
+                    break;
+            }
+            tomato_draw(state);
+
+            break;
+        case EVENT_ALARM_LONG_PRESS:
+            state->done_count = 0;
+            break;
+        case EVENT_BACKGROUND_TASK:
+            tomato_ring(state);
+            tomato_draw(state);
+            break;
+        case EVENT_TIMEOUT:
+            movement_move_to_face(0);
+            break;
+        default:
+            break;
+    }
+
+    return true;
+}
+
+void tomato_face_resign(movement_settings_t *settings, void *context) {
+    (void) settings;
+    (void) context;
+}
+

--- a/movement/watch_faces/complication/tomato_face.h
+++ b/movement/watch_faces/complication/tomato_face.h
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022 Joey Castillo
+ * Copyright (c) 2022 Wesley Ellis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,32 +22,42 @@
  * SOFTWARE.
  */
 
-#ifndef MOVEMENT_FACES_H_
-#define MOVEMENT_FACES_H_
+#ifndef TOMATO_FACE_H_
+#define TOMATO_FACE_H_
 
-#include "simple_clock_face.h"
-#include "world_clock_face.h"
-#include "preferences_face.h"
-#include "set_time_face.h"
-#include "pulsometer_face.h"
-#include "thermistor_readout_face.h"
-#include "thermistor_logging_face.h"
-#include "character_set_face.h"
-#include "beats_face.h"
-#include "day_one_face.h"
-#include "voltage_face.h"
-#include "stopwatch_face.h"
-#include "totp_face.h"
-#include "lis2dh_logging_face.h"
-#include "demo_face.h"
-#include "hello_there_face.h"
-#include "sunrise_sunset_face.h"
-#include "countdown_face.h"
-#include "blinky_face.h"
-#include "moon_phase_face.h"
-#include "orrery_face.h"
-#include "astronomy_face.h"
-#include "tomato_face.h"
-// New includes go above this line.
+#include "movement.h"
 
-#endif // MOVEMENT_FACES_H_
+typedef enum {
+    tomato_ready,
+    tomato_run,
+    // to_pause, // TODO implement pausing
+} tomato_mode;
+
+typedef enum {
+    tomato_break,
+    tomato_focus,
+} tomato_kind;
+
+typedef struct {
+    uint32_t target_ts;
+    uint32_t now_ts;
+    tomato_mode mode;
+    tomato_kind kind;
+    uint8_t done_count;
+} tomato_state_t;
+
+void tomato_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr);
+void tomato_face_activate(movement_settings_t *settings, void *context);
+bool tomato_face_loop(movement_event_t event, movement_settings_t *settings, void *context);
+void tomato_face_resign(movement_settings_t *settings, void *context);
+
+#define tomato_face ((const watch_face_t){ \
+    tomato_face_setup, \
+    tomato_face_activate, \
+    tomato_face_loop, \
+    tomato_face_resign, \
+    NULL, \
+})
+
+#endif // TOMATO_FACE_H_
+

--- a/watch-library/shared/watch/watch_utility.c
+++ b/watch-library/shared/watch/watch_utility.c
@@ -188,3 +188,11 @@ float watch_utility_thermistor_temperature(uint16_t value, bool highside, float 
 
     return reading;
 }
+
+uint32_t watch_utility_offset_timestamp(uint32_t now, int8_t hours, int8_t minutes, int8_t seconds) {
+    uint32_t new = now;
+    new += hours * 60 * 60;
+    new += minutes * 60;
+    new += seconds;
+    return new;
+}

--- a/watch-library/shared/watch/watch_utility.h
+++ b/watch-library/shared/watch/watch_utility.h
@@ -124,4 +124,12 @@ watch_date_time watch_utility_date_time_convert_zone(watch_date_time date_time, 
   */
 float watch_utility_thermistor_temperature(uint16_t value, bool highside, float b_coefficient, float nominal_temperature, float nominal_resistance, float series_resistance);
 
+/** @brief Offset a timestamp by a given amount
+ * @param now Timestamp to offset from
+ * @param hours Number of hours to offset
+ * @param minutes Nmber of minutes to offset
+ * @param seconds Number of secodns to offset
+ */
+uint32_t watch_utility_offset_timestamp(uint32_t now, int8_t hours, int8_t minutes, int8_t seconds);
+
 #endif


### PR DESCRIPTION
Add a tomato timer watch face that alternates between 25 and 5 minute timers as in the [pomodoro technique](https://en.wikipedia.org/wiki/Pomodoro_Technique). I think Pomodoro might be copyright or something, so we just call it the tomato timer

![image](https://user-images.githubusercontent.com/362769/160307969-956b17f3-5611-4e7b-b15f-77991625f5a5.png)

The top right letter shows mode (f for focus or b for break). The bottom right shows how many focus sessions you've completed. (You can reset the count with a long press of alarm)

- When you show up and it says 25 minutes, you can start it (alarm), switch to 5 minute (light) mode or leave (mode)
- When it's running you can reset (alarm), or leave (mode)
- when it's done, we beep and go back to step 1, changing switching mode from focus to break (or break to focus)

I also pulled out a watch_utility_offset_timestamp and put it in watch_utitlity