### PR TITLE
Long press mode button to return to first watch face + fix lag when watch face changes

### DIFF
--- a/movement/movement.c
+++ b/movement/movement.c
@@ -417,7 +417,6 @@ bool app_loop(void) {
             && movement_state.current_watch_face > 0 
             && movement_state.current_watch_face == movement_state.next_watch_face) {
             movement_move_to_face(0);
-            movement_state.watch_face_changed = true;
         }
         event.event_type = EVENT_NONE;
     }

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -407,9 +407,14 @@ bool app_loop(void) {
     if (event.event_type) {
         event.subsecond = movement_state.subsecond;
         can_sleep = watch_faces[movement_state.current_watch_face].loop(event, &movement_state.settings, watch_face_contexts[movement_state.current_watch_face]);
-        // escape hatch: a watch face may not resign on EVENT_MODE_BUTTON_DOWN. In that case, a long press of MODE should let them out.
-        if (event.event_type == EVENT_MODE_LONG_PRESS) {
-            movement_move_to_next_face();
+
+        // Long-pressing MODE brings one back to the first face, provided that the watch face hasn't decided to send them elsewhere
+        // (and we're not currently on the first face).
+        // Note that it's the face's responsibility to provide some way to get to the next face, so if EVENT_MODE_BUTTON_* is
+        // used for face functionality EVENT_MODE_LONG_PRESS should probably be handled and next_face() triggered in the face
+        // (which would effectively disable the normal 'long press to face 0' behaviour).
+        if (event.event_type == EVENT_MODE_LONG_PRESS && movement_state.current_watch_face > 0 && movement_state.current_watch_face == movement_state.next_watch_face) {
+            movement_move_to_face(0);
             can_sleep = false;
         }
         event.event_type = EVENT_NONE;

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -415,7 +415,7 @@ bool app_loop(void) {
         // (which would effectively disable the normal 'long press to face 0' behaviour).
         if (event.event_type == EVENT_MODE_LONG_PRESS 
             && movement_state.current_watch_face > 0 
-            && movement_state.current_watch_face == movement_state.next_watch_face) {
+            && !movement_state.watch_face_changed) {
             movement_move_to_face(0);
         }
         event.event_type = EVENT_NONE;

--- a/movement/movement.h
+++ b/movement/movement.h
@@ -174,7 +174,11 @@ typedef void (*watch_face_activate)(movement_settings_t *settings, void *context
   *              for a list of all possible event types.
   * @param settings A pointer to the global Movement settings. @see watch_face_setup.
   * @param context A pointer to your application's context. @see watch_face_setup.
-  * @return true if Movement can enter STANDBY mode; false to keep it awake. You should almost always return true.
+  * @return true if your watch face is prepared for the system to enter STANDBY mode; false to keep the system awake.
+  *         You should almost always return true.
+  *         Note that this return value has no effect if your loop function has called movement_move_to_next_face
+  *         or movement_move_to_face; in that case, your watch face will resign immediately, and the next watch
+  *         face will make the decision on entering standby mode.
   * @note There are two event types that require some extra thought:
           The EVENT_LOW_ENERGY_UPDATE event type is a special case. If you are in the foreground when the watch
           goes into low energy mode, you will receive this tick once a minute (at the top of the minute) so that


### PR DESCRIPTION
This is the simple version of #89 

I'm in two minds about this. It seems like a neat hack, but I think a better solution would be to have the loop() functions return whether they want to capture/bubble the event (cf Javascript), in which case we could handle _all_ the standard functions here in a consistent way without relying on the faces.

i.e. EVENT_MODE_BUTTON_UP => movement_move_to_next_face(), EVENT_MODE_LONG_PRESS/EVENT_TIMEOUT => movement_move_to_face(0),  EVENT_LIGHT_BUTTON_DOWN => movement_illuminate_led()

The return from 'loop' would be something like:

```
struct {
  bool can_sleep;
  bool event_swallowed;
}
```

@josecastillo - how would you feel about this refactor?