### PR TITLE
Have setting to allow a long press to go back to the home screen

### DIFF
--- a/movement/movement.c
+++ b/movement/movement.c
@@ -409,7 +409,15 @@ bool app_loop(void) {
         can_sleep = watch_faces[movement_state.current_watch_face].loop(event, &movement_state.settings, watch_face_contexts[movement_state.current_watch_face]);
         // escape hatch: a watch face may not resign on EVENT_MODE_BUTTON_DOWN. In that case, a long press of MODE should let them out.
         if (event.event_type == EVENT_MODE_LONG_PRESS) {
-            movement_move_to_next_face();
+            if (movement_state.settings.bit.mode_long_press_home == true) {
+                if (movement_state.current_watch_face == 0) {
+                    movement_move_to_face(MODE_LONG_PRESS_HOME_REPEAT);
+                } else {
+                    movement_move_to_face(0);
+                }
+            } else {
+                movement_move_to_next_face();
+            }
             can_sleep = false;
         }
         event.event_type = EVENT_NONE;

--- a/movement/movement.h
+++ b/movement/movement.h
@@ -61,7 +61,10 @@ typedef union {
         // altimeter to display feet or meters as easily as it tells a thermometer to display degrees in F or C.
         bool clock_mode_24h : 1;            // indicates whether clock should use 12 or 24 hour mode.
         bool use_imperial_units : 1;        // indicates whether to use metric units (the default) or imperial.
-        uint8_t reserved : 7;               // room for more preferences if needed.
+
+        bool mode_long_press_home : 1;      // if true, long pressing mode goes to face 0 instead of the next face.
+
+        uint8_t reserved : 6;               // room for more preferences if needed.
     } bit;
     uint32_t reg;
 } movement_settings_t;

--- a/movement/movement_config.h
+++ b/movement/movement_config.h
@@ -39,4 +39,12 @@ const watch_face_t watch_faces[] = {
 
 #define MOVEMENT_NUM_FACES (sizeof(watch_faces) / sizeof(watch_face_t))
 
+/* Determines what face to go to from the first face if you've already set 
+ * a mode long press to go to the first face in preferences.
+ * Usually it makes sense to set this to the preferences face,
+ * so you can definitely get to it to disable this mode (in case one of the faces
+ * doesn't obey the short press).
+ */
+#define MODE_LONG_PRESS_HOME_REPEAT (MOVEMENT_NUM_FACES - 2)
+
 #endif // MOVEMENT_CONFIG_H_

--- a/movement/watch_faces/settings/preferences_face.c
+++ b/movement/watch_faces/settings/preferences_face.c
@@ -26,10 +26,11 @@
 #include "preferences_face.h"
 #include "watch.h"
 
-#define PREFERENCES_FACE_NUM_PREFEFENCES (7)
+#define PREFERENCES_FACE_NUM_PREFEFENCES (8)
 const char preferences_face_titles[PREFERENCES_FACE_NUM_PREFEFENCES][11] = {
     "CL        ",   // Clock: 12 or 24 hour
     "BT  Beep  ",   // Buttons: should they beep?
+    "MO  Home  ",   // Long press mode: should it go back to the clock face instead of advancing?
     "TO        ",   // Timeout: how long before we snap back to the clock face?
     "LE        ",   // Low Energy mode: how long before it engages?
     "LT        ",   // Light: duration
@@ -73,18 +74,21 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
                     settings->bit.button_should_sound = !(settings->bit.button_should_sound);
                     break;
                 case 2:
-                    settings->bit.to_interval = settings->bit.to_interval + 1;
+                    settings->bit.mode_long_press_home = !(settings->bit.mode_long_press_home);
                     break;
                 case 3:
-                    settings->bit.le_interval = settings->bit.le_interval + 1;
+                    settings->bit.to_interval = settings->bit.to_interval + 1;
                     break;
                 case 4:
-                    settings->bit.led_duration = settings->bit.led_duration + 1;
+                    settings->bit.le_interval = settings->bit.le_interval + 1;
                     break;
                 case 5:
-                    settings->bit.led_green_color = settings->bit.led_green_color + 1;
+                    settings->bit.led_duration = settings->bit.led_duration + 1;
                     break;
                 case 6:
+                    settings->bit.led_green_color = settings->bit.led_green_color + 1;
+                    break;
+                case 7:
                     settings->bit.led_red_color = settings->bit.led_red_color + 1;
                     break;
             }
@@ -111,6 +115,10 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
                 else watch_display_string("n", 9);
                 break;
             case 2:
+                if (settings->bit.mode_long_press_home) watch_display_string("y", 9);
+                else watch_display_string("n", 9);
+                break;
+            case 3:
                 switch (settings->bit.to_interval) {
                     case 0:
                         watch_display_string("60 SeC", 4);
@@ -126,7 +134,7 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
                         break;
                 }
                 break;
-            case 3:
+            case 4:
                 switch (settings->bit.le_interval) {
                     case 0:
                         watch_display_string(" Never", 4);
@@ -154,7 +162,7 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
                         break;
                 }
                 break;
-            case 4:
+            case 5:
                 if (settings->bit.led_duration) {
                     sprintf(buf, " %1d SeC", settings->bit.led_duration * 2 - 1);
                     watch_display_string(buf, 4);
@@ -162,19 +170,19 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
                     watch_display_string("no LEd", 4);
                 }
                 break;
-            case 5:
+            case 6:
                 sprintf(buf, "%2d", settings->bit.led_green_color);
                 watch_display_string(buf, 8);
                 break;
-            case 6:
+            case 7:
                 sprintf(buf, "%2d", settings->bit.led_red_color);
                 watch_display_string(buf, 8);
                 break;
         }
     }
 
-    // on LED color select screns, preview the color.
-    if (current_page >= 5) {
+    // on LED color select screens, preview the color.
+    if (current_page >= 6) {
         watch_set_led_color(settings->bit.led_red_color ? (0xF | settings->bit.led_red_color << 4) : 0,
                             settings->bit.led_green_color ? (0xF | settings->bit.led_green_color << 4) : 0);
         // return false so the watch stays awake (needed for the PWM driver to function).


### PR DESCRIPTION
When you've configured a few too many watch faces, sometimes it's nice to just jump back to the start without having to rely on the timeout.

Of course, if a face is always intercepting mode, this is a problem and you won't be able to get past that face, so there's an escape hatch that lets you get straight to the settings (with a long press on the first face).