### PR TITLE
Set bell indicator on reactivating countdown/tomato faces

### DIFF
--- a/movement/watch_faces/complication/countdown_face.c
+++ b/movement/watch_faces/complication/countdown_face.c
@@ -132,6 +132,7 @@ void countdown_face_activate(movement_settings_t *settings, void *context) {
     if(state->mode == cd_running) {
         watch_date_time now = watch_rtc_get_date_time();
         state->now_ts = watch_utility_date_time_to_unix_time(now, get_tz_offset(settings));
+        watch_set_indicator(WATCH_INDICATOR_BELL);
     }
 }
 

--- a/movement/watch_faces/complication/tomato_face.c
+++ b/movement/watch_faces/complication/tomato_face.c
@@ -124,6 +124,7 @@ void tomato_face_activate(movement_settings_t *settings, void *context) {
     if (state->mode == tomato_run) {
         watch_date_time now = watch_rtc_get_date_time();
         state->now_ts = watch_utility_date_time_to_unix_time(now, get_tz_offset(settings));
+        watch_set_indicator(WATCH_INDICATOR_BELL);
     }
     watch_set_colon();
 }


### PR DESCRIPTION
If you moved away and back to these faces, you'd lose the indicator. Not that the indicator here seems very valuable, since it's not displayed on simple_clock_face, but at least this makes things more consistent.