### PR TITLE
Alarm face: make active alarm indicator show up only when there is an alarm set within the next 24 h

### DIFF
--- a/movement/watch_faces/complication/alarm_face.c
+++ b/movement/watch_faces/complication/alarm_face.c
@@ -37,8 +37,10 @@
 
     Usage:
     - In normal mode, the alarm button cycles through all 16 alarms. 
-    - Long pressing the alarm button in normal mode toggles the corresponding alarm on or off.
+    - Pressing the alarm button long in normal mode toggles the corresponding alarm on or off.
+      (Whereas pressing the alarm button extra long brings you back to alarm no. 1.)
     - Pressing the light button enters setting mode and cycles through the settings of each alarm.
+      (Long pressing the light button enters setting mode without illuminating the led.)
     - In setting mode an alarm slot is selected by pressing the alarm button when the slot number 
       in the upper right corner is blinking.
     - For each alarm slot, you can select the day. These are the day modes:
@@ -51,7 +53,8 @@
     - You can select the tone in which the alarm is played. (Three pitch levels available.)
     - You can select how many "beep rounds" are played for each alarm. 1 to 9 rounds, plus extra 
       long ('L') and extra short ('o') alarms.
-    - The simple watch face indicates any alarm set by showing the bell indicator.
+    - The simple watch face indicates if any alarm is set within the next 24h by showing the signal
+      indicator.
 */
 
 typedef enum {
@@ -69,6 +72,8 @@ static const uint8_t _blink_idx2[ALARM_SETTING_STATES] = {3, 1, 5, 7, 8, 9};
 static const BuzzerNote _buzzer_notes[3] = {BUZZER_NOTE_B6, BUZZER_NOTE_C8, BUZZER_NOTE_A8};
 static const uint8_t _buzzer_segdata[3][2] = {{0, 3}, {1, 3}, {2, 2}};
 
+int8_t _wait_ticks;
+
 static uint8_t _get_weekday_idx(watch_date_time date_time) {
     date_time.unit.year += 20;
     if (date_time.unit.month <= 2) {
@@ -76,6 +81,13 @@ static uint8_t _get_weekday_idx(watch_date_time date_time) {
         date_time.unit.year--;
     }
     return (date_time.unit.day + 13 * (date_time.unit.month + 1) / 5 + date_time.unit.year + date_time.unit.year / 4 + 525 - 2) % 7;
+}
+
+static void _alarm_set_signal(alarm_state_t *state) {
+    if (state->alarm[state->alarm_idx].enabled)
+        watch_set_indicator(WATCH_INDICATOR_SIGNAL);
+    else
+        watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
 }
 
 static void _alarm_face_draw(movement_settings_t *settings, alarm_state_t *state, uint8_t subsecond) {
@@ -127,12 +139,8 @@ static void _alarm_face_draw(movement_settings_t *settings, alarm_state_t *state
         }
     }
 
-    // set bell indicator
-    if (state->alarm[state->alarm_idx].enabled)
-        watch_set_indicator(WATCH_INDICATOR_BELL);
-    else
-        watch_clear_indicator(WATCH_INDICATOR_BELL);
-
+    // set alarm indicator
+    _alarm_set_signal(state);
 }
 
 static void _alarm_initiate_setting(movement_settings_t *settings, alarm_state_t *state, uint8_t subsecond) {
@@ -151,10 +159,36 @@ static void _alarm_resume_setting(movement_settings_t *settings, alarm_state_t *
 static void _alarm_update_alarm_enabled(movement_settings_t *settings, alarm_state_t *state) {
     // save indication for active alarms to movement settings
     bool active_alarms = false;
+    watch_date_time *now = NULL;
+    uint8_t weekday_idx;
+    uint16_t now_minutes_of_day;
+    uint16_t alarm_minutes_of_day;
     for (uint8_t i = 0; i < ALARM_ALARMS; i++) {
         if (state->alarm[i].enabled) {
+            // figure out if alarm is to go off in the next 24 h
+            if (state->alarm[i].day == ALARM_DAY_EACH_DAY || state->alarm[i].day == ALARM_DAY_ONE_TIME) {
             active_alarms = true;
             break;
+            } else {
+                if (now == NULL) {
+                    *now = watch_rtc_get_date_time();
+                    weekday_idx = _get_weekday_idx(*now);
+                    now_minutes_of_day = now->unit.hour * 60 + now->unit.minute;
+                }
+                alarm_minutes_of_day = state->alarm[i].hour * 60 + state->alarm[i].minute;
+                // no more shortcuts: check days and times for all possible cases...
+                if ((state->alarm[i].day == weekday_idx && alarm_minutes_of_day >= now_minutes_of_day)
+                    || ((weekday_idx + 1) % 7 == state->alarm[i].day && alarm_minutes_of_day <= now_minutes_of_day) 
+                    || (state->alarm[i].day == ALARM_DAY_WORKDAY && (weekday_idx < 4
+                        || (weekday_idx = 5 && alarm_minutes_of_day >= now_minutes_of_day)
+                        || (weekday_idx = 6 && alarm_minutes_of_day <= now_minutes_of_day))) 
+                    || (state->alarm[i].day == ALARM_DAY_WEEKEND && (weekday_idx == 5 
+                        || (weekday_idx = 6 && alarm_minutes_of_day >= now_minutes_of_day)
+                        || (weekday_idx = 4 && alarm_minutes_of_day <= now_minutes_of_day)))) {
+                    active_alarms = true;
+                    break;
+                }
+            }
         }
     }
     settings->bit.alarm_enabled = active_alarms;
@@ -202,6 +236,7 @@ void alarm_face_setup(movement_settings_t *settings, uint8_t watch_face_index, v
             state->alarm[i].pitch = 1;
         }
         state->alarm_handled_minute = -1;
+        _wait_ticks = -1;
     }
 }
 
@@ -218,6 +253,7 @@ void alarm_face_resign(movement_settings_t *settings, void *context) {
     watch_set_led_off();
     watch_store_backup_data(settings->reg, 0);
     state->alarm_quick_ticks = false;
+    _wait_ticks = -1;
     movement_request_tick_frequency(1);
 }
 
@@ -252,6 +288,8 @@ bool alarm_face_wants_background_task(movement_settings_t *settings, void *conte
         }
     }
     state->alarm_handled_minute = -1;
+    // update the movement's alarm indicator five times an hour
+    if (now.unit.minute % 12 == 0) _alarm_update_alarm_enabled(settings, state);
     return false;
 }
 
@@ -268,7 +306,20 @@ bool alarm_face_loop(movement_event_t event, movement_settings_t *settings, void
             } else if (state->setting_state == alarm_setting_idx_minute) {
                         state->alarm[state->alarm_idx].minute = (state->alarm[state->alarm_idx].minute + 1) % 60;
             } else _abort_quick_ticks(state);
-        } else if (!state->is_setting) break; // no need to do anything when we are not in settings mode and no quick ticks are running
+        } else if (!state->is_setting) {
+            if (_wait_ticks >= 0 && _wait_ticks <= INT8_MAX) _wait_ticks++;
+            if (_wait_ticks == 2) {
+                // extra long press of alarm button
+                _wait_ticks = -1;
+                if (state->alarm_idx) {
+                    // revert change of enabled flag and show it briefly
+                    state->alarm[state->alarm_idx].enabled ^= 1;
+                    _alarm_set_signal(state);
+                    delay_ms(275);
+                    state->alarm_idx = 0;
+                }
+            } else break; // no need to do anything when we are not in settings mode and no quick ticks are running
+        }
         // fall through
     case EVENT_ACTIVATE:
         _alarm_face_draw(settings, state, event.subsecond);
@@ -294,6 +345,8 @@ bool alarm_face_loop(movement_event_t event, movement_settings_t *settings, void
         break;
     case EVENT_ALARM_BUTTON_UP:
         if (!state->is_setting) {
+            // stop wait ticks counter
+            _wait_ticks = -1;
             // cycle through the alarms
             state->alarm_idx = (state->alarm_idx + 1) % (ALARM_ALARMS);
         } else {
@@ -341,6 +394,8 @@ bool alarm_face_loop(movement_event_t event, movement_settings_t *settings, void
         if (!state->is_setting) {
             // toggle the enabled flag for current alarm
             state->alarm[state->alarm_idx].enabled ^= 1;
+            // start wait ticks counter
+            _wait_ticks = 0;
         } else {
             // handle the long press settings behaviour
             switch (state->setting_state) {
@@ -364,7 +419,7 @@ bool alarm_face_loop(movement_event_t event, movement_settings_t *settings, void
         if (state->is_setting) {
             if (state->setting_state == alarm_setting_idx_hour || state->setting_state == alarm_setting_idx_minute)
                 _abort_quick_ticks(state);
-        }
+        } else _wait_ticks = -1;
         break;
     case EVENT_BACKGROUND_TASK:
         // play alarm


### PR DESCRIPTION
I fell like spamming PRs for my alarm complication face, but after wearing it on the wrist for quite a while now, I found that two things needed some improvement.

1. As discussed with @wryun on #96, the active alarm indicator currently shows that there is _any_ alarm set, no matter the time or day. If you are working with alarms that fire off on specific days, this is not particularly useful. In these cases, it would be more helpful to see if there are any alarms set for an upcoming time period.
2. A minor UI issue: if you happen to (short) press the alarm button in normal mode, you are doomed to cycle through all 16 alarms to get back to where you were. A shortcut to jump back to the first alarm slot would be nice.

This PR fixes both issues:

On the simple clock watch face the alarm indicator is only shown, when there is an alarm active within the next 24 h set. (Give or take - this is only updated every 12 minutes to save battery power.)

If you hold the alarm button for more than 2 secs in normal mode, you are taken back to alarm slot no. 1. (Regular long press still toggles the enabled flag for an alarm.)

What else? I updated the comments to reflect the latest changes.