### PR TITLE
Make movement auto fire long press event

### DIFF
--- a/movement/movement.h
+++ b/movement/movement.h
@@ -61,7 +61,8 @@ typedef union {
         // altimeter to display feet or meters as easily as it tells a thermometer to display degrees in F or C.
         bool clock_mode_24h : 1;            // indicates whether clock should use 12 or 24 hour mode.
         bool use_imperial_units : 1;        // indicates whether to use metric units (the default) or imperial.
-        uint8_t reserved : 7;               // room for more preferences if needed.
+        bool alarm_enabled : 1;             // indicates whether there is at least one alarm enabled.
+        uint8_t reserved : 6;               // room for more preferences if needed.
     } bit;
     uint32_t reg;
 } movement_settings_t;
@@ -109,13 +110,16 @@ typedef enum {
     EVENT_TIMEOUT,              // Your watch face has been inactive for a while. You may want to resign, depending on your watch face's intended use case.
     EVENT_LIGHT_BUTTON_DOWN,    // The light button has been pressed, but not yet released.
     EVENT_LIGHT_BUTTON_UP,      // The light button was pressed and released.
-    EVENT_LIGHT_LONG_PRESS,     // The light button was held for >2 seconds, and released.
+    EVENT_LIGHT_LONG_PRESS,     // The light button was held for >2 seconds, but not yet released.
+    EVENT_LIGHT_LONG_UP,        // The light button was held for >2 seconds, and released.
     EVENT_MODE_BUTTON_DOWN,     // The mode button has been pressed, but not yet released.
     EVENT_MODE_BUTTON_UP,       // The mode button was pressed and released.
-    EVENT_MODE_LONG_PRESS,      // The mode button was held for >2 seconds, and released. NOTE: your watch face will resign immediately after receiving this event.
+    EVENT_MODE_LONG_PRESS,      // The mode button was held for >2 seconds, but not yet released.
+    EVENT_MODE_LONG_UP,         // The mode button was held for >2 seconds, and released. NOTE: your watch face will resign immediately after receiving this event.
     EVENT_ALARM_BUTTON_DOWN,    // The alarm button has been pressed, but not yet released.
     EVENT_ALARM_BUTTON_UP,      // The alarm button was pressed and released.
-    EVENT_ALARM_LONG_PRESS,     // The alarm button was held for >2 seconds, and released.
+    EVENT_ALARM_LONG_PRESS,     // The alarm button was held for >2 seconds, but not yet released.
+    EVENT_ALARM_LONG_UP,        // The alarm button was held for >2 seconds, and released.
 } movement_event_type_t;
 
 typedef struct {
@@ -252,11 +256,12 @@ typedef struct {
     // alarm stuff
     int16_t alarm_ticks;
     bool is_buzzing;
+    BuzzerNote alarm_note;
 
     // button tracking for long press
-    uint8_t light_down_timestamp;
-    uint8_t mode_down_timestamp;
-    uint8_t alarm_down_timestamp;
+    uint16_t light_down_timestamp;
+    uint16_t mode_down_timestamp;
+    uint16_t alarm_down_timestamp;
 
     // background task handling
     bool needs_background_tasks_handled;
@@ -300,6 +305,7 @@ void movement_request_wake(void);
 
 void movement_play_signal(void);
 void movement_play_alarm(void);
+void movement_play_alarm_beeps(uint8_t rounds, BuzzerNote alarm_note);
 
 uint8_t movement_claim_backup_register(void);
 

--- a/movement/movement.h
+++ b/movement/movement.h
@@ -109,17 +109,17 @@ typedef enum {
     EVENT_BACKGROUND_TASK,      // Your watch face is being invoked to perform a background task. Don't update the display here; you may not be in the foreground.
     EVENT_TIMEOUT,              // Your watch face has been inactive for a while. You may want to resign, depending on your watch face's intended use case.
     EVENT_LIGHT_BUTTON_DOWN,    // The light button has been pressed, but not yet released.
-    EVENT_LIGHT_BUTTON_UP,      // The light button was pressed and released.
-    EVENT_LIGHT_LONG_PRESS,     // The light button was held for >2 seconds, but not yet released.
-    EVENT_LIGHT_LONG_UP,        // The light button was held for >2 seconds, and released.
+    EVENT_LIGHT_BUTTON_UP,      // The light button was pressed for less than half a second, and released.
+    EVENT_LIGHT_LONG_PRESS,     // The light button was held for over half a second, but not yet released.
+    EVENT_LIGHT_LONG_UP,        // The light button was held for over half a second, and released.
     EVENT_MODE_BUTTON_DOWN,     // The mode button has been pressed, but not yet released.
-    EVENT_MODE_BUTTON_UP,       // The mode button was pressed and released.
-    EVENT_MODE_LONG_PRESS,      // The mode button was held for >2 seconds, but not yet released.
-    EVENT_MODE_LONG_UP,         // The mode button was held for >2 seconds, and released. NOTE: your watch face will resign immediately after receiving this event.
+    EVENT_MODE_BUTTON_UP,       // The mode button was pressed for less than half a second, and released.
+    EVENT_MODE_LONG_PRESS,      // The mode button was held for over half a second, but not yet released.
+    EVENT_MODE_LONG_UP,         // The mode button was held for over half a second, and released. NOTE: your watch face will resign immediately after receiving this event.
     EVENT_ALARM_BUTTON_DOWN,    // The alarm button has been pressed, but not yet released.
-    EVENT_ALARM_BUTTON_UP,      // The alarm button was pressed and released.
-    EVENT_ALARM_LONG_PRESS,     // The alarm button was held for >2 seconds, but not yet released.
-    EVENT_ALARM_LONG_UP,        // The alarm button was held for >2 seconds, and released.
+    EVENT_ALARM_BUTTON_UP,      // The alarm button was pressed for less than half a second, and released.
+    EVENT_ALARM_LONG_PRESS,     // The alarm button was held for over half a second, but not yet released.
+    EVENT_ALARM_LONG_UP,        // The alarm button was held for over half a second, and released.
 } movement_event_type_t;
 
 typedef struct {

--- a/movement/watch_faces/complication/alarm_face.c
+++ b/movement/watch_faces/complication/alarm_face.c
@@ -89,9 +89,10 @@ static void _alarm_face_draw(movement_settings_t *settings, alarm_state_t *state
     //handle am/pm for hour display
     uint8_t h = state->alarm[state->alarm_idx].hour;
     if (!settings->bit.clock_mode_24h) {
-        if (h > 12) {
+        if (h >= 12) {
             watch_set_indicator(WATCH_INDICATOR_PM);
-            h -= 12;
+            h = h % 12;
+            h += h ? 0 : 12;
         } else {
             watch_clear_indicator(WATCH_INDICATOR_PM);
         }
@@ -207,8 +208,6 @@ void alarm_face_setup(movement_settings_t *settings, uint8_t watch_face_index, v
 void alarm_face_activate(movement_settings_t *settings, void *context) {
     (void) settings;
     (void) context;
-    watch_display_string("  ", 8);
-    watch_clear_indicator(WATCH_INDICATOR_LAP); // may be unnecessary, but who knows
     watch_set_colon();
 }
 
@@ -270,7 +269,7 @@ bool alarm_face_loop(movement_event_t event, movement_settings_t *settings, void
                         state->alarm[state->alarm_idx].minute = (state->alarm[state->alarm_idx].minute + 1) % 60;
             } else _abort_quick_ticks(state);
         } else if (!state->is_setting) break; // no need to do anything when we are not in settings mode and no quick ticks are running
-        // otherwise fall through and draw the current face state
+        // fall through
     case EVENT_ACTIVATE:
         _alarm_face_draw(settings, state, event.subsecond);
         break;

--- a/movement/watch_faces/complication/alarm_face.c
+++ b/movement/watch_faces/complication/alarm_face.c
@@ -1,0 +1,399 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Andreas Nebinger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+//-----------------------------------------------------------------------------
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "alarm_face.h"
+#include "watch.h"
+#include "watch_utility.h"
+#include "watch_private_display.h"
+
+/*
+    Implements 16 alarm slots on the sensor watch
+
+    Usage:
+    - In normal mode, the alarm button cycles through all 16 alarms. 
+    - Long pressing the alarm button in normal mode toggles the corresponding alarm on or off.
+    - Pressing the light button enters setting mode and cycles through the settings of each alarm.
+    - In setting mode an alarm slot is selected by pressing the alarm button when the slot number 
+      in the upper right corner is blinking.
+    - For each alarm slot, you can select the day. These are the day modes:
+        - ED = the alarm rings every day
+        - 1t = the alarm fires only one time and is erased afterwards
+        - MF = the alarm fires Mondays to Fridays
+        - WN = the alarm fires on weekends (Sa/Su)
+        - MO to SU = the alarm fires only on the given day of week
+    - You can fast cycle through hour or minute setting via long press of the alarm button.
+    - You can select the tone in which the alarm is played. (Three pitch levels available.)
+    - You can select how many "beep rounds" are played for each alarm. 1 to 9 rounds, plus extra 
+      long ('L') and extra short ('o') alarms.
+    - The simple watch face indicates any alarm set by showing the bell indicator.
+*/
+
+typedef enum {
+    alarm_setting_idx_alarm,
+    alarm_setting_idx_day,
+    alarm_setting_idx_hour,
+    alarm_setting_idx_minute,
+    alarm_setting_idx_pitch,
+    alarm_setting_idx_beeps
+} alarm_setting_idx_t;
+
+static const char _dow_strings[ALARM_DAY_STATES + 1][2] ={"AL", "MO", "TU", "WE", "TH", "FR", "SA", "SO", "ED", "1t", "MF", "WN"};
+static const uint8_t _blink_idx[ALARM_SETTING_STATES] = {2, 0, 4, 6, 8, 9};
+static const uint8_t _blink_idx2[ALARM_SETTING_STATES] = {3, 1, 5, 7, 8, 9};
+static const BuzzerNote _buzzer_notes[3] = {BUZZER_NOTE_B6, BUZZER_NOTE_C8, BUZZER_NOTE_A8};
+static const uint8_t _buzzer_segdata[3][2] = {{0, 3}, {1, 3}, {2, 2}};
+
+static uint8_t _get_weekday_idx(watch_date_time date_time) {
+    date_time.unit.year += 20;
+    if (date_time.unit.month <= 2) {
+        date_time.unit.month += 12;
+        date_time.unit.year--;
+    }
+    return (date_time.unit.day + 13 * (date_time.unit.month + 1) / 5 + date_time.unit.year + date_time.unit.year / 4 + 525 - 2) % 7;
+}
+
+static void _alarm_face_draw(movement_settings_t *settings, alarm_state_t *state, uint8_t subsecond) {
+    char buf[12];
+
+    uint8_t i = 0;
+    if (state->is_setting) {
+        // display the actual day indicating string for the current alarm
+        i = state->alarm[state->alarm_idx].day + 1;
+    }
+    //handle am/pm for hour display
+    uint8_t h = state->alarm[state->alarm_idx].hour;
+    if (!settings->bit.clock_mode_24h) {
+        if (h > 12) {
+            watch_set_indicator(WATCH_INDICATOR_PM);
+            h -= 12;
+        } else {
+            watch_clear_indicator(WATCH_INDICATOR_PM);
+        }
+    }
+    sprintf(buf, "%c%c%2d%2d%02d  ",
+        _dow_strings[i][0], _dow_strings[i][1],
+        (state->alarm_idx + 1),
+        h,
+        state->alarm[state->alarm_idx].minute);
+    // blink items if in settings mode
+    if (state->is_setting && subsecond % 2 && state->setting_state < alarm_setting_idx_pitch && !state->alarm_quick_ticks) {
+        buf[_blink_idx[state->setting_state]] = buf[_blink_idx2[state->setting_state]] = ' ';
+    }
+    watch_display_string(buf, 0);
+    
+    if (state->is_setting) {
+    // draw pitch level indicator
+        if ((subsecond % 2) == 0 || (state->setting_state != alarm_setting_idx_pitch)) {
+        for (i = 0; i <= state->alarm[state->alarm_idx].pitch && i < 3; i++)
+            watch_set_pixel(_buzzer_segdata[i][0], _buzzer_segdata[i][1]);
+    }
+        // draw beep rounds indicator
+        if ((subsecond % 2) == 0 || (state->setting_state != alarm_setting_idx_beeps)) {
+            if (state->alarm[state->alarm_idx].beeps == ALARM_MAX_BEEP_ROUNDS - 1)
+                watch_display_character('L', _blink_idx[alarm_setting_idx_beeps]);
+            else {
+                if (state->alarm[state->alarm_idx].beeps == 0)
+                    watch_display_character('o', _blink_idx[alarm_setting_idx_beeps]);
+            else
+                    watch_display_character(state->alarm[state->alarm_idx].beeps + 48, _blink_idx[alarm_setting_idx_beeps]);
+            }
+        }
+    }
+
+    // set bell indicator
+    if (state->alarm[state->alarm_idx].enabled)
+        watch_set_indicator(WATCH_INDICATOR_BELL);
+    else
+        watch_clear_indicator(WATCH_INDICATOR_BELL);
+
+}
+
+static void _alarm_initiate_setting(movement_settings_t *settings, alarm_state_t *state, uint8_t subsecond) {
+    state->is_setting = true;
+    state->setting_state = 0;
+    movement_request_tick_frequency(4);
+    _alarm_face_draw(settings, state, subsecond);
+}
+
+static void _alarm_resume_setting(movement_settings_t *settings, alarm_state_t *state, uint8_t subsecond) {
+    state->is_setting = false;
+    movement_request_tick_frequency(1);
+    _alarm_face_draw(settings, state, subsecond);
+}
+
+static void _alarm_update_alarm_enabled(movement_settings_t *settings, alarm_state_t *state) {
+    // save indication for active alarms to movement settings
+    bool active_alarms = false;
+    for (uint8_t i = 0; i < ALARM_ALARMS; i++) {
+        if (state->alarm[i].enabled) {
+            active_alarms = true;
+            break;
+        }
+    }
+    settings->bit.alarm_enabled = active_alarms;
+}
+
+static void _alarm_play_short_beep(uint8_t pitch_idx) {
+    // play a short double beep
+    watch_buzzer_play_note(_buzzer_notes[pitch_idx], 50);
+    watch_buzzer_play_note(BUZZER_NOTE_REST, 50);
+    watch_buzzer_play_note(_buzzer_notes[pitch_idx], 70);
+}
+
+static void _alarm_indicate_beep(alarm_state_t *state) {
+    // play an example for the current beep setting
+    if (state->alarm[state->alarm_idx].beeps == 0) {
+        // short double beep
+        _alarm_play_short_beep(state->alarm[state->alarm_idx].pitch);
+    } else {
+        // regular alarm beep
+        movement_play_alarm_beeps(1, _buzzer_notes[state->alarm[state->alarm_idx].pitch]);
+    }
+}
+
+static void _abort_quick_ticks(alarm_state_t *state) {
+    // abort counting quick ticks
+    if (state->alarm_quick_ticks) {
+        state->alarm[state->alarm_idx].enabled = true;
+        state->alarm_quick_ticks = false;
+        movement_request_tick_frequency(4);
+    }
+}
+
+void alarm_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void **context_ptr) {
+    (void) settings;
+    (void) watch_face_index;
+
+    if (*context_ptr == NULL) {
+        *context_ptr = malloc(sizeof(alarm_state_t));
+        alarm_state_t *state = (alarm_state_t *)*context_ptr;
+        memset(*context_ptr, 0, sizeof(alarm_state_t));
+        // initialize the default alarm values
+        for (uint8_t i = 0; i < ALARM_ALARMS; i++) {
+            state->alarm[i].day = ALARM_DAY_EACH_DAY;
+            state->alarm[i].beeps = 5;
+            state->alarm[i].pitch = 1;
+        }
+        state->alarm_handled_minute = -1;
+    }
+}
+
+void alarm_face_activate(movement_settings_t *settings, void *context) {
+    (void) settings;
+    (void) context;
+    watch_display_string("  ", 8);
+    watch_clear_indicator(WATCH_INDICATOR_LAP); // may be unnecessary, but who knows
+    watch_set_colon();
+}
+
+void alarm_face_resign(movement_settings_t *settings, void *context) {
+    alarm_state_t *state = (alarm_state_t *)context;
+    state->is_setting = false;
+    _alarm_update_alarm_enabled(settings, state);
+    watch_set_led_off();
+    watch_store_backup_data(settings->reg, 0);
+    state->alarm_quick_ticks = false;
+    movement_request_tick_frequency(1);
+}
+
+bool alarm_face_wants_background_task(movement_settings_t *settings, void *context) {
+    (void) settings;
+    alarm_state_t *state = (alarm_state_t *)context;
+    watch_date_time now = watch_rtc_get_date_time();
+    // just a failsafe: never fire more than one alarm within a minute
+    if (state->alarm_handled_minute == now.unit.minute) return false;
+    state->alarm_handled_minute = now.unit.minute;
+    // check the rest
+    for (uint8_t i = 0; i < ALARM_ALARMS; i++) {
+        if (state->alarm[i].enabled) {
+            if (state->alarm[i].minute == now.unit.minute) {
+                if (state->alarm[i].hour == now.unit.hour) {
+                    state->alarm_playing_idx = i;
+                    if (state->alarm[i].day == ALARM_DAY_EACH_DAY) return true;
+                    if (state->alarm[i].day == ALARM_DAY_ONE_TIME) {
+                        // erase this alarm
+                        state->alarm[i].day = ALARM_DAY_EACH_DAY;
+                        state->alarm[i].minute = state->alarm[i].hour = 0;
+                        state->alarm[i].enabled = false;
+                        _alarm_update_alarm_enabled(settings, state);
+                        return true;
+                    }
+                    uint8_t weekday_idx = _get_weekday_idx(now);
+                    if (state->alarm[i].day == weekday_idx) return true;
+                    if (state->alarm[i].day == ALARM_DAY_WORKDAY && weekday_idx < 5) return true;
+                    if (state->alarm[i].day == ALARM_DAY_WEEKEND && weekday_idx >= 5) return true;
+                }
+            }
+        }
+    }
+    state->alarm_handled_minute = -1;
+    return false;
+}
+
+bool alarm_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
+    (void) settings;
+    alarm_state_t *state = (alarm_state_t *)context;
+
+    switch (event.event_type) {
+    case EVENT_TICK:
+        if (state->alarm_quick_ticks) {
+            // we are in fast cycling mode
+            if (state->setting_state == alarm_setting_idx_hour) {
+                        state->alarm[state->alarm_idx].hour = (state->alarm[state->alarm_idx].hour + 1) % 24;
+            } else if (state->setting_state == alarm_setting_idx_minute) {
+                        state->alarm[state->alarm_idx].minute = (state->alarm[state->alarm_idx].minute + 1) % 60;
+            } else _abort_quick_ticks(state);
+        } else if (!state->is_setting) break; // no need to do anything when we are not in settings mode and no quick ticks are running
+        // otherwise fall through and draw the current face state
+    case EVENT_ACTIVATE:
+        _alarm_face_draw(settings, state, event.subsecond);
+        break;
+    case EVENT_LIGHT_BUTTON_UP:
+        if (!state->is_setting) {
+            movement_illuminate_led();
+            _alarm_initiate_setting(settings, state, event.subsecond);
+            break;
+        }
+        state->setting_state += 1;
+        if (state->setting_state >= ALARM_SETTING_STATES) {
+            // we have done a full settings cycle, so resume to normal
+            _alarm_resume_setting(settings, state, event.subsecond);
+        }
+        break;
+    case EVENT_LIGHT_LONG_PRESS:
+        if (state->is_setting) {
+            _alarm_resume_setting(settings, state, event.subsecond);
+        } else {
+            _alarm_initiate_setting(settings, state, event.subsecond);
+        }
+        break;
+    case EVENT_ALARM_BUTTON_UP:
+        if (!state->is_setting) {
+            // cycle through the alarms
+            state->alarm_idx = (state->alarm_idx + 1) % (ALARM_ALARMS);
+        } else {
+            // handle the settings behaviour
+            switch (state->setting_state) {
+            case alarm_setting_idx_alarm:
+                // alarm selection
+                state->alarm_idx = (state->alarm_idx + 1) % (ALARM_ALARMS);
+                break;
+            case alarm_setting_idx_day:
+                // day selection
+                state->alarm[state->alarm_idx].day = (state->alarm[state->alarm_idx].day + 1) % (ALARM_DAY_STATES);
+                break;
+            case alarm_setting_idx_hour:
+                // hour selection
+                _abort_quick_ticks(state);
+                state->alarm[state->alarm_idx].hour = (state->alarm[state->alarm_idx].hour + 1) % 24;
+                break;
+            case alarm_setting_idx_minute:
+                // minute selection
+                _abort_quick_ticks(state);
+                state->alarm[state->alarm_idx].minute = (state->alarm[state->alarm_idx].minute + 1) % 60;
+                break;
+            case alarm_setting_idx_pitch:
+                // pitch level
+                state->alarm[state->alarm_idx].pitch = (state->alarm[state->alarm_idx].pitch + 1) % 3;
+                // play sound to show user what this is for
+                _alarm_indicate_beep(state);
+                break;
+            case alarm_setting_idx_beeps:
+                // number of beeping rounds selection
+                state->alarm[state->alarm_idx].beeps = (state->alarm[state->alarm_idx].beeps + 1) % ALARM_MAX_BEEP_ROUNDS;
+                // play sounds when user reaches 'short' length and also one time on regular beep length
+                if (state->alarm[state->alarm_idx].beeps <= 1) _alarm_indicate_beep(state);
+                break;
+            default:
+                break;
+            }
+            // auto enable an alarm if user sets anything
+            if (state->setting_state > alarm_setting_idx_alarm) state->alarm[state->alarm_idx].enabled = true;
+        }
+        _alarm_face_draw(settings, state, event.subsecond);
+        break;
+    case EVENT_ALARM_LONG_PRESS:
+        if (!state->is_setting) {
+            // toggle the enabled flag for current alarm
+            state->alarm[state->alarm_idx].enabled ^= 1;
+        } else {
+            // handle the long press settings behaviour
+            switch (state->setting_state) {
+            case alarm_setting_idx_alarm:
+                // alarm selection
+                state->alarm_idx = 0;
+                break;
+            case alarm_setting_idx_minute:
+            case alarm_setting_idx_hour:
+                // initiate fast cycling for hour or minute settings
+                movement_request_tick_frequency(8);
+                state->alarm_quick_ticks = true;
+                break;
+            default:
+                break;
+            }
+        }
+        _alarm_face_draw(settings, state, event.subsecond);
+        break;
+    case EVENT_ALARM_LONG_UP:
+        if (state->is_setting) {
+            if (state->setting_state == alarm_setting_idx_hour || state->setting_state == alarm_setting_idx_minute)
+                _abort_quick_ticks(state);
+        }
+        break;
+    case EVENT_BACKGROUND_TASK:
+        // play alarm
+        if (state->alarm[state->alarm_playing_idx].beeps == 0) {
+            // short beep
+            if (watch_is_buzzer_or_led_enabled()) {
+                _alarm_play_short_beep(state->alarm[state->alarm_playing_idx].pitch);
+            } else {
+                // enable, play beep and disable buzzer again
+                watch_enable_buzzer();
+                _alarm_play_short_beep(state->alarm[state->alarm_playing_idx].pitch);
+                watch_disable_buzzer();
+            }
+        } else {
+            // regular alarm beeps
+            movement_play_alarm_beeps((state->alarm[state->alarm_idx].beeps == (ALARM_MAX_BEEP_ROUNDS - 1) ? 20 : state->alarm[state->alarm_playing_idx].beeps), 
+                                  _buzzer_notes[state->alarm[state->alarm_playing_idx].pitch]);
+        }
+        break;
+    case EVENT_MODE_BUTTON_UP:
+        movement_move_to_next_face();
+        break;
+    case EVENT_TIMEOUT:
+        movement_move_to_face(0);
+        break;
+    default:
+      break;
+    }
+
+    return true;
+}

--- a/movement/watch_faces/complication/alarm_face.h
+++ b/movement/watch_faces/complication/alarm_face.h
@@ -1,0 +1,79 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Andreas Nebinger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+//-----------------------------------------------------------------------------
+
+#ifndef ALARM_FACE_H_
+#define ALARM_FACE_H_
+
+#include "movement.h"
+
+/*
+A face for setting various alarms
+*/
+
+#define ALARM_ALARMS 16     // no of available alarm slots (be aware: only 4 bits reserved for this value in struct below)
+#define ALARM_DAY_STATES 11 // no of different day settings
+#define ALARM_DAY_EACH_DAY 7
+#define ALARM_DAY_ONE_TIME 8
+#define ALARM_DAY_WORKDAY 9
+#define ALARM_DAY_WEEKEND 10
+#define ALARM_MAX_BEEP_ROUNDS 11 // maximum number of beeping rounds for an alarm slot (including short and long alarms)
+#define ALARM_SETTING_STATES 6
+
+typedef struct {
+    uint8_t day : 4;    // day of week: 0=MO, 1=TU, 2=WE, 3=TH, 4=FR, 5=SA, 6=SU, 7=each day, 8=one time alarm, 9=Weekdays, 10=Weekend
+    uint8_t hour : 5;
+    uint8_t minute : 6;
+    uint8_t beeps : 4;
+    uint8_t pitch :2;
+    bool enabled : 1;
+} alarm_setting_t;
+
+typedef struct {
+    uint8_t alarm_idx : 4;
+    uint8_t alarm_playing_idx : 4;
+    uint8_t setting_state : 3;
+    int8_t alarm_handled_minute;
+    bool alarm_quick_ticks : 1;
+    bool is_setting : 1;
+    alarm_setting_t alarm[ALARM_ALARMS];
+} alarm_state_t;
+
+
+void alarm_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr);
+void alarm_face_activate(movement_settings_t *settings, void *context);
+bool alarm_face_loop(movement_event_t event, movement_settings_t *settings, void *context);
+void alarm_face_resign(movement_settings_t *settings, void *context);
+bool alarm_face_wants_background_task(movement_settings_t *settings, void *context);
+
+#define alarm_face ((const watch_face_t){ \
+    alarm_face_setup, \
+    alarm_face_activate, \
+    alarm_face_loop, \
+    alarm_face_resign, \
+    alarm_face_wants_background_task, \
+})
+
+#endif // ALARM_FACE_H_

--- a/movement/watch_faces/complication/pulsometer_face.c
+++ b/movement/watch_faces/complication/pulsometer_face.c
@@ -59,7 +59,7 @@ bool pulsometer_face_loop(movement_event_t event, movement_settings_t *settings,
             movement_request_tick_frequency(PULSOMETER_FACE_FREQUENCY);
             break;
         case EVENT_ALARM_BUTTON_UP:
-        case EVENT_ALARM_LONG_PRESS:
+        case EVENT_ALARM_LONG_UP:
             pulsometer_state->measuring = false;
             movement_request_tick_frequency(1);
             break;


### PR DESCRIPTION
As discussed on Discord this PR changes the behavior of movement firmware: the *_LONG_PRESS events are fired automatically when a button is pressed for longer than 64 ticks (half a second). This makes the long press experience a lot snappier than the current implementation.

To avoid disturbing existing watch faces, a new event type is introduced to signal a button release after a long press: the EVENT_(*)_LONG_UP event. Watch faces can react to this, if they want.

Additionally, in the alarm watch face I had to adjust the quick cycling logic (for hours/minutes) to make use of the new behavior of the movement firmware. (The watch face logic is much simpler than it was before!)

Notice: In the movement files, there is also (again) some logic for customizable alarms. This is thanks to my lack of git wizardry... ;-/

Edit: Added some words about why this is useful.