### PR TITLE
Parallelize alternate fw builds

### DIFF
--- a/make.mk
+++ b/make.mk
@@ -24,6 +24,7 @@ else
 endif
 $(if ${VERBOSE},$(info OS detected: $(DETECTED_OS)))
 
+ifeq ($(OS), Windows_NT)
   MKDIR = gmkdir
 else
   MKDIR = mkdir

--- a/make.mk
+++ b/make.mk
@@ -9,7 +9,21 @@ endif
 ##############################################################################
 .PHONY: all directory clean size
 
-ifeq ($(OS), Windows_NT)
+# OS detection, adapted from https://gist.github.com/sighingnow/deee806603ec9274fd47
+DETECTED_OS :=
+ifeq ($(OS),Windows_NT)
+  DETECTED_OS = WINDOWS
+else
+  UNAME_S := $(shell uname -s)
+  ifeq ($(UNAME_S),Linux)
+    DETECTED_OS = LINUX
+  endif
+  ifeq ($(UNAME_S),Darwin)
+    DETECTED_OS = OSX
+  endif
+endif
+$(if ${VERBOSE},$(info OS detected: $(DETECTED_OS)))
+
   MKDIR = gmkdir
 else
   MKDIR = mkdir

--- a/make.mk
+++ b/make.mk
@@ -29,6 +29,17 @@ else
   MKDIR = mkdir
 endif
 
+ifeq ($(DETECTED_OS), LINUX)
+  MAKEFLAGS += -j `nproc`
+endif
+ifeq ($(DETECTED_OS), OSX)
+  NPROCS = $(shell sysctl hw.ncpu  | grep -o '[0-9]\+')
+  MAKEFLAGS += -j $(NPROCS)
+endif
+ifeq ($(DETECTED_OS), WINDOWS)
+  MAKEFLAGS += -j $(NUMBER_OF_PROCESSORS)
+endif
+
 ifndef EMSCRIPTEN
 CC = arm-none-eabi-gcc
 OBJCOPY = arm-none-eabi-objcopy

--- a/movement/make/make_alternate_fw.sh
+++ b/movement/make/make_alternate_fw.sh
@@ -22,11 +22,11 @@ do
     do
         COLOR=$(echo "$color" | tr '[:lower:]' '[:upper:]')
         make clean
-        make LED=$COLOR FIRMWARE=$VARIANT -j `nproc`
+        make LED=$COLOR FIRMWARE=$VARIANT
         mv "build/watch.uf2" "$fw_dir/$variant-$color.uf2"
     done
     make clean
-    emmake make FIRMWARE=$VARIANT -j `nproc`
+    emmake make FIRMWARE=$VARIANT
     mkdir "$sim_dir/$variant/"
     mv "build/watch.wasm" "$sim_dir/$variant/"
     mv "build/watch.js" "$sim_dir/$variant/"

--- a/movement/make/make_alternate_fw.sh
+++ b/movement/make/make_alternate_fw.sh
@@ -22,11 +22,11 @@ do
     do
         COLOR=$(echo "$color" | tr '[:lower:]' '[:upper:]')
         make clean
-        make LED=$COLOR FIRMWARE=$VARIANT
+        make LED=$COLOR FIRMWARE=$VARIANT -j `nproc`
         mv "build/watch.uf2" "$fw_dir/$variant-$color.uf2"
     done
     make clean
-    emmake make FIRMWARE=$VARIANT
+    emmake make FIRMWARE=$VARIANT -j `nproc`
     mkdir "$sim_dir/$variant/"
     mv "build/watch.wasm" "$sim_dir/$variant/"
     mv "build/watch.js" "$sim_dir/$variant/"

--- a/rules.mk
+++ b/rules.mk
@@ -7,9 +7,9 @@ SUBMODULES = tinyusb
 COBRA = cobra -f
 
 ifndef EMSCRIPTEN
-all: directory $(SUBMODULES) $(BUILD)/$(BIN).elf $(BUILD)/$(BIN).hex $(BUILD)/$(BIN).bin $(BUILD)/$(BIN).uf2 size
+all: $(BUILD)/$(BIN).elf $(BUILD)/$(BIN).hex $(BUILD)/$(BIN).bin $(BUILD)/$(BIN).uf2 size
 else
-all: directory $(SUBMODULES) $(BUILD)/$(BIN).html
+all: $(BUILD)/$(BIN).html
 endif
 
 $(BUILD)/$(BIN).html: $(OBJS)
@@ -35,13 +35,14 @@ $(BUILD)/$(BIN).uf2: $(BUILD)/$(BIN).bin
 	@echo UF2CONV $@
 	@$(UF2) $^ -co $@
 
+.phony: $(SUBMODULES)
 $(SUBMODULES):
 	git submodule update --init
 
 install:
 	@$(UF2) -D $(BUILD)/$(BIN).uf2
 
-%.o:
+$(BUILD)/%.o: | $(SUBMODULES) directory
 	@echo CC $@
 	@$(CC) $(CFLAGS) $(filter %/$(subst .o,.c,$(notdir $@)), $(SRCS)) -c -o $@
 
@@ -59,4 +60,6 @@ clean:
 analyze:
 	@$(COBRA) basic $(INCLUDES) $(DEFINES) $(SRCS)
 
--include $(wildcard $(BUILD)/*.d)
+DEPFILES := $(SRCS:%.c=$(BUILD)/%.d)
+
+-include $(wildcard $(DEPFILES))


### PR DESCRIPTION
The alternate fw build script performs a bunch of builds. Parallelizing the compilation of these builds speeds up the process by quite a bit.

I suspect you may have omitted this for a reason. If that's the case, I'd like to switch this PR to add some notes around parallel compilation issues.