### PR TITLE
fixes #161: sets both CCBUF and PERFBUF for correct buzzer tone

### DIFF
--- a/watch-library/hardware/watch/watch_buzzer.c
+++ b/watch-library/hardware/watch/watch_buzzer.c
@@ -31,6 +31,7 @@
 }
 inline void watch_set_buzzer_period(uint32_t period) {
     hri_tcc_write_PERBUF_reg(TCC0, period);
+    hri_tcc_write_CCBUF_reg(TCC0, WATCH_BUZZER_TCC_CHANNEL, period / 2);
 }
 
 void watch_disable_buzzer(void) {
@@ -51,8 +52,7 @@ void watch_buzzer_play_note(BuzzerNote note, uint16_t duration_ms) {
     if (note == BUZZER_NOTE_REST) {
         watch_set_buzzer_off();
     } else {
-        hri_tcc_write_PERBUF_reg(TCC0, NotePeriods[note]);
-        hri_tcc_write_CCBUF_reg(TCC0, WATCH_BUZZER_TCC_CHANNEL, NotePeriods[note] / 2);
+        watch_set_buzzer_period(NotePeriods[note]);
         watch_set_buzzer_on();
     }
     delay_ms(duration_ms);


### PR DESCRIPTION
Fixes issue 161 where call to `watch_set_buzzer_period()` resulted in erratic buzzer behavior. Also changed `watch_buzzer_play_note()` to call `watch_set_buzzer_period()` instead of duplicating low-level calls.