### PR TITLE
Make starter project work in simulator

### DIFF
--- a/apps/starter-project/app.c
+++ b/apps/starter-project/app.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "watch.h"
+#include "watch_main_loop.h"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // This section sets up types and storage for our application state.
@@ -156,13 +157,13 @@ bool app_loop(void) {
 
     if (application_state.enter_sleep_mode) {
         // wait a moment for the user's finger to be off the button
-        delay_ms(250);
+        main_loop_sleep(250);
 
         // nap time :)
         watch_enter_deep_sleep_mode();
 
         // we just woke up; wait a moment again for the user's finger to be off the button...
-        delay_ms(250);
+        main_loop_sleep(250);
 
         // and prevent ourselves from going right back to sleep.
         application_state.enter_sleep_mode = false;

--- a/apps/starter-project/app.c
+++ b/apps/starter-project/app.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <string.h>
 #include "watch.h"
-#include "watch_main_loop.h"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // This section sets up types and storage for our application state.

--- a/apps/starter-project/app.c
+++ b/apps/starter-project/app.c
@@ -156,13 +156,13 @@ bool app_loop(void) {
 
     if (application_state.enter_sleep_mode) {
         // wait a moment for the user's finger to be off the button
-        main_loop_sleep(250);
+        delay_ms(250);
 
         // nap time :)
         watch_enter_deep_sleep_mode();
 
         // we just woke up; wait a moment again for the user's finger to be off the button...
-        main_loop_sleep(250);
+        delay_ms(250);
 
         // and prevent ourselves from going right back to sleep.
         application_state.enter_sleep_mode = false;

--- a/watch-library/shared/watch/watch.h
+++ b/watch-library/shared/watch/watch.h
@@ -30,6 +30,10 @@
 #include "driver_init.h"
 #include "pins.h"
 
+#ifdef __EMSCRIPTEN__
+#include "watch_main_loop.h"
+#endif // __EMSCRIPTEN__
+
 /** @mainpage Sensor Watch Documentation
  *  @brief This documentation covers most of the functions you will use to interact with the Sensor Watch
            hardware. It is divided into the following sections:

--- a/watch-library/simulator/main.c
+++ b/watch-library/simulator/main.c
@@ -101,6 +101,10 @@ static void main_loop_set_sleeping(bool sleeping) {
     }, sleeping);
 }
 
+void delay_ms(const uint16_t ms) {
+    main_loop_sleep(ms);
+}
+
 int main(void) {
     app_init();
     _watch_init();

--- a/watch-library/simulator/watch/watch_main_loop.h
+++ b/watch-library/simulator/watch/watch_main_loop.h
@@ -31,3 +31,5 @@ void resume_main_loop(void);
 void main_loop_sleep(uint32_t ms);
 
 bool main_loop_is_sleeping(void);
+
+void delay_ms(const uint16_t ms);


### PR DESCRIPTION
Use the higher abstraction level sleeping, since the simulator (emulator?) doesn't understand the lower level HAL.

I'm assuming this is a reasonable thing to do...