### PR TITLE
Make countdown face reset to 0

### DIFF
--- a/movement/movement_config.h
+++ b/movement/movement_config.h
@@ -32,7 +32,6 @@ const watch_face_t watch_faces[] = {
     world_clock_face,
     sunrise_sunset_face,
     moon_phase_face,
-    countdown_face,
     thermistor_readout_face,
     preferences_face,
     set_time_face,

--- a/movement/movement_config.h
+++ b/movement/movement_config.h
@@ -32,6 +32,7 @@ const watch_face_t watch_faces[] = {
     world_clock_face,
     sunrise_sunset_face,
     moon_phase_face,
+    countdown_face,
     thermistor_readout_face,
     preferences_face,
     set_time_face,

--- a/movement/watch_faces/complication/countdown_face.c
+++ b/movement/watch_faces/complication/countdown_face.c
@@ -179,7 +179,10 @@ bool countdown_face_loop(movement_event_t event, movement_settings_t *settings, 
                     reset(state);
                     break;
                 case cd_waiting:
-                    start(state, settings);
+                    if (!(state->minutes == 0 && state->seconds == 0)) {
+                        // Only start the timer if we have a valid time.
+                        start(state, settings);
+                    }
                     break;
                 case cd_setting:
                     settings_increment(state);
@@ -192,7 +195,7 @@ bool countdown_face_loop(movement_event_t event, movement_settings_t *settings, 
             break;
         case EVENT_ALARM_LONG_PRESS:
             if (state->mode == cd_setting) {
-                    state->minutes = DEFAULT_MINUTES;
+                    state->minutes = 0;
                     state->seconds = 0;
                     draw(state, event.subsecond);
                     break;


### PR DESCRIPTION
It was annoying to have countdowns less than DEFAULT_MINUTES. Admittedly, this does make DEFAULT_MINUTES fairly useless, since we only ever see it the first time...

Also fixes minor negative overflow issue if you start the countdown at 0. 