### PR TITLE
Replace python with python3 for calling uf2conv

### DIFF
--- a/make.mk
+++ b/make.mk
@@ -45,7 +45,7 @@ ifndef EMSCRIPTEN
 CC = arm-none-eabi-gcc
 OBJCOPY = arm-none-eabi-objcopy
 SIZE = arm-none-eabi-size
-UF2 = python $(TOP)/utils/uf2conv.py
+UF2 = python3 $(TOP)/utils/uf2conv.py
 
 CFLAGS += -W -Wall -Wextra -Wmissing-prototypes -Wmissing-declarations
 CFLAGS += --std=gnu99 -Os


### PR DESCRIPTION
Instead of calling python use python3.

On a default debian 11 install there is no python binary, only python3.
Given that the uf2conv script is written for python 3 I think this is a
safe change to make