### PR TITLE
Add break statement for EVENT_TICK in watch_face template

### DIFF
--- a/movement/template/template.c
+++ b/movement/template/template.c
@@ -52,6 +52,7 @@ bool <#watch_face_name#>_face_loop(movement_event_t event, movement_settings_t *
             break;
         case EVENT_TICK:
             // If needed, update your display here.
+            break;
         case EVENT_MODE_BUTTON_UP:
             // You shouldn't need to change this case; Mode almost always moves to the next watch face.
             movement_move_to_next_face();


### PR DESCRIPTION
Fixes an issue where if you generate a watch face using `watch_face.py`, the resulting `___face.c` has a bug where the EVENT_TICK case does not have a break statement and therefore falls through to EVENT_MODE_BUTTON_UP. 

The end result is the watch face displays, then on the first tick it immediately moves to the next watch face. I don't want to talk about how long it took me to figure out why my watch face was appearing for a second and then immediately going away 😅 