### PR TITLE
Optimization: compare raw ADC battery readings

### DIFF
--- a/movement/watch_faces/clock/simple_clock_face.c
+++ b/movement/watch_faces/clock/simple_clock_face.c
@@ -72,11 +72,13 @@ bool simple_clock_face_loop(movement_event_t event, movement_settings_t *setting
             if (date_time.unit.day != state->last_battery_check) {
                 state->last_battery_check = date_time.unit.day;
                 watch_enable_adc();
-                uint16_t voltage = watch_get_vcc_voltage();
+            uint32_t voltage = watch_get_raw_vcc_voltage();
                 watch_disable_adc();
                 // 2.2 volts will happen when the battery has maybe 5-10% remaining?
                 // we can refine this later.
-                state->battery_low = (voltage < 2200);
+            uint16_t low_batt_threshold_mv = 2200;
+            uint32_t pre_scaled_value = (low_batt_threshold_mv * (1024 * 1 << 4)) / 1000;
+            state->battery_low = (voltage <= pre_scaled_value);
             }
 
             // ...and set the LAP indicator if low.

--- a/watch-library/hardware/watch/watch_adc.c
+++ b/watch-library/hardware/watch/watch_adc.c
@@ -171,7 +171,7 @@ void watch_set_analog_reference_voltage(watch_adc_reference_voltage reference) {
     _watch_get_analog_value(ADC_INPUTCTRL_MUXPOS_SCALEDCOREVCC);
 }
 
-uint16_t watch_get_vcc_voltage(void) {
+uint32_t watch_get_raw_vcc_voltage(void) {
     // stash the previous reference so we can restore it when we're done.
     uint8_t oldref = ADC->REFCTRL.bit.REFSEL;
 
@@ -183,6 +183,12 @@ uint16_t watch_get_vcc_voltage(void) {
 
     // restore the old reference, if needed.
     if (oldref != ADC_REFERENCE_INTREF) watch_set_analog_reference_voltage(oldref);
+
+    return raw_val;
+}
+
+uint16_t watch_get_vcc_voltage(void) {
+    uint32_t raw_val = watch_get_raw_vcc_voltage();
 
     return (uint16_t)((raw_val * 1000) / (1024 * 1 << ADC->AVGCTRL.bit.SAMPLENUM));
 }

--- a/watch-library/shared/watch/watch_adc.h
+++ b/watch-library/shared/watch/watch_adc.h
@@ -141,6 +141,13 @@ void watch_set_analog_reference_voltage(watch_adc_reference_voltage reference);
   */
 uint16_t watch_get_vcc_voltage(void);
 
+/** @brief Returns the voltage of the VCC supply as the raw ADC value that corresponds to VCC / 4.
+ *    If running on a coin cell, this will be the battery voltage.
+ * @note This function depends on INTREF being 1.024V. If you have changed it by poking at the supply
+ *       controller's VREF.SEL bits, this function will return inaccurate values.
+ */
+uint32_t watch_get_raw_vcc_voltage(void);
+
 /** @brief Disables the analog circuitry on the selected pin.
   * @param pin One of pins A0-A4.
   */


### PR DESCRIPTION
This is a silly optimization to make. It saves about four instructions
once a day when the battery is checked. There is a tiny bit of extra
hidden savings: those instructions happen while the ADC is enabled.
I'm sure it saves whole picojoules!

Note the operator change from less than to less than or equal. This is
due to a rounding difference when the raw ADC value is exactly equal to
the threshold value. I didn't work this through to a definitive answer
for where the rounding is happening. After the operator change, the code
displays equivalent behavior.

See this godbolt for more details https://godbolt.org/z/9W7vha5P6