### PR TITLE
Fix changed files detection in Make

### DIFF
--- a/make.mk
+++ b/make.mk
@@ -159,6 +159,7 @@ else
 
 CFLAGS += -W -Wall -Wextra -Wmissing-prototypes -Wmissing-declarations
 CFLAGS += -Wno-format -Wno-unused-parameter
+CFLAGS += -MD -MP -MT $(BUILD)/$(*F).o -MF $(BUILD)/$(@F).d
 
 INCLUDES += \
   -I$(TOP)/boards/$(BOARD) \

--- a/rules.mk
+++ b/rules.mk
@@ -1,3 +1,5 @@
+.SUFFIXES:
+
 CFLAGS += $(INCLUDES) $(DEFINES)
 
 OBJS = $(addprefix $(BUILD)/, $(notdir %/$(subst .c,.o, $(SRCS))))

--- a/rules.mk
+++ b/rules.mk
@@ -60,6 +60,6 @@ clean:
 analyze:
 	@$(COBRA) basic $(INCLUDES) $(DEFINES) $(SRCS)
 
-DEPFILES := $(SRCS:%.c=$(BUILD)/%.d)
+DEPFILES := $(OBJS:%.o=%.o.d)
 
 -include $(wildcard $(DEPFILES))


### PR DESCRIPTION
Detecting files changes doesn't work for me in the movement project. Whenever I change a source file, I have to run `make clean` and `make` to compile my changes.

AFAICT this is because of a broken expansion of the `DEPFILES` variable. If I add `$(warning DEPFILES=$(DEPFILES))` to the end of _rules.mk_ and run `make` in _movement/make_, I get something like

    ../../rules.mk:67: DEPFILES=./build/../../tinyusb/src/tusb.d ... ./build/../watch_faces/demo/hello_there_face.d ...

It somehow assumes that the .o.d. files have the same directory structure as the source files, but they are actually flat in the `$(BUILD)` directory. Consequently, adding `$(warning DEPFILES=$(wildcard $(DEPFILES)))` to _rules.mk_ just outputs

    ../../rules.mk:67: DEPFILES=

which just means no dependency files are actually included.

This change makes it derive the dependency file names from the object file names, which seems to work fine for me. Change detection works now, building all the projects from clean and dirty states also works for me.