### PR TITLE
Add an Alarm face to movement

### DIFF
--- a/movement/make/Makefile
+++ b/movement/make/Makefile
@@ -68,6 +68,7 @@ SRCS += \
   ../watch_faces/complication/probability_face.c \
   ../watch_faces/complication/wake_face.c \
   ../watch_faces/demo/frequency_correction_face.c \
+  ../watch_faces/complication/alarm_face.c \
 # New watch faces go above this line.
 
 # Leave this line at the bottom of the file; it has all the targets for making your project.

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -440,6 +440,9 @@ bool app_loop(void) {
     if (movement_state.alarm_ticks >= 0) {
         uint8_t buzzer_phase = (movement_state.alarm_ticks + 80) % 128;
         if(buzzer_phase == 127) {
+            // failsafe: buzzer could have been disabled in the meantime
+            if (!watch_is_buzzer_or_led_enabled()) watch_enable_buzzer();
+            // play 4 beeps plus pause
             for(uint8_t i = 0; i < 4; i++) {
                 // TODO: This method of playing the buzzer blocks the UI while it's beeping.
                 // It might be better to time it with the fast tick.
@@ -494,7 +497,7 @@ static movement_event_type_t _figure_out_button_event(bool pin_level, movement_e
         *down_timestamp = movement_state.fast_ticks + 1;
         return button_down_event_type;
     } else {
-        // this line is hack but it handles the situation where the light button was held for more than 10 seconds.
+        // this line is hack but it handles the situation where the light button was held for more than 20 seconds.
         // fast tick is disabled by then, and the LED would get stuck on since there's no one left decrementing light_ticks.
         if (movement_state.light_ticks == 1) movement_state.light_ticks = 0;
         // now that that's out of the way, handle falling edge

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -238,11 +238,16 @@ void movement_play_signal(void) {
 }
 
 void movement_play_alarm(void) {
+    movement_play_alarm_beeps(5, BUZZER_NOTE_C8);
+}
+
+void movement_play_alarm_beeps(uint8_t rounds, BuzzerNote alarm_note) {
+    if (rounds == 0) rounds = 1;
+    if (rounds > 20) rounds = 20;
     movement_request_wake();
-    // alarm length: 75 ticks short of 5 seconds, or 4.414 seconds:
-    // our tone is 0.375 seconds of beep and 0.625 of silence, repeated five times.
-    // so 4.375 + a few ticks to wake up from sleep mode.
-    movement_state.alarm_ticks = 128 * 5 - 75;
+    movement_state.alarm_note = alarm_note;
+    // our tone is 0.375 seconds of beep and 0.625 of silence, repeated as given.
+    movement_state.alarm_ticks = 128 * rounds - 75;
     _movement_enable_fast_tick_if_needed();
 }
 
@@ -438,7 +443,7 @@ bool app_loop(void) {
             for(uint8_t i = 0; i < 4; i++) {
                 // TODO: This method of playing the buzzer blocks the UI while it's beeping.
                 // It might be better to time it with the fast tick.
-                watch_buzzer_play_note(BUZZER_NOTE_C8, (i != 3) ? 50 : 75);
+                watch_buzzer_play_note(movement_state.alarm_note, (i != 3) ? 50 : 75);
                 if (i != 3) watch_buzzer_play_note(BUZZER_NOTE_REST, 50);
             }
         }
@@ -534,8 +539,8 @@ void cb_fast_tick(void) {
     if (movement_state.light_ticks > 0) movement_state.light_ticks--;
     if (movement_state.alarm_ticks > 0) movement_state.alarm_ticks--;
     // this is just a fail-safe; fast tick should be disabled as soon as the button is up, the LED times out, and/or the alarm finishes.
-    // but if for whatever reason it isn't, this forces the fast tick off after 10 seconds.
-    if (movement_state.fast_ticks >= 1280) watch_rtc_disable_periodic_callback(128);
+    // but if for whatever reason it isn't, this forces the fast tick off after 20 seconds.
+    if (movement_state.fast_ticks >= 128 * 20) watch_rtc_disable_periodic_callback(128);
 }
 
 void cb_tick(void) {

--- a/movement/movement.h
+++ b/movement/movement.h
@@ -61,7 +61,8 @@ typedef union {
         // altimeter to display feet or meters as easily as it tells a thermometer to display degrees in F or C.
         bool clock_mode_24h : 1;            // indicates whether clock should use 12 or 24 hour mode.
         bool use_imperial_units : 1;        // indicates whether to use metric units (the default) or imperial.
-        uint8_t reserved : 7;               // room for more preferences if needed.
+        bool alarm_enabled : 1;             // indicates wheter there is at least one alarm enabled.
+        uint8_t reserved : 6;               // room for more preferences if needed.
     } bit;
     uint32_t reg;
 } movement_settings_t;
@@ -248,6 +249,7 @@ typedef struct {
     // alarm stuff
     int16_t alarm_ticks;
     bool is_buzzing;
+    BuzzerNote alarm_note;
 
     // button tracking for long press
     uint8_t light_down_timestamp;
@@ -292,6 +294,7 @@ void movement_request_wake(void);
 
 void movement_play_signal(void);
 void movement_play_alarm(void);
+void movement_play_alarm_beeps(uint8_t rounds, BuzzerNote alarm_note);
 
 uint8_t movement_claim_backup_register(void);
 

--- a/movement/movement_config.h
+++ b/movement/movement_config.h
@@ -30,7 +30,6 @@
 const watch_face_t watch_faces[] = {
     simple_clock_face,
     world_clock_face,
-    alarm_face,
     sunrise_sunset_face,
     moon_phase_face,
     thermistor_readout_face,
@@ -39,5 +38,12 @@ const watch_face_t watch_faces[] = {
 };
 
 #define MOVEMENT_NUM_FACES (sizeof(watch_faces) / sizeof(watch_face_t))
+
+/* Determines what face to go to from the first face if you've already set 
+ * a mode long press to go to the first face in preferences, and
+ * excludes these faces from the normal rotation.
+ * Usually it makes sense to set this to the preferences face.
+ */
+#define MOVEMENT_SECONDARY_FACE_INDEX 0 // or (MOVEMENT_NUM_FACES - 2)
 
 #endif // MOVEMENT_CONFIG_H_

--- a/movement/movement_config.h
+++ b/movement/movement_config.h
@@ -30,6 +30,7 @@
 const watch_face_t watch_faces[] = {
     simple_clock_face,
     world_clock_face,
+    alarm_face,
     sunrise_sunset_face,
     moon_phase_face,
     thermistor_readout_face,

--- a/movement/movement_faces.h
+++ b/movement/movement_faces.h
@@ -55,6 +55,7 @@
 #include "probability_face.h"
 #include "wake_face.h"
 #include "frequency_correction_face.h"
+#include "alarm_face.h"
 // New includes go above this line.
 
 #endif // MOVEMENT_FACES_H_

--- a/movement/watch_faces/clock/simple_clock_face.c
+++ b/movement/watch_faces/clock/simple_clock_face.c
@@ -47,6 +47,13 @@ void simple_clock_face_activate(movement_settings_t *settings, void *context) {
     if (settings->bit.clock_mode_24h) watch_set_indicator(WATCH_INDICATOR_24H);
     if (state->signal_enabled) watch_set_indicator(WATCH_INDICATOR_SIGNAL);
 
+    // show alarm indicator if there is an active alarm
+    if (settings->bit.alarm_enabled) {
+        watch_set_indicator(WATCH_INDICATOR_BELL);
+    } else {
+        watch_clear_indicator(WATCH_INDICATOR_BELL);
+    }
+
     watch_set_colon();
 
     // this ensures that none of the timestamp fields will match, so we can re-render them all.

--- a/movement/watch_faces/clock/simple_clock_face.c
+++ b/movement/watch_faces/clock/simple_clock_face.c
@@ -29,8 +29,8 @@
 
 static void _update_alarm_indicator(bool settings_alarm_enabled, simple_clock_state_t *state) {
     state->alarm_enabled = settings_alarm_enabled;
-    if (state->alarm_enabled) watch_set_indicator(WATCH_INDICATOR_BELL);
-    else watch_clear_indicator(WATCH_INDICATOR_BELL);
+    if (state->alarm_enabled) watch_set_indicator(WATCH_INDICATOR_SIGNAL);
+    else watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
 }
 
 void simple_clock_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {
@@ -51,11 +51,10 @@ void simple_clock_face_activate(movement_settings_t *settings, void *context) {
     if (watch_tick_animation_is_running()) watch_stop_tick_animation();
 
     if (settings->bit.clock_mode_24h) watch_set_indicator(WATCH_INDICATOR_24H);
-    if (state->signal_enabled) watch_set_indicator(WATCH_INDICATOR_SIGNAL);
 
     // handle chime indicator
-    if (state->signal_enabled) watch_set_indicator(WATCH_INDICATOR_SIGNAL);
-    else watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
+    if (state->signal_enabled) watch_set_indicator(WATCH_INDICATOR_BELL);
+    else watch_clear_indicator(WATCH_INDICATOR_BELL);
 
     // show alarm indicator if there is an active alarm
     _update_alarm_indicator(settings->bit.alarm_enabled, state);
@@ -135,8 +134,8 @@ bool simple_clock_face_loop(movement_event_t event, movement_settings_t *setting
             break;
         case EVENT_ALARM_LONG_PRESS:
             state->signal_enabled = !state->signal_enabled;
-            if (state->signal_enabled) watch_set_indicator(WATCH_INDICATOR_SIGNAL);
-            else watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
+            if (state->signal_enabled) watch_set_indicator(WATCH_INDICATOR_BELL);
+            else watch_clear_indicator(WATCH_INDICATOR_BELL);
             break;
         case EVENT_BACKGROUND_TASK:
             // uncomment this line to snap back to the clock face when the hour signal sounds:

--- a/movement/watch_faces/clock/simple_clock_face.c
+++ b/movement/watch_faces/clock/simple_clock_face.c
@@ -27,6 +27,12 @@
 #include "watch.h"
 #include "watch_utility.h"
 
+static void _update_alarm_indicator(bool settings_alarm_enabled, simple_clock_state_t *state) {
+    state->alarm_enabled = settings_alarm_enabled;
+    if (state->alarm_enabled) watch_set_indicator(WATCH_INDICATOR_BELL);
+    else watch_clear_indicator(WATCH_INDICATOR_BELL);
+}
+
 void simple_clock_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {
     (void) settings;
     (void) watch_face_index;
@@ -47,12 +53,12 @@ void simple_clock_face_activate(movement_settings_t *settings, void *context) {
     if (settings->bit.clock_mode_24h) watch_set_indicator(WATCH_INDICATOR_24H);
     if (state->signal_enabled) watch_set_indicator(WATCH_INDICATOR_SIGNAL);
 
+    // handle chime indicator
+    if (state->signal_enabled) watch_set_indicator(WATCH_INDICATOR_SIGNAL);
+    else watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
+
     // show alarm indicator if there is an active alarm
-    if (settings->bit.alarm_enabled) {
-        watch_set_indicator(WATCH_INDICATOR_BELL);
-    } else {
-        watch_clear_indicator(WATCH_INDICATOR_BELL);
-    }
+    _update_alarm_indicator(settings->bit.alarm_enabled, state);
 
     watch_set_colon();
 
@@ -118,6 +124,8 @@ bool simple_clock_face_loop(movement_event_t event, movement_settings_t *setting
                 }
             }
             watch_display_string(buf, pos);
+            // handle alarm indicator
+            if (state->alarm_enabled != settings->bit.alarm_enabled) _update_alarm_indicator(settings->bit.alarm_enabled, state);
             break;
         case EVENT_MODE_BUTTON_UP:
             movement_move_to_next_face();

--- a/movement/watch_faces/clock/simple_clock_face.h
+++ b/movement/watch_faces/clock/simple_clock_face.h
@@ -33,6 +33,7 @@ typedef struct {
     uint8_t watch_face_index;
     bool signal_enabled;
     bool battery_low;
+    bool alarm_enabled;
 } simple_clock_state_t;
 
 void simple_clock_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr);

--- a/movement/watch_faces/complication/alarm_face.c
+++ b/movement/watch_faces/complication/alarm_face.c
@@ -89,9 +89,10 @@ static void _alarm_face_draw(movement_settings_t *settings, alarm_state_t *state
     //handle am/pm for hour display
     uint8_t h = state->alarm[state->alarm_idx].hour;
     if (!settings->bit.clock_mode_24h) {
-        if (h > 12) {
+        if (h >= 12) {
             watch_set_indicator(WATCH_INDICATOR_PM);
-            h -= 12;
+            h = h % 12;
+            h += h ? 0 : 12;
         } else {
             watch_clear_indicator(WATCH_INDICATOR_PM);
         }
@@ -102,7 +103,7 @@ static void _alarm_face_draw(movement_settings_t *settings, alarm_state_t *state
         h,
         state->alarm[state->alarm_idx].minute);
     // blink items if in settings mode
-    if (state->is_setting && subsecond % 2 && state->setting_state < alarm_setting_idx_pitch && state->alarm_quick_ticks == -1) {
+    if (state->is_setting && subsecond % 2 && state->setting_state < alarm_setting_idx_pitch && !state->alarm_quick_ticks) {
         buf[_blink_idx[state->setting_state]] = buf[_blink_idx2[state->setting_state]] = ' ';
     }
     watch_display_string(buf, 0);
@@ -179,9 +180,9 @@ static void _alarm_indicate_beep(alarm_state_t *state) {
 
 static void _abort_quick_ticks(alarm_state_t *state) {
     // abort counting quick ticks
-    if (state->alarm_quick_ticks >= ALARM_QUICK_MIN_TICKS) state->alarm[state->alarm_idx].enabled = true;
-    if (state->alarm_quick_ticks >= 0) {
-        state->alarm_quick_ticks = -1;
+    if (state->alarm_quick_ticks) {
+        state->alarm[state->alarm_idx].enabled = true;
+        state->alarm_quick_ticks = false;
         movement_request_tick_frequency(4);
     }
 }
@@ -201,15 +202,12 @@ void alarm_face_setup(movement_settings_t *settings, uint8_t watch_face_index, v
             state->alarm[i].pitch = 1;
         }
         state->alarm_handled_minute = -1;
-        state->alarm_quick_ticks = -1;
     }
 }
 
 void alarm_face_activate(movement_settings_t *settings, void *context) {
     (void) settings;
     (void) context;
-    watch_display_string("  ", 8);
-    watch_clear_indicator(WATCH_INDICATOR_LAP); // may be unnecessary, but who knows
     watch_set_colon();
 }
 
@@ -219,7 +217,7 @@ void alarm_face_resign(movement_settings_t *settings, void *context) {
     _alarm_update_alarm_enabled(settings, state);
     watch_set_led_off();
     watch_store_backup_data(settings->reg, 0);
-    state->alarm_quick_ticks = -1;
+    state->alarm_quick_ticks = false;
     movement_request_tick_frequency(1);
 }
 
@@ -263,37 +261,17 @@ bool alarm_face_loop(movement_event_t event, movement_settings_t *settings, void
 
     switch (event.event_type) {
     case EVENT_TICK:
-        if (state->alarm_quick_ticks >= 0) {
-            // we are counting ticks for the alarm button
-            if (state->setting_state == alarm_setting_idx_hour || state->setting_state == alarm_setting_idx_minute) {
-                if (state->alarm_quick_ticks < INT8_MAX) state->alarm_quick_ticks++;
-                if (state->alarm_quick_ticks == ALARM_QUICK_MIN_TICKS) {
-                    // initiate fast counting
-                    movement_request_tick_frequency(8);
-                } else if (state->alarm_quick_ticks > ALARM_QUICK_MIN_TICKS) {
-                    // fast count hours or minutes
-                    if (state->setting_state == alarm_setting_idx_hour)
+        if (state->alarm_quick_ticks) {
+            // we are in fast cycling mode
+            if (state->setting_state == alarm_setting_idx_hour) {
                         state->alarm[state->alarm_idx].hour = (state->alarm[state->alarm_idx].hour + 1) % 24;
-                    else if (state->setting_state == alarm_setting_idx_minute)
+            } else if (state->setting_state == alarm_setting_idx_minute) {
                         state->alarm[state->alarm_idx].minute = (state->alarm[state->alarm_idx].minute + 1) % 60;
-                    _alarm_face_draw(settings, state, event.subsecond);
-                    break;
-                }
-            } else {
-                _abort_quick_ticks(state);
-            }
+            } else _abort_quick_ticks(state);
         } else if (!state->is_setting) break; // no need to do anything when we are not in settings mode and no quick ticks are running
-        // otherwise fall through
+        // fall through
     case EVENT_ACTIVATE:
         _alarm_face_draw(settings, state, event.subsecond);
-        break;
-    case EVENT_LIGHT_BUTTON_DOWN:
-        break;
-    case EVENT_ALARM_BUTTON_DOWN:
-        // check if we need to start counting ticks
-        if (state->is_setting && (state->setting_state == alarm_setting_idx_hour || state->setting_state == alarm_setting_idx_minute)) {
-            state->alarm_quick_ticks = 0;
-        }
         break;
     case EVENT_LIGHT_BUTTON_UP:
         if (!state->is_setting) {
@@ -372,14 +350,21 @@ bool alarm_face_loop(movement_event_t event, movement_settings_t *settings, void
                 break;
             case alarm_setting_idx_minute:
             case alarm_setting_idx_hour:
-                // hour or minute selection
-                _abort_quick_ticks(state);
+                // initiate fast cycling for hour or minute settings
+                movement_request_tick_frequency(8);
+                state->alarm_quick_ticks = true;
                 break;
             default:
                 break;
             }
         }
         _alarm_face_draw(settings, state, event.subsecond);
+        break;
+    case EVENT_ALARM_LONG_UP:
+        if (state->is_setting) {
+            if (state->setting_state == alarm_setting_idx_hour || state->setting_state == alarm_setting_idx_minute)
+                _abort_quick_ticks(state);
+        }
         break;
     case EVENT_BACKGROUND_TASK:
         // play alarm
@@ -405,7 +390,6 @@ bool alarm_face_loop(movement_event_t event, movement_settings_t *settings, void
     case EVENT_TIMEOUT:
         movement_move_to_face(0);
         break;
-    case EVENT_LOW_ENERGY_UPDATE:
     default:
       break;
     }

--- a/movement/watch_faces/complication/alarm_face.c
+++ b/movement/watch_faces/complication/alarm_face.c
@@ -100,7 +100,7 @@ static void _alarm_face_draw(movement_settings_t *settings, alarm_state_t *state
     }
     watch_display_string(buf, 0);
     
-    // draw pith level indicator
+    // draw pitch level indicator
     if (state->is_setting && ((subsecond % 2) == 0 || (state->setting_state != 4))) {
         for (i = 0; i <= state->alarm[state->alarm_idx].pitch && i < 3; i++)
             watch_set_pixel(_buzzer_segdata[i][0], _buzzer_segdata[i][1]);
@@ -138,6 +138,7 @@ void alarm_face_setup(movement_settings_t *settings, uint8_t watch_face_index, v
 }
 
 void alarm_face_activate(movement_settings_t *settings, void *context) {
+    (void) settings;
     (void) context;
     watch_display_string("  ", 8);
     watch_clear_indicator(WATCH_INDICATOR_LAP); // may be unnecessary, but who knows
@@ -229,7 +230,7 @@ bool alarm_face_loop(movement_event_t event, movement_settings_t *settings, void
             // cycle through the alarms
             state->alarm_idx = (state->alarm_idx + 1) % (ALARM_ALARMS);
         } else {
-            // TODO: Handle the settings behaviour
+            // handle the settings behaviour
             switch (state->setting_state) {
             case 0:
                 // alarm selection

--- a/movement/watch_faces/complication/alarm_face.c
+++ b/movement/watch_faces/complication/alarm_face.c
@@ -160,7 +160,7 @@ static void _alarm_update_alarm_enabled(movement_settings_t *settings, alarm_sta
 }
 
 static void _alarm_play_short_beep(uint8_t pitch_idx) {
-    // plays a short double beep
+    // play a short double beep
     watch_buzzer_play_note(_buzzer_notes[pitch_idx], 50);
     watch_buzzer_play_note(BUZZER_NOTE_REST, 50);
     watch_buzzer_play_note(_buzzer_notes[pitch_idx], 70);
@@ -362,7 +362,7 @@ bool alarm_face_loop(movement_event_t event, movement_settings_t *settings, void
             }
         } else {
             // regular alarm beeps
-        movement_play_alarm_beeps((state->alarm[state->alarm_idx].beeps == (ALARM_MAX_BEEP_ROUNDS - 1) ? 20 : state->alarm[state->alarm_playing_idx].beeps + 1), 
+            movement_play_alarm_beeps((state->alarm[state->alarm_idx].beeps == (ALARM_MAX_BEEP_ROUNDS - 1) ? 20 : state->alarm[state->alarm_playing_idx].beeps), 
                                   _buzzer_notes[state->alarm[state->alarm_playing_idx].pitch]);
         }
         break;

--- a/movement/watch_faces/complication/alarm_face.c
+++ b/movement/watch_faces/complication/alarm_face.c
@@ -30,12 +30,13 @@
 #include "alarm_face.h"
 #include "watch.h"
 #include "watch_utility.h"
+#include "watch_private_display.h"
 
 /*
-    Implements 10 alarm slots on the sensor watch
+    Implements 16 alarm slots on the sensor watch
 
     Usage:
-    - In normal mode, the alarm button cycles through all 10 alarms. 
+    - In normal mode, the alarm button cycles through all 16 alarms. 
     - Long pressing the alarm button in normal mode toggles the corresponding alarm on or off.
     - Pressing the light button enters setting mode and cycles through the settings of each alarm.
     - In setting mode an alarm slot is selected by pressing the alarm button when the slot number 
@@ -43,16 +44,26 @@
     - For each alarm slot, you can select the day. These are the day modes:
         - ED = the alarm rings every day
         - 1t = the alarm fires only one time and is erased afterwards
-        - MF = the alarm fires Mondays to Fridays (yes, I am aware of the ambiguity of the abbreviation  ;-)
+        - MF = the alarm fires Mondays to Fridays
         - WN = the alarm fires on weekends (Sa/Su)
         - MO to SU = the alarm fires only on the given day of week
     - You can fast jump (kinda) through hour or minute setting via long press of the alarm button.
-    - You can select the tone in which the alarm is played. (Three pitch levels available)
-    - You can select how many "beep rounds" are played for each alarm (1 to 9).
+    - You can select the tone in which the alarm is played. (Three pitch levels available.)
+    - You can select how many "beep rounds" are played for each alarm. 1 to 9 rounds, plus extra 
+      long ('L') and extra short ('o') alarms.
     - The simple watch face indicates any alarm set by showing the bell indicator.
 */
 
-static const char _dow_strings[ALARM_DAY_STATES + 1][3] ={"AL", "MO", "TU", "WE", "TH", "FR", "SA", "SO", "ED", "1t", "MF", "WN"};
+typedef enum {
+    alarm_setting_idx_alarm,
+    alarm_setting_idx_day,
+    alarm_setting_idx_hour,
+    alarm_setting_idx_minute,
+    alarm_setting_idx_pitch,
+    alarm_setting_idx_beeps
+} alarm_setting_idx_t;
+
+static const char _dow_strings[ALARM_DAY_STATES + 1][2] ={"AL", "MO", "TU", "WE", "TH", "FR", "SA", "SO", "ED", "1t", "MF", "WN"};
 static const uint8_t _blink_idx[ALARM_SETTING_STATES] = {2, 0, 4, 6, 8, 9};
 static const uint8_t _blink_idx2[ALARM_SETTING_STATES] = {3, 1, 5, 7, 8, 9};
 static const BuzzerNote _buzzer_notes[3] = {BUZZER_NOTE_B6, BUZZER_NOTE_C8, BUZZER_NOTE_A8};
@@ -85,26 +96,36 @@ static void _alarm_face_draw(movement_settings_t *settings, alarm_state_t *state
             watch_clear_indicator(WATCH_INDICATOR_PM);
         }
     }
-    sprintf(buf, "%s%2d%2d%02d %1d",
-        _dow_strings[i],
+    sprintf(buf, "%c%c%2d%2d%02d  ",
+        _dow_strings[i][0], _dow_strings[i][1],
         (state->alarm_idx + 1),
         h,
-        state->alarm[state->alarm_idx].minute,
-        state->alarm[state->alarm_idx].beeps + 1);
-    // don't show beep rounds in normal mode to avoid user confusion
-    if (!state->is_setting) 
-        buf[_blink_idx[5]] = buf[_blink_idx2[5]] = ' ';
+        state->alarm[state->alarm_idx].minute);
     // blink items if in settings mode
-    if (state->is_setting && subsecond % 2) {
+    if (state->is_setting && subsecond % 2 && state->setting_state < alarm_setting_idx_pitch) {
         buf[_blink_idx[state->setting_state]] = buf[_blink_idx2[state->setting_state]] = ' ';
     }
     watch_display_string(buf, 0);
     
+    if (state->is_setting) {
     // draw pitch level indicator
-    if (state->is_setting && ((subsecond % 2) == 0 || (state->setting_state != 4))) {
+        if ((subsecond % 2) == 0 || (state->setting_state != alarm_setting_idx_pitch)) {
         for (i = 0; i <= state->alarm[state->alarm_idx].pitch && i < 3; i++)
             watch_set_pixel(_buzzer_segdata[i][0], _buzzer_segdata[i][1]);
     }
+        // draw beep rounds indicator
+        if ((subsecond % 2) == 0 || (state->setting_state != alarm_setting_idx_beeps)) {
+            if (state->alarm[state->alarm_idx].beeps == ALARM_MAX_BEEP_ROUNDS - 1)
+                watch_display_character('L', _blink_idx[alarm_setting_idx_beeps]);
+            else {
+                if (state->alarm[state->alarm_idx].beeps == 0)
+                    watch_display_character('o', _blink_idx[alarm_setting_idx_beeps]);
+            else
+                    watch_display_character(state->alarm[state->alarm_idx].beeps + 48, _blink_idx[alarm_setting_idx_beeps]);
+            }
+        }
+    }
+
     // set bell indicator
     if (state->alarm[state->alarm_idx].enabled)
         watch_set_indicator(WATCH_INDICATOR_BELL);
@@ -113,10 +134,47 @@ static void _alarm_face_draw(movement_settings_t *settings, alarm_state_t *state
 
 }
 
+static void _alarm_initiate_setting(movement_settings_t *settings, alarm_state_t *state, uint8_t subsecond) {
+    state->is_setting = true;
+    state->setting_state = 0;
+    movement_request_tick_frequency(4);
+    _alarm_face_draw(settings, state, subsecond);
+}
+
 static void _alarm_resume_setting(movement_settings_t *settings, alarm_state_t *state, uint8_t subsecond) {
     state->is_setting = false;
     movement_request_tick_frequency(1);
     _alarm_face_draw(settings, state, subsecond);
+}
+
+static void _alarm_update_alarm_enabled(movement_settings_t *settings, alarm_state_t *state) {
+    // save indication for active alarms to movement settings
+    bool active_alarms = false;
+    for (uint8_t i = 0; i < ALARM_ALARMS; i++) {
+        if (state->alarm[i].enabled) {
+            active_alarms = true;
+            break;
+        }
+    }
+    settings->bit.alarm_enabled = active_alarms;
+}
+
+static void _alarm_play_short_beep(uint8_t pitch_idx) {
+    // plays a short double beep
+    watch_buzzer_play_note(_buzzer_notes[pitch_idx], 50);
+    watch_buzzer_play_note(BUZZER_NOTE_REST, 50);
+    watch_buzzer_play_note(_buzzer_notes[pitch_idx], 70);
+}
+
+static void _alarm_indicate_beep(alarm_state_t *state) {
+    // play an example for the current beep setting
+    if (state->alarm[state->alarm_idx].beeps == 0) {
+        // short double beep
+        _alarm_play_short_beep(state->alarm[state->alarm_idx].pitch);
+    } else {
+        // regular alarm beep
+        movement_play_alarm_beeps(1, _buzzer_notes[state->alarm[state->alarm_idx].pitch]);
+    }
 }
 
 void alarm_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void **context_ptr) {
@@ -148,15 +206,7 @@ void alarm_face_activate(movement_settings_t *settings, void *context) {
 void alarm_face_resign(movement_settings_t *settings, void *context) {
     alarm_state_t *state = (alarm_state_t *)context;
     state->is_setting = false;
-    // save indication for active alarms to movement settings
-    bool active_alarms = false;
-    for (uint8_t i = 0; i < ALARM_ALARMS; i++) {
-        if (state->alarm[i].enabled) {
-            active_alarms = true;
-            break;
-        }
-    }
-    settings->bit.alarm_enabled = active_alarms;
+    _alarm_update_alarm_enabled(settings, state);
     watch_set_led_off();
     watch_store_backup_data(settings->reg, 0);
 }
@@ -180,6 +230,7 @@ bool alarm_face_wants_background_task(movement_settings_t *settings, void *conte
                         state->alarm[i].day = ALARM_DAY_EACH_DAY;
                         state->alarm[i].minute = state->alarm[i].hour = 0;
                         state->alarm[i].enabled = false;
+                        _alarm_update_alarm_enabled(settings, state);
                         return true;
                     }
                     uint8_t weekday_idx = _get_weekday_idx(now);
@@ -199,19 +250,19 @@ bool alarm_face_loop(movement_event_t event, movement_settings_t *settings, void
     alarm_state_t *state = (alarm_state_t *)context;
 
     switch (event.event_type) {
-    case EVENT_ACTIVATE:
     case EVENT_TICK:
+        // no need to do anything when we are not in settings mode
+        if (!state->is_setting) break;
+        // otherwise fall through
+    case EVENT_ACTIVATE:
         _alarm_face_draw(settings, state, event.subsecond);
         break;
     case EVENT_LIGHT_BUTTON_DOWN:
         break;
     case EVENT_LIGHT_BUTTON_UP:
-        if (!state->is_setting) movement_illuminate_led();
         if (!state->is_setting) {
-            state->is_setting = true;
-            state->setting_state = 0;
-            movement_request_tick_frequency(4);
-            _alarm_face_draw(settings, state, event.subsecond);
+            movement_illuminate_led();
+            _alarm_initiate_setting(settings, state, event.subsecond);
             break;
         }
         state->setting_state += 1;
@@ -223,6 +274,8 @@ bool alarm_face_loop(movement_event_t event, movement_settings_t *settings, void
     case EVENT_LIGHT_LONG_PRESS:
         if (state->is_setting) {
             _alarm_resume_setting(settings, state, event.subsecond);
+        } else {
+            _alarm_initiate_setting(settings, state, event.subsecond);
         }
         break;
     case EVENT_ALARM_BUTTON_UP:
@@ -232,39 +285,39 @@ bool alarm_face_loop(movement_event_t event, movement_settings_t *settings, void
         } else {
             // handle the settings behaviour
             switch (state->setting_state) {
-            case 0:
+            case alarm_setting_idx_alarm:
                 // alarm selection
                 state->alarm_idx = (state->alarm_idx + 1) % (ALARM_ALARMS);
                 break;
-            case 1:
+            case alarm_setting_idx_day:
                 // day selection
                 state->alarm[state->alarm_idx].day = (state->alarm[state->alarm_idx].day + 1) % (ALARM_DAY_STATES);
                 break;
-            case 2:
+            case alarm_setting_idx_hour:
                 // hour selection
                 state->alarm[state->alarm_idx].hour = (state->alarm[state->alarm_idx].hour + 1) % 24;
                 break;
-            case 3:
+            case alarm_setting_idx_minute:
                 // minute selection
                 state->alarm[state->alarm_idx].minute = (state->alarm[state->alarm_idx].minute + 1) % 60;
                 break;
-            case 4:
+            case alarm_setting_idx_pitch:
                 // pitch level
                 state->alarm[state->alarm_idx].pitch = (state->alarm[state->alarm_idx].pitch + 1) % 3;
-                // play sound to indicate user what we are doing
-                watch_buzzer_play_note(_buzzer_notes[state->alarm[state->alarm_idx].pitch], 50);
-                watch_buzzer_play_note(BUZZER_NOTE_REST, 50);
-                watch_buzzer_play_note(_buzzer_notes[state->alarm[state->alarm_idx].pitch], 75);
+                // play sound to show user what this is for
+                _alarm_indicate_beep(state);
                 break;
-            case 5:
+            case alarm_setting_idx_beeps:
                 // number of beeping rounds selection
-                state->alarm[state->alarm_idx].beeps = (state->alarm[state->alarm_idx].beeps + 1) % (ALARM_MAX_BEEP_ROUNDS);
+                state->alarm[state->alarm_idx].beeps = (state->alarm[state->alarm_idx].beeps + 1) % ALARM_MAX_BEEP_ROUNDS;
+                // play sounds when user reaches 'short' length and also one time on regular beep length
+                if (state->alarm[state->alarm_idx].beeps <= 1) _alarm_indicate_beep(state);
                 break;
             default:
                 break;
             }
             // auto enable an alarm if user sets anything
-            if (state->setting_state > 0) state->alarm[state->alarm_idx].enabled = true;
+            if (state->setting_state > alarm_setting_idx_alarm) state->alarm[state->alarm_idx].enabled = true;
         }
         _alarm_face_draw(settings, state, event.subsecond);
         break;
@@ -275,11 +328,15 @@ bool alarm_face_loop(movement_event_t event, movement_settings_t *settings, void
         } else {
             // handle the long press settings behaviour
             switch (state->setting_state) {
-            case 2:
+            case alarm_setting_idx_alarm:
+                // alarm selection
+                state->alarm_idx = 0;
+                break;
+            case alarm_setting_idx_hour:
                 // hour selection
                 state->alarm[state->alarm_idx].hour = ((state->alarm[state->alarm_idx].hour / 12) * 12 + 12) % 24;
                 break;
-            case 3:
+            case alarm_setting_idx_minute:
                 // minute selection
                 state->alarm[state->alarm_idx].minute = ((state->alarm[state->alarm_idx].minute / 15) * 15 + 15) % 60;
                 break;
@@ -293,7 +350,21 @@ bool alarm_face_loop(movement_event_t event, movement_settings_t *settings, void
         break;
     case EVENT_BACKGROUND_TASK:
         // play alarm
-        movement_play_alarm_beeps(state->alarm[state->alarm_playing_idx].beeps + 1, _buzzer_notes[state->alarm[state->alarm_playing_idx].pitch]);
+        if (state->alarm[state->alarm_playing_idx].beeps == 0) {
+            // short beep
+            if (watch_is_buzzer_or_led_enabled()) {
+                _alarm_play_short_beep(state->alarm[state->alarm_playing_idx].pitch);
+            } else {
+                // enable, play beep and disable buzzer again
+                watch_enable_buzzer();
+                _alarm_play_short_beep(state->alarm[state->alarm_playing_idx].pitch);
+                watch_disable_buzzer();
+            }
+        } else {
+            // regular alarm beeps
+        movement_play_alarm_beeps((state->alarm[state->alarm_idx].beeps == (ALARM_MAX_BEEP_ROUNDS - 1) ? 20 : state->alarm[state->alarm_playing_idx].beeps + 1), 
+                                  _buzzer_notes[state->alarm[state->alarm_playing_idx].pitch]);
+        }
         break;
     case EVENT_MODE_BUTTON_UP:
         movement_move_to_next_face();

--- a/movement/watch_faces/complication/alarm_face.c
+++ b/movement/watch_faces/complication/alarm_face.c
@@ -1,0 +1,310 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Andreas Nebinger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+//-----------------------------------------------------------------------------
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "alarm_face.h"
+#include "watch.h"
+#include "watch_utility.h"
+
+/*
+    Implements 10 alarm slots on the sensor watch
+
+    Usage:
+    - In normal mode, the alarm button cycles through all 10 alarms. 
+    - Long pressing the alarm button in normal mode toggles the corresponding alarm on or off.
+    - Pressing the light button enters setting mode and cycles through the settings of each alarm.
+    - In setting mode an alarm slot is selected by pressing the alarm button when the slot number 
+      in the upper right corner is blinking.
+    - For each alarm slot, you can select the day. These are the day modes:
+        - ED = the alarm rings every day
+        - 1t = the alarm fires only one time and is erased afterwards
+        - MF = the alarm fires Mondays to Fridays (yes, I am aware of the ambiguity of the abbreviation  ;-)
+        - WN = the alarm fires on weekends (Sa/Su)
+        - MO to SU = the alarm fires only on the given day of week
+    - You can fast jump (kinda) through hour or minute setting via long press of the alarm button.
+    - You can select the tone in which the alarm is played. (Three pitch levels available)
+    - You can select how many "beep rounds" are played for each alarm (1 to 9).
+    - The simple watch face indicates any alarm set by showing the bell indicator.
+*/
+
+static const char _dow_strings[ALARM_DAY_STATES + 1][3] ={"AL", "MO", "TU", "WE", "TH", "FR", "SA", "SO", "ED", "1t", "MF", "WN"};
+static const uint8_t _blink_idx[ALARM_SETTING_STATES] = {2, 0, 4, 6, 8, 9};
+static const uint8_t _blink_idx2[ALARM_SETTING_STATES] = {3, 1, 5, 7, 8, 9};
+static const BuzzerNote _buzzer_notes[3] = {BUZZER_NOTE_B6, BUZZER_NOTE_C8, BUZZER_NOTE_A8};
+static const uint8_t _buzzer_segdata[3][2] = {{0, 3}, {1, 3}, {2, 2}};
+
+static uint8_t _get_weekday_idx(watch_date_time date_time) {
+    date_time.unit.year += 20;
+    if (date_time.unit.month <= 2) {
+        date_time.unit.month += 12;
+        date_time.unit.year--;
+    }
+    return (date_time.unit.day + 13 * (date_time.unit.month + 1) / 5 + date_time.unit.year + date_time.unit.year / 4 + 525 - 2) % 7;
+}
+
+static void _alarm_face_draw(movement_settings_t *settings, alarm_state_t *state, uint8_t subsecond) {
+    char buf[12];
+
+    uint8_t i = 0;
+    if (state->is_setting) {
+        // display the actual day indicating string for the current alarm
+        i = state->alarm[state->alarm_idx].day + 1;
+    }
+    //handle am/pm for hour display
+    uint8_t h = state->alarm[state->alarm_idx].hour;
+    if (!settings->bit.clock_mode_24h) {
+        if (h > 12) {
+            watch_set_indicator(WATCH_INDICATOR_PM);
+            h -= 12;
+        } else {
+            watch_clear_indicator(WATCH_INDICATOR_PM);
+        }
+    }
+    sprintf(buf, "%s%2d%2d%02d %1d",
+        _dow_strings[i],
+        (state->alarm_idx + 1),
+        h,
+        state->alarm[state->alarm_idx].minute,
+        state->alarm[state->alarm_idx].beeps + 1);
+    // don't show beep rounds in normal mode to avoid user confusion
+    if (!state->is_setting) 
+        buf[_blink_idx[5]] = buf[_blink_idx2[5]] = ' ';
+    // blink items if in settings mode
+    if (state->is_setting && subsecond % 2) {
+        buf[_blink_idx[state->setting_state]] = buf[_blink_idx2[state->setting_state]] = ' ';
+    }
+    watch_display_string(buf, 0);
+    
+    // draw pith level indicator
+    if (state->is_setting && ((subsecond % 2) == 0 || (state->setting_state != 4))) {
+        for (i = 0; i <= state->alarm[state->alarm_idx].pitch && i < 3; i++)
+            watch_set_pixel(_buzzer_segdata[i][0], _buzzer_segdata[i][1]);
+    }
+    // set bell indicator
+    if (state->alarm[state->alarm_idx].enabled)
+        watch_set_indicator(WATCH_INDICATOR_BELL);
+    else
+        watch_clear_indicator(WATCH_INDICATOR_BELL);
+
+}
+
+static void _alarm_resume_setting(movement_settings_t *settings, alarm_state_t *state, uint8_t subsecond) {
+    state->is_setting = false;
+    movement_request_tick_frequency(1);
+    _alarm_face_draw(settings, state, subsecond);
+}
+
+void alarm_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void **context_ptr) {
+    (void) settings;
+    (void) watch_face_index;
+
+    if (*context_ptr == NULL) {
+        *context_ptr = malloc(sizeof(alarm_state_t));
+        alarm_state_t *state = (alarm_state_t *)*context_ptr;
+        memset(*context_ptr, 0, sizeof(alarm_state_t));
+        // initialize the default alarm values
+        for (uint8_t i = 0; i < ALARM_ALARMS; i++) {
+            state->alarm[i].day = ALARM_DAY_EACH_DAY;
+            state->alarm[i].beeps = 5;
+            state->alarm[i].pitch = 1;
+        }
+        state->alarm_handled_minute = -1;
+    }
+}
+
+void alarm_face_activate(movement_settings_t *settings, void *context) {
+    (void) context;
+    watch_display_string("  ", 8);
+    watch_clear_indicator(WATCH_INDICATOR_LAP); // may be unnecessary, but who knows
+    watch_set_colon();
+}
+
+void alarm_face_resign(movement_settings_t *settings, void *context) {
+    alarm_state_t *state = (alarm_state_t *)context;
+    state->is_setting = false;
+    // save indication for active alarms to movement settings
+    bool active_alarms = false;
+    for (uint8_t i = 0; i < ALARM_ALARMS; i++) {
+        if (state->alarm[i].enabled) {
+            active_alarms = true;
+            break;
+        }
+    }
+    settings->bit.alarm_enabled = active_alarms;
+    watch_set_led_off();
+    watch_store_backup_data(settings->reg, 0);
+}
+
+bool alarm_face_wants_background_task(movement_settings_t *settings, void *context) {
+    (void) settings;
+    alarm_state_t *state = (alarm_state_t *)context;
+    watch_date_time now = watch_rtc_get_date_time();
+    // just a failsafe: never fire more than one alarm within a minute
+    if (state->alarm_handled_minute == now.unit.minute) return false;
+    state->alarm_handled_minute = now.unit.minute;
+    // check the rest
+    for (uint8_t i = 0; i < ALARM_ALARMS; i++) {
+        if (state->alarm[i].enabled) {
+            if (state->alarm[i].minute == now.unit.minute) {
+                if (state->alarm[i].hour == now.unit.hour) {
+                    state->alarm_playing_idx = i;
+                    if (state->alarm[i].day == ALARM_DAY_EACH_DAY) return true;
+                    if (state->alarm[i].day == ALARM_DAY_ONE_TIME) {
+                        // erase this alarm
+                        state->alarm[i].day = ALARM_DAY_EACH_DAY;
+                        state->alarm[i].minute = state->alarm[i].hour = 0;
+                        state->alarm[i].enabled = false;
+                        return true;
+                    }
+                    uint8_t weekday_idx = _get_weekday_idx(now);
+                    if (state->alarm[i].day == weekday_idx) return true;
+                    if (state->alarm[i].day == ALARM_DAY_WORKDAY && weekday_idx < 5) return true;
+                    if (state->alarm[i].day == ALARM_DAY_WEEKEND && weekday_idx >= 5) return true;
+                }
+            }
+        }
+    }
+    state->alarm_handled_minute = -1;
+    return false;
+}
+
+bool alarm_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
+    (void) settings;
+    alarm_state_t *state = (alarm_state_t *)context;
+
+    switch (event.event_type) {
+    case EVENT_ACTIVATE:
+    case EVENT_TICK:
+        _alarm_face_draw(settings, state, event.subsecond);
+        break;
+    case EVENT_LIGHT_BUTTON_DOWN:
+        break;
+    case EVENT_LIGHT_BUTTON_UP:
+        if (!state->is_setting) movement_illuminate_led();
+        if (!state->is_setting) {
+            state->is_setting = true;
+            state->setting_state = 0;
+            movement_request_tick_frequency(4);
+            _alarm_face_draw(settings, state, event.subsecond);
+            break;
+        }
+        state->setting_state += 1;
+        if (state->setting_state >= ALARM_SETTING_STATES) {
+            // we have done a full settings cycle, so resume to normal
+            _alarm_resume_setting(settings, state, event.subsecond);
+        }
+        break;
+    case EVENT_LIGHT_LONG_PRESS:
+        if (state->is_setting) {
+            _alarm_resume_setting(settings, state, event.subsecond);
+        }
+        break;
+    case EVENT_ALARM_BUTTON_UP:
+        if (!state->is_setting) {
+            // cycle through the alarms
+            state->alarm_idx = (state->alarm_idx + 1) % (ALARM_ALARMS);
+        } else {
+            // TODO: Handle the settings behaviour
+            switch (state->setting_state) {
+            case 0:
+                // alarm selection
+                state->alarm_idx = (state->alarm_idx + 1) % (ALARM_ALARMS);
+                break;
+            case 1:
+                // day selection
+                state->alarm[state->alarm_idx].day = (state->alarm[state->alarm_idx].day + 1) % (ALARM_DAY_STATES);
+                break;
+            case 2:
+                // hour selection
+                state->alarm[state->alarm_idx].hour = (state->alarm[state->alarm_idx].hour + 1) % 24;
+                break;
+            case 3:
+                // minute selection
+                state->alarm[state->alarm_idx].minute = (state->alarm[state->alarm_idx].minute + 1) % 60;
+                break;
+            case 4:
+                // pitch level
+                state->alarm[state->alarm_idx].pitch = (state->alarm[state->alarm_idx].pitch + 1) % 3;
+                // play sound to indicate user what we are doing
+                watch_buzzer_play_note(_buzzer_notes[state->alarm[state->alarm_idx].pitch], 50);
+                watch_buzzer_play_note(BUZZER_NOTE_REST, 50);
+                watch_buzzer_play_note(_buzzer_notes[state->alarm[state->alarm_idx].pitch], 75);
+                break;
+            case 5:
+                // number of beeping rounds selection
+                state->alarm[state->alarm_idx].beeps = (state->alarm[state->alarm_idx].beeps + 1) % (ALARM_MAX_BEEP_ROUNDS);
+                break;
+            default:
+                break;
+            }
+            // auto enable an alarm if user sets anything
+            if (state->setting_state > 0) state->alarm[state->alarm_idx].enabled = true;
+        }
+        _alarm_face_draw(settings, state, event.subsecond);
+        break;
+    case EVENT_ALARM_LONG_PRESS:
+        if (!state->is_setting) {
+            // toggle the enabled flag for current alarm
+            if (state->alarm[state->alarm_idx].hour > 0 || state->alarm[state->alarm_idx].minute > 0)
+                state->alarm[state->alarm_idx].enabled ^= 1;
+        } else {
+            // handle the long press settings behaviour
+            switch (state->setting_state) {
+            case 2:
+                // hour selection
+                state->alarm[state->alarm_idx].hour = ((state->alarm[state->alarm_idx].hour / 12) * 12 + 12) % 24;
+                break;
+            case 3:
+                // minute selection
+                state->alarm[state->alarm_idx].minute = ((state->alarm[state->alarm_idx].minute / 15) * 15 + 15) % 60;
+                break;
+            default:
+                break;
+            }
+            // auto enable an alarm if user sets anything
+            if (state->setting_state > 0) state->alarm[state->alarm_idx].enabled = true;
+        }
+        _alarm_face_draw(settings, state, event.subsecond);
+        break;
+    case EVENT_BACKGROUND_TASK:
+        // play alarm
+        movement_play_alarm_beeps(state->alarm[state->alarm_playing_idx].beeps + 1, _buzzer_notes[state->alarm[state->alarm_playing_idx].pitch]);
+        break;
+    case EVENT_MODE_BUTTON_UP:
+        movement_move_to_next_face();
+        break;
+    case EVENT_TIMEOUT:
+        movement_move_to_face(0);
+        break;
+    case EVENT_LOW_ENERGY_UPDATE:
+    default:
+      break;
+    }
+
+    return true;
+}

--- a/movement/watch_faces/complication/alarm_face.c
+++ b/movement/watch_faces/complication/alarm_face.c
@@ -270,8 +270,7 @@ bool alarm_face_loop(movement_event_t event, movement_settings_t *settings, void
     case EVENT_ALARM_LONG_PRESS:
         if (!state->is_setting) {
             // toggle the enabled flag for current alarm
-            if (state->alarm[state->alarm_idx].hour > 0 || state->alarm[state->alarm_idx].minute > 0)
-                state->alarm[state->alarm_idx].enabled ^= 1;
+            state->alarm[state->alarm_idx].enabled ^= 1;
         } else {
             // handle the long press settings behaviour
             switch (state->setting_state) {

--- a/movement/watch_faces/complication/alarm_face.h
+++ b/movement/watch_faces/complication/alarm_face.h
@@ -41,7 +41,6 @@ A face for setting various alarms
 #define ALARM_DAY_WEEKEND 10
 #define ALARM_MAX_BEEP_ROUNDS 11 // maximum number of beeping rounds for an alarm slot (including short and long alarms)
 #define ALARM_SETTING_STATES 6
-#define ALARM_QUICK_MIN_TICKS 2 * 4    // number of ticks (quarter seconds) to wait until fast counting for hours and minutes kicks in
 
 typedef struct {
     uint8_t day : 4;    // day of week: 0=MO, 1=TU, 2=WE, 3=TH, 4=FR, 5=SA, 6=SU, 7=each day, 8=one time alarm, 9=Weekdays, 10=Weekend
@@ -57,7 +56,7 @@ typedef struct {
     uint8_t alarm_playing_idx : 4;
     uint8_t setting_state : 3;
     int8_t alarm_handled_minute;
-    int8_t alarm_quick_ticks;
+    bool alarm_quick_ticks : 1;
     bool is_setting : 1;
     alarm_setting_t alarm[ALARM_ALARMS];
 } alarm_state_t;

--- a/movement/watch_faces/complication/alarm_face.h
+++ b/movement/watch_faces/complication/alarm_face.h
@@ -41,7 +41,6 @@ A face for setting various alarms
 #define ALARM_DAY_WEEKEND 10
 #define ALARM_MAX_BEEP_ROUNDS 9 // maximum number of beeping rounds for an alarm slot
 #define ALARM_SETTING_STATES 6
-#define ALARM_INDICATOR_BIT 4   // arbitrary choice: this bit within the movement_setting.reserved byte will indicate if at least one alarm is set
 
 typedef struct {
     uint8_t day : 4;    // day of week: 0=MO, 1=TU, 2=WE, 3=TH, 4=FR, 5=SA, 6=SU, 7=each day, 8=one time alarm, 9=Weekdays, 10=Weekend

--- a/movement/watch_faces/complication/alarm_face.h
+++ b/movement/watch_faces/complication/alarm_face.h
@@ -1,0 +1,79 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Andreas Nebinger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+//-----------------------------------------------------------------------------
+
+#ifndef ALARM_FACE_H_
+#define ALARM_FACE_H_
+
+#include "movement.h"
+
+/*
+A face for setting various alarms
+*/
+
+#define ALARM_ALARMS 10      // no of available alarm slots (be aware: only 4 bits reserved for this value in struct below)
+#define ALARM_DAY_STATES 11 // no of different day settings
+#define ALARM_DAY_EACH_DAY 7
+#define ALARM_DAY_ONE_TIME 8
+#define ALARM_DAY_WORKDAY 9
+#define ALARM_DAY_WEEKEND 10
+#define ALARM_MAX_BEEP_ROUNDS 9 // maximum number of beeping rounds for an alarm slot
+#define ALARM_SETTING_STATES 6
+#define ALARM_INDICATOR_BIT 4   // arbitrary choice: this bit within the movement_setting.reserved byte will indicate if at least one alarm is set
+
+typedef struct {
+    uint8_t day : 4;    // day of week: 0=MO, 1=TU, 2=WE, 3=TH, 4=FR, 5=SA, 6=SU, 7=each day, 8=one time alarm, 9=Weekdays, 10=Weekend
+    uint8_t hour : 5;
+    uint8_t minute : 6;
+    uint8_t beeps : 4;
+    uint8_t pitch :2;
+    bool enabled : 1;
+} alarm_setting_t;
+
+typedef struct {
+    bool is_setting : 1;
+    uint8_t setting_state : 3;
+    uint8_t alarm_idx : 4;
+    uint8_t alarm_playing_idx : 4;
+    int8_t alarm_handled_minute;
+    alarm_setting_t alarm[ALARM_ALARMS];
+} alarm_state_t;
+
+
+void alarm_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr);
+void alarm_face_activate(movement_settings_t *settings, void *context);
+bool alarm_face_loop(movement_event_t event, movement_settings_t *settings, void *context);
+void alarm_face_resign(movement_settings_t *settings, void *context);
+bool alarm_face_wants_background_task(movement_settings_t *settings, void *context);
+
+#define alarm_face ((const watch_face_t){ \
+    alarm_face_setup, \
+    alarm_face_activate, \
+    alarm_face_loop, \
+    alarm_face_resign, \
+    alarm_face_wants_background_task, \
+})
+
+#endif // ALARM_FACE_H_

--- a/movement/watch_faces/complication/alarm_face.h
+++ b/movement/watch_faces/complication/alarm_face.h
@@ -41,6 +41,7 @@ A face for setting various alarms
 #define ALARM_DAY_WEEKEND 10
 #define ALARM_MAX_BEEP_ROUNDS 11 // maximum number of beeping rounds for an alarm slot (including short and long alarms)
 #define ALARM_SETTING_STATES 6
+#define ALARM_QUICK_MIN_TICKS 2 * 4    // number of ticks (quarter seconds) to wait until fast counting for hours and minutes kicks in
 
 typedef struct {
     uint8_t day : 4;    // day of week: 0=MO, 1=TU, 2=WE, 3=TH, 4=FR, 5=SA, 6=SU, 7=each day, 8=one time alarm, 9=Weekdays, 10=Weekend
@@ -56,7 +57,7 @@ typedef struct {
     uint8_t alarm_playing_idx : 4;
     uint8_t setting_state : 3;
     int8_t alarm_handled_minute;
-    bool alarm_quick_ticks : 1;
+    int8_t alarm_quick_ticks;
     bool is_setting : 1;
     alarm_setting_t alarm[ALARM_ALARMS];
 } alarm_state_t;

--- a/movement/watch_faces/complication/alarm_face.h
+++ b/movement/watch_faces/complication/alarm_face.h
@@ -33,13 +33,13 @@
 A face for setting various alarms
 */
 
-#define ALARM_ALARMS 10      // no of available alarm slots (be aware: only 4 bits reserved for this value in struct below)
+#define ALARM_ALARMS 16     // no of available alarm slots (be aware: only 4 bits reserved for this value in struct below)
 #define ALARM_DAY_STATES 11 // no of different day settings
 #define ALARM_DAY_EACH_DAY 7
 #define ALARM_DAY_ONE_TIME 8
 #define ALARM_DAY_WORKDAY 9
 #define ALARM_DAY_WEEKEND 10
-#define ALARM_MAX_BEEP_ROUNDS 9 // maximum number of beeping rounds for an alarm slot
+#define ALARM_MAX_BEEP_ROUNDS 11 // maximum number of beeping rounds for an alarm slot (including short and long alarms)
 #define ALARM_SETTING_STATES 6
 
 typedef struct {

--- a/movement/watch_faces/complication/alarm_face.h
+++ b/movement/watch_faces/complication/alarm_face.h
@@ -41,6 +41,7 @@ A face for setting various alarms
 #define ALARM_DAY_WEEKEND 10
 #define ALARM_MAX_BEEP_ROUNDS 11 // maximum number of beeping rounds for an alarm slot (including short and long alarms)
 #define ALARM_SETTING_STATES 6
+#define ALARM_QUICK_MIN_TICKS 2 * 4    // number of ticks (quarter seconds) to wait until fast counting for hours and minutes kicks in
 
 typedef struct {
     uint8_t day : 4;    // day of week: 0=MO, 1=TU, 2=WE, 3=TH, 4=FR, 5=SA, 6=SU, 7=each day, 8=one time alarm, 9=Weekdays, 10=Weekend
@@ -52,11 +53,12 @@ typedef struct {
 } alarm_setting_t;
 
 typedef struct {
-    bool is_setting : 1;
-    uint8_t setting_state : 3;
     uint8_t alarm_idx : 4;
     uint8_t alarm_playing_idx : 4;
+    uint8_t setting_state : 3;
     int8_t alarm_handled_minute;
+    int8_t alarm_quick_ticks;
+    bool is_setting : 1;
     alarm_setting_t alarm[ALARM_ALARMS];
 } alarm_state_t;
 


### PR DESCRIPTION
Implements 16 alarm slots for the sensor watch.

**How to use the alarm face:**
- In normal mode, the alarm button cycles through all 16 alarms. 
- Long pressing the alarm button in normal mode toggles the corresponding alarm on or off.
- Pressing the light button enters setting mode and cycles through the settings of each alarm.
- In setting mode an alarm slot is selected by pressing the alarm button when the slot number 
  in the upper right corner is blinking.
- For each alarm slot, you can select the day. These are the day modes:
	- ED = the alarm rings every day
	- 1t = the alarm fires only one time and is erased afterwards
	- MF = the alarm fires Mondays to Fridays
	- WN = the alarm fires on weekends (Sa/Su)
	- MO to SU = the alarm fires only on the given day of week
- You can fast cycle through hour or minute setting via long press of the alarm button.
- You can select the tone in which the alarm is played. (Three pitch levels available)
- You can select how many "beep rounds" are played for each alarm (1 to 9 beep rounds plus extra short [o] and extra long [L]).
- The simple watch face indicates any alarm set by showing the bell indicator.

**Technical Stuff:**

There are changes in `movement.c`, `movement.h`, and `simple_clock_face.c` to make customizable alarm lengths and pitch levels possible, and also to be able to show an alarm indicator on the simple watch face.
- `movement_settings_t` has an additional flag `alarm_enabled`.
- `movement_state_t` has an additional field `alarm_note`.
- I added the function `movement_play_alarm_beeps(uint8_t rounds, BuzzerNote alarm_note)` to `movement.c` to play alarms of customizable length and tone.
- `simple_clock_face.c` now indicates if `alarm_enabled` is set with the bell indicator.

Edit: Bump number of alarms to 16 and mention extra short and extra long alarms.