### PR TITLE
Fix Linux Makefile parallelism

### DIFF
--- a/make.mk
+++ b/make.mk
@@ -31,7 +31,7 @@ else
 endif
 
 ifeq ($(DETECTED_OS), LINUX)
-  MAKEFLAGS += -j `nproc`
+  MAKEFLAGS += -j $(shell nproc)
 endif
 ifeq ($(DETECTED_OS), OSX)
   NPROCS = $(shell sysctl hw.ncpu  | grep -o '[0-9]\+')


### PR DESCRIPTION
Makefile != bourne shell, I think.

At least on my systems, this was causing a raw -j, which meant that make had no restriction on its parallelism
(i.e. tried to build everything at once).

Couldn't see how to trivially show exactly what was happening (i.e. why ``nroc`` was evaluating to the empty string (?) ), but at least this changed fixed the issue and seems harmless.