### PR TITLE
movement: fix movement_request_wake() prototype

### DIFF
--- a/movement/movement.h
+++ b/movement/movement.h
@@ -288,7 +288,7 @@ void movement_schedule_background_task(watch_date_time date_time);
 // movement will associate the scheduled task with the currently active face.
 void movement_cancel_background_task(void);
 
-void movement_request_wake();
+void movement_request_wake(void);
 
 void movement_play_signal(void);
 void movement_play_alarm(void);


### PR DESCRIPTION
This function has `void` args, currently it can throw a compiler warning:

```
../movement.c:225:6: warning: no previous prototype for function 'movement_request_wake' [-Wmissing-prototypes]
void movement_request_wake() {
     ^
../movement.h:291:6: note: this declaration is not a prototype; add 'void' to make it a prototype for a zero-parameter function
void movement_request_wake();
     ^
                           void
```