### PR TITLE
Adjust probability watch face timeout/LE behavior

### DIFF
--- a/movement/watch_faces/complication/probability_face.c
+++ b/movement/watch_faces/complication/probability_face.c
@@ -166,8 +166,9 @@ bool probability_face_loop(movement_event_t event, movement_settings_t *settings
             // Dice rolling animation begins on next tick and new roll will be displayed on completion
             movement_request_tick_frequency(PROBABILITY_ANIMATION_TICK_FREQUENCY);
             break;
-        case EVENT_TIMEOUT:
-            movement_move_to_face(0);
+        case EVENT_LOW_ENERGY_UPDATE:
+            watch_display_string("      ", 4);
+            if (!watch_tick_animation_is_running()) watch_start_tick_animation(500);
             break;
         default:
             break;

--- a/movement/watch_faces/complication/probability_face.c
+++ b/movement/watch_faces/complication/probability_face.c
@@ -167,8 +167,7 @@ bool probability_face_loop(movement_event_t event, movement_settings_t *settings
             movement_request_tick_frequency(PROBABILITY_ANIMATION_TICK_FREQUENCY);
             break;
         case EVENT_LOW_ENERGY_UPDATE:
-            watch_display_string("      ", 4);
-            if (!watch_tick_animation_is_running()) watch_start_tick_animation(500);
+            watch_display_string("SLEEP ", 4);
             break;
         default:
             break;


### PR DESCRIPTION
@joeycastillo I realized yesterday that my probability watch face will timeout and go back to the first watch face after a minute (or whatever's in settings) of inactivity.

I think this is undesirable behavior because my main use case for this is rolling dice during a game, which you'd likely have to do multiple times while playing.

I've changed it to **not** timeout and instead just enter low energy mode after 1 hour (or whatever's in settings).

Question: Is it worth it to enter LE mode if my watch face doesn't really do anything when it's not being used? I'm assuming there are some power savings so I figured why not.