### PR TITLE
Separate emscripten build directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         run: emmake make
         working-directory: 'movement/make'
       - name: Archive simulator build
-        working-directory: 'movement/make/build'
+        working-directory: 'movement/make/build-sim'
         run: |
           cp watch.html index.html
           tar -czf simulator.tar.gz index.html watch.wasm watch.js
@@ -52,4 +52,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: simulator.tar.gz
-          path: movement/make/build/simulator.tar.gz
+          path: movement/make/build-sim/simulator.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/build/
+**/build-sim/
 *.b#*
 *.bin
 *.d

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You may want to test out changes in the emulator first. To do this, you'll need 
 ```
 cd movement/make
 emmake make
-python3 -m http.server 8000 -d build
+python3 -m http.server -d build-sim
 ```
 
 Finally, visit [watch.html](http://localhost:8000/watch.html) to see your work.

--- a/make.mk
+++ b/make.mk
@@ -1,5 +1,9 @@
 ##############################################################################
+ifndef EMSCRIPTEN
 BUILD = ./build
+else
+BUILD = ./build-sim
+endif
 BIN = watch
 
 ifndef BOARD

--- a/movement/make/make_alternate_fw.sh
+++ b/movement/make/make_alternate_fw.sh
@@ -28,9 +28,9 @@ do
     make clean
     emmake make FIRMWARE=$VARIANT
     mkdir "$sim_dir/$variant/"
-    mv "build/watch.wasm" "$sim_dir/$variant/"
-    mv "build/watch.js" "$sim_dir/$variant/"
-    mv "build/watch.html" "$sim_dir/$variant/index.html"
+    mv "build-sim/watch.wasm" "$sim_dir/$variant/"
+    mv "build-sim/watch.js" "$sim_dir/$variant/"
+    mv "build-sim/watch.html" "$sim_dir/$variant/index.html"
 done
 
 echo "Done."


### PR DESCRIPTION
This avoids the need to 'make clean' before you do a simulator build (or vice-versa).