### PR TITLE
Add Devcontainer as an easy dev environment option

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,16 +1,39 @@
 FROM ubuntu:22.10
 
-# TODO: aarch64 support (gcc-arm-none-eabi-10.3-2021.07-aarch64-linux.tar.bz2)
 # TODO: install emscripten (https://emscripten.org/docs/getting_started/downloads.html)
 
-ARG TOOLCHAIN="https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.07/gcc-arm-none-eabi-10.3-2021.07-x86_64-linux.tar.bz2"
-ARG TOOLCHAIN_CHECKSUM="b56ae639d9183c340f065ae114a30202"
+# TODO: Clean this up once buildkit is supported gracefully in devcontainers
+# https://github.com/microsoft/vscode-remote-release/issues/1409
+
+ARG X86_64_TOOLCHAIN_FILENAME="gcc-arm-none-eabi-10.3-2021.07-x86_64-linux.tar.bz2"
+ARG X86_64_TOOLCHAIN="https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.07/gcc-arm-none-eabi-10.3-2021.07-x86_64-linux.tar.bz2"
+ARG X86_64_TOOLCHAIN_CHECKSUM="b56ae639d9183c340f065ae114a30202"
+
+ARG AARCH64_TOOLCHAIN_FILENAME="gcc-arm-none-eabi-10.3-2021.07-aarch64-linux.tar.bz2"
+ARG AARCH64_TOOLCHAIN="https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.07/gcc-arm-none-eabi-10.3-2021.07-aarch64-linux.tar.bz2"
+ARG AARCH64_TOOLCHAIN_CHECKSUM="c20b0535d01f8d4418341d893c62a782"
 
 WORKDIR /setup
 
-# Download and verify toolchain checksum
-ADD $TOOLCHAIN gcc-arm-none-eabi-x86_64-linux.tar.bz2
-RUN echo "${TOOLCHAIN_CHECKSUM} ./gcc-arm-none-eabi-x86_64-linux.tar.bz2" | md5sum --check
+# Download and verify both x86-64 and aarch64 toolchains. This is unfortunate and
+# slows down the build, but it's a clean-ish option until buildkit can be used.
+ADD $X86_64_TOOLCHAIN $X86_64_TOOLCHAIN_FILENAME
+ADD $AARCH64_TOOLCHAIN $AARCH64_TOOLCHAIN_FILENAME
+
+RUN echo "${X86_64_TOOLCHAIN_CHECKSUM} ${X86_64_TOOLCHAIN_FILENAME}" | md5sum --check
+RUN echo "${AARCH64_TOOLCHAIN_CHECKSUM} ${AARCH64_TOOLCHAIN_FILENAME}" | md5sum --check
+
+# Extract toolchain directly into /usr
+RUN /bin/sh -c 'set -ex && \
+    ARCH=`uname -m` && \
+    if [ "$ARCH" == "x86_64" ]; then \
+       tar --strip-components=1 -C /usr -xjf $X86_64_TOOLCHAIN_FILENAME \
+    else \
+       tar --strip-components=1 -C /usr -xjf $AARCH64_TOOLCHAIN_FILENAME ; \
+    fi'
+
+RUN rm $X86_64_TOOLCHAIN_FILENAME
+RUN rm $AARCH64_TOOLCHAIN_FILENAME
 
 # Install required packages
 RUN apt-get update \
@@ -25,7 +48,3 @@ RUN apt-get update \
     ca-certificates \
     # python is used to convert binaries to uf2 files
     python3 python-is-python3
-
-# Extract toolchain directly into /usr
-RUN tar --strip-components=1 -C /usr -xjf ./gcc-arm-none-eabi-x86_64-linux.tar.bz2
-RUN rm ./gcc-arm-none-eabi-x86_64-linux.tar.bz2

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,6 +15,20 @@ ARG AARCH64_TOOLCHAIN_CHECKSUM="c20b0535d01f8d4418341d893c62a782"
 
 WORKDIR /setup
 
+# Install required packages
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    # make is used as the build system
+    make \
+    # git is used for fetching submodules & interactive development
+    git \
+    # bzip2 is required to extract the Arm toolchain
+    bzip2 \
+    # ca certs need to be available for fetching git submodules
+    ca-certificates \
+    # python is used to convert binaries to uf2 files
+    python3 python-is-python3
+
 # Download and verify both x86-64 and aarch64 toolchains. This is unfortunate and
 # slows down the build, but it's a clean-ish option until buildkit can be used.
 ADD $X86_64_TOOLCHAIN $X86_64_TOOLCHAIN_FILENAME
@@ -34,17 +48,3 @@ RUN /bin/sh -c 'set -ex && \
 
 RUN rm $X86_64_TOOLCHAIN_FILENAME
 RUN rm $AARCH64_TOOLCHAIN_FILENAME
-
-# Install required packages
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-    # make is used as the build system
-    make \
-    # git is used for fetching submodules & interactive development
-    git \
-    # bzip2 is required to extract the Arm toolchain
-    bzip2 \
-    # ca certs need to be available for fetching git submodules
-    ca-certificates \
-    # python is used to convert binaries to uf2 files
-    python3 python-is-python3

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -26,8 +26,8 @@ RUN echo "${AARCH64_TOOLCHAIN_CHECKSUM} ${AARCH64_TOOLCHAIN_FILENAME}" | md5sum 
 # Extract toolchain directly into /usr
 RUN /bin/sh -c 'set -ex && \
     ARCH=`uname -m` && \
-    if [ "$ARCH" == "x86_64" ]; then \
-       tar --strip-components=1 -C /usr -xjf $X86_64_TOOLCHAIN_FILENAME \
+    if [ "$ARCH" = "x86_64" ]; then \
+       tar --strip-components=1 -C /usr -xjf $X86_64_TOOLCHAIN_FILENAME ; \
     else \
        tar --strip-components=1 -C /usr -xjf $AARCH64_TOOLCHAIN_FILENAME ; \
     fi'

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:22.10
+
+# TODO: aarch64 support (gcc-arm-none-eabi-10.3-2021.07-aarch64-linux.tar.bz2)
+# TODO: install emscripten (https://emscripten.org/docs/getting_started/downloads.html)
+
+ARG TOOLCHAIN="https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.07/gcc-arm-none-eabi-10.3-2021.07-x86_64-linux.tar.bz2"
+ARG TOOLCHAIN_CHECKSUM="b56ae639d9183c340f065ae114a30202"
+
+WORKDIR /setup
+
+# Download and verify toolchain checksum
+ADD $TOOLCHAIN gcc-arm-none-eabi-x86_64-linux.tar.bz2
+RUN echo "${TOOLCHAIN_CHECKSUM} ./gcc-arm-none-eabi-x86_64-linux.tar.bz2" | md5sum --check
+
+# Install required packages
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    # make is used as the build system
+    make \
+    # git is used for fetching submodules & interactive development
+    git \
+    # bzip2 is required to extract the Arm toolchain
+    bzip2 \
+    # ca certs need to be available for fetching git submodules
+    ca-certificates \
+    # python is used to convert binaries to uf2 files
+    python3 python-is-python3
+
+# Extract toolchain directly into /usr
+RUN tar --strip-components=1 -C /usr -xjf ./gcc-arm-none-eabi-x86_64-linux.tar.bz2
+RUN rm ./gcc-arm-none-eabi-x86_64-linux.tar.bz2

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.231.6/containers/docker-existing-dockerfile
+{
+    "name": "GNU Arm Embedded Environment",
+    // Sets the run context to one level up instead of the .devcontainer folder.
+    "context": "..",
+    // Set the location of the dockerfile to use
+    "dockerFile": "Dockerfile",
+    // Set *default* container specific settings.json values on container create.
+    "settings": {},
+    // Add the IDs of extensions you want installed when the container is created.
+    "extensions": [
+        "ms-vscode.cpptools"
+    ]
+    // Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+    // "remoteUser": "vscode"
+}


### PR DESCRIPTION
Add a [Devcontainer](https://code.visualstudio.com/docs/remote/containers) for a super simple setup experience. This allows folks to clone the repo and have a fully assembled development environment in VSCode.

Devcontainers are primarily used with VSCode and the [Remote - Containers](https://code.visualstudio.com/docs/remote/containers) extension. The [spec](https://github.com/devcontainers/spec) is open and there's a plan to build a standalone tool for launching devcontainers in the future.