### PR TITLE
Make thermistor logging face show current temp.

### DIFF
--- a/movement/watch_faces/sensor/thermistor_logging_face.c
+++ b/movement/watch_faces/sensor/thermistor_logging_face.c
@@ -107,6 +107,11 @@ bool thermistor_logging_face_loop(movement_event_t event, movement_settings_t *s
             logger_state->ts_ticks = 2;
             _thermistor_logging_face_update_display(logger_state, settings->bit.use_imperial_units, settings->bit.clock_mode_24h);
             break;
+        case EVENT_ALARM_LONG_PRESS:
+            logger_state->display_index = 0;
+            logger_state->ts_ticks = 0;
+            _thermistor_logging_face_update_display(logger_state, settings->bit.use_imperial_units, settings->bit.clock_mode_24h);
+            break;
         case EVENT_ALARM_BUTTON_DOWN:
             logger_state->display_index = (logger_state->display_index + 1) % THERMISTOR_LOGGING_NUM_DATA_POINTS;
             logger_state->ts_ticks = 0;


### PR DESCRIPTION
Use position 0 in the logging face to show the current temp (and echo the 'signal' behaviour from the readout face).

This means you don't need to 'waste' a face if you want logging and readout.