### PR TITLE
Fix scheduled tasks scheduling another task

### DIFF
--- a/movement/movement.c
+++ b/movement/movement.c
@@ -159,6 +159,10 @@ static void _movement_handle_scheduled_tasks(void) {
                 scheduled_tasks[i].reg = 0;
                 movement_event_t background_event = { EVENT_BACKGROUND_TASK, 0 };
                 watch_faces[i].loop(background_event, &movement_state.settings, watch_face_contexts[i]);
+                // check if loop scheduled a new task
+                if (scheduled_tasks[i].reg) {
+                    num_active_tasks++;
+                }
             } else {
                 num_active_tasks++;
             }

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -211,15 +211,23 @@ void movement_move_to_next_face(void) {
 }
 
 void movement_schedule_background_task(watch_date_time date_time) {
-    watch_date_time now = watch_rtc_get_date_time();
-    if (date_time.reg > now.reg) {
-        movement_state.has_scheduled_background_task = true;
-        scheduled_tasks[movement_state.current_watch_face].reg = date_time.reg;
-    }
+    movement_schedule_background_task_for_face(movement_state.current_watch_face, date_time);
 }
 
 void movement_cancel_background_task(void) {
-    scheduled_tasks[movement_state.current_watch_face].reg = 0;
+    movement_cancel_background_task_for_face(movement_state.current_watch_face);
+}
+
+void movement_schedule_background_task_for_face(uint8_t watch_face_index, watch_date_time date_time) {
+    watch_date_time now = watch_rtc_get_date_time();
+    if (date_time.reg > now.reg) {
+        movement_state.has_scheduled_background_task = true;
+        scheduled_tasks[watch_face_index].reg = date_time.reg;
+    }
+}
+
+void movement_cancel_background_task_for_face(uint8_t watch_face_index) {
+    scheduled_tasks[watch_face_index].reg = 0;
     bool other_tasks_scheduled = false;
     for(uint8_t i = 0; i < MOVEMENT_NUM_FACES; i++) {
         if (scheduled_tasks[i].reg != 0) {

--- a/movement/movement.h
+++ b/movement/movement.h
@@ -292,6 +292,10 @@ void movement_schedule_background_task(watch_date_time date_time);
 // movement will associate the scheduled task with the currently active face.
 void movement_cancel_background_task(void);
 
+// these functions should work around the limitation of the above functions, which will be deprecated.
+void movement_schedule_background_task_for_face(uint8_t watch_face_index, watch_date_time date_time);
+void movement_cancel_background_task_for_face(uint8_t watch_face_index);
+
 void movement_request_wake(void);
 
 void movement_play_signal(void);


### PR DESCRIPTION
I stumbled on this while creating a watch face that needs a (kinda) periodic countdown.

The watch face handles the background task event and immediately schedules a new background task. Without these changes the next background task is not run if it was the only watch face with a background task, because `num_active_tasks` is zero.