### PR TITLE
Adds a rate meter watchface

### DIFF
--- a/movement/make/Makefile
+++ b/movement/make/Makefile
@@ -68,6 +68,7 @@ SRCS += \
   ../watch_faces/complication/probability_face.c \
   ../watch_faces/complication/wake_face.c \
   ../watch_faces/demo/frequency_correction_face.c \
+  ../watch_faces/complication/ratemeter_face.c \
 # New watch faces go above this line.
 
 # Leave this line at the bottom of the file; it has all the targets for making your project.

--- a/movement/watch_faces/complication/ratemeter_face.c
+++ b/movement/watch_faces/complication/ratemeter_face.c
@@ -1,0 +1,97 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Joey Castillo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "ratemeter_face.h"
+#include "watch.h"
+
+#define RATEMETER_FACE_FREQUENCY_FACTOR (4ul) // refresh rate will be 2 to this power Hz (0 for 1 Hz, 2 for 4 Hz, etc.)
+#define RATEMETER_FACE_FREQUENCY (1 << RATEMETER_FACE_FREQUENCY_FACTOR)
+
+void ratemeter_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {
+    (void) settings;
+    (void) watch_face_index;
+    if (*context_ptr == NULL) *context_ptr = malloc(sizeof(ratemeter_state_t));
+}
+
+void ratemeter_face_activate(movement_settings_t *settings, void *context) {
+    (void) settings;
+    memset(context, 0, sizeof(ratemeter_state_t));
+}
+
+bool ratemeter_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
+    (void) settings;
+    ratemeter_state_t *ratemeter_state = (ratemeter_state_t *)context;
+    char buf[14];
+    switch (event.event_type) {
+        case EVENT_ACTIVATE:
+            watch_display_string("ra          ", 0);
+            break;
+        case EVENT_MODE_BUTTON_UP:
+            movement_move_to_next_face();
+            break;
+        case EVENT_LIGHT_BUTTON_DOWN:
+            movement_illuminate_led();
+            break;
+        case EVENT_ALARM_BUTTON_DOWN:
+            if (ratemeter_state->ticks != 0) {
+                ratemeter_state->rate = (int16_t)(60.0 / ((float)ratemeter_state->ticks / (float)RATEMETER_FACE_FREQUENCY));
+            }
+            ratemeter_state->ticks = 0;
+            movement_request_tick_frequency(RATEMETER_FACE_FREQUENCY);
+            break;
+        case EVENT_ALARM_BUTTON_UP:
+            break;
+        case EVENT_ALARM_LONG_PRESS:
+            break;
+        case EVENT_TICK:
+            if (ratemeter_state->rate == 0) {
+                watch_display_string("ra          ", 0);
+            } else {
+                if (ratemeter_state->rate > 500) {
+                    watch_display_string("ra      Hi", 0);
+                } else if (ratemeter_state->rate < 1) {
+                    watch_display_string("ra      Lo", 0);
+                } else {
+                    sprintf(buf, "ra  %-3d pn", ratemeter_state->rate);
+                    watch_display_string(buf, 0);
+                }
+            }
+            ratemeter_state->ticks++;
+            break;
+        case EVENT_TIMEOUT:
+            movement_move_to_face(0);
+            break;
+        default:
+            break;
+    }
+
+    return true;
+}
+
+void ratemeter_face_resign(movement_settings_t *settings, void *context) {
+    (void) settings;
+    (void) context;
+}

--- a/movement/watch_faces/complication/ratemeter_face.c
+++ b/movement/watch_faces/complication/ratemeter_face.c
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022 Joey Castillo
+ * Copyright (c) 2022 David Singleton
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/movement/watch_faces/complication/ratemeter_face.h
+++ b/movement/watch_faces/complication/ratemeter_face.h
@@ -22,40 +22,27 @@
  * SOFTWARE.
  */
 
-#ifndef MOVEMENT_FACES_H_
-#define MOVEMENT_FACES_H_
+#ifndef RATEMETER_FACE_H_
+#define RATEMETER_FACE_H_
 
-#include "simple_clock_face.h"
-#include "world_clock_face.h"
-#include "preferences_face.h"
-#include "set_time_face.h"
-#include "pulsometer_face.h"
-#include "thermistor_readout_face.h"
-#include "thermistor_logging_face.h"
-#include "thermistor_testing_face.h"
-#include "character_set_face.h"
-#include "beats_face.h"
-#include "day_one_face.h"
-#include "voltage_face.h"
-#include "stopwatch_face.h"
-#include "totp_face.h"
-#include "lis2dw_logging_face.h"
-#include "demo_face.h"
-#include "hello_there_face.h"
-#include "sunrise_sunset_face.h"
-#include "countdown_face.h"
-#include "counter_face.h"
-#include "blinky_face.h"
-#include "moon_phase_face.h"
-#include "accelerometer_data_acquisition_face.h"
-#include "mars_time_face.h"
-#include "orrery_face.h"
-#include "astronomy_face.h"
-#include "tomato_face.h"
-#include "probability_face.h"
-#include "wake_face.h"
-#include "frequency_correction_face.h"
-#include "ratemeter_face.h"
-// New includes go above this line.
+#include "movement.h"
 
-#endif // MOVEMENT_FACES_H_
+typedef struct {
+    int16_t rate;
+    int16_t ticks;
+} ratemeter_state_t;
+
+void ratemeter_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr);
+void ratemeter_face_activate(movement_settings_t *settings, void *context);
+bool ratemeter_face_loop(movement_event_t event, movement_settings_t *settings, void *context);
+void ratemeter_face_resign(movement_settings_t *settings, void *context);
+
+#define ratemeter_face ((const watch_face_t){ \
+    ratemeter_face_setup, \
+    ratemeter_face_activate, \
+    ratemeter_face_loop, \
+    ratemeter_face_resign, \
+    NULL, \
+})
+
+#endif // RATEMETER_FACE_H_


### PR DESCRIPTION
This pull request adds a rate meter watchface.

The rate meter shows the rate per minute at which the alarm button is being pressed. This is particularly useful in sports where cadence tracking is useful. For instance, rowing coaches often use a dedicated rate meter - clicking the rate button each time the crew puts their oars in the water to see the rate (strokes per minute) on the rate meter.%                                                                                                                                            