### PR TITLE
Add Tachymeter face

### DIFF
--- a/movement/make/Makefile
+++ b/movement/make/Makefile
@@ -74,6 +74,7 @@ SRCS += \
   ../watch_faces/demo/frequency_correction_face.c \
   ../watch_faces/complication/alarm_face.c \
   ../watch_faces/complication/ratemeter_face.c \
+  ../watch_faces/complication/tachymeter_face.c \
 # New watch faces go above this line.
 
 # Leave this line at the bottom of the file; it has all the targets for making your project.

--- a/movement/movement_faces.h
+++ b/movement/movement_faces.h
@@ -59,6 +59,7 @@
 #include "alarm_face.h"
 #include "ratemeter_face.h"
 #include "weeknumber_clock_face.h"
+#include "tachymeter_face.h"
 // New includes go above this line.
 
 #endif // MOVEMENT_FACES_H_

--- a/movement/watch_faces/complication/tachymeter_face.c
+++ b/movement/watch_faces/complication/tachymeter_face.c
@@ -163,10 +163,10 @@ bool tachymeter_face_loop(movement_event_t event, movement_settings_t *settings,
             }
             break;
         case EVENT_ALARM_BUTTON_UP:
-            if (settings->bit.button_should_sound && !state->editing) {
-                watch_buzzer_play_note(BUZZER_NOTE_C8, 50);
-            }
-            if (!state->running){
+            if (!state->running && state->total_time == 0){
+                if (settings->bit.button_should_sound && !state->editing) {
+                    watch_buzzer_play_note(BUZZER_NOTE_C8, 50);
+                }
                 if (!state->editing) {
                     // Start running
                     state->running = true;
@@ -196,7 +196,10 @@ bool tachymeter_face_loop(movement_event_t event, movement_settings_t *settings,
                             break;
                     }
                 }
-            } else {
+            } else if (state->running) {
+                if (settings->bit.button_should_sound && !state->editing) {
+                    watch_buzzer_play_note(BUZZER_NOTE_C8, 50);
+                }
                 // Stop running
                 state->running = false;
                 watch_date_time now = watch_rtc_get_date_time();
@@ -209,7 +212,7 @@ bool tachymeter_face_loop(movement_event_t event, movement_settings_t *settings,
             }
             break;
         case EVENT_ALARM_LONG_PRESS:
-            if (!state->running){
+            if (!state->running && state->total_time == 0){
                 if (!state->editing) {
                     // Enter editing
                     state->editing = true;

--- a/movement/watch_faces/complication/tachymeter_face.c
+++ b/movement/watch_faces/complication/tachymeter_face.c
@@ -39,6 +39,8 @@ static uint32_t _distance_from_struct(distance_digits_t dist_digits) {
 }
 
 void tachymeter_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {
+    (void)settings;
+    (void)watch_face_index;
     if (*context_ptr == NULL) {
         *context_ptr = malloc(sizeof(tachymeter_state_t));
         memset(*context_ptr, 0, sizeof(tachymeter_state_t));
@@ -50,7 +52,8 @@ void tachymeter_face_setup(movement_settings_t *settings, uint8_t watch_face_ind
 }
 
 void tachymeter_face_activate(movement_settings_t *settings, void *context) {
-    tachymeter_state_t *state = (tachymeter_state_t *)context;
+    (void)settings;
+    (void)context;
     movement_request_tick_frequency(4); // 4Hz
 }
 
@@ -74,7 +77,7 @@ static void _tachymeter_face_distance_lcd(movement_event_t event, tachymeter_sta
 }
 
 static void _tachymeter_face_totals_lcd(tachymeter_state_t *state, bool show_time){
-    char buf[11];
+    char buf[15];
     if (!show_time){
         sprintf(buf, "TC %c%6lu", 'h',  state->total_speed);
     } else {
@@ -89,6 +92,7 @@ static void _tachymeter_face_totals_lcd(tachymeter_state_t *state, bool show_tim
 }
 
 bool tachymeter_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
+    (void)settings;
     tachymeter_state_t *state = (tachymeter_state_t *)context;
     switch (event.event_type) {
         case EVENT_ACTIVATE:
@@ -258,5 +262,7 @@ bool tachymeter_face_loop(movement_event_t event, movement_settings_t *settings,
 }
 
 void tachymeter_face_resign(movement_settings_t *settings, void *context) {
+    (void)settings;
+    (void)context;
     // handle any cleanup before your watch face goes off-screen.
 }

--- a/movement/watch_faces/complication/tachymeter_face.c
+++ b/movement/watch_faces/complication/tachymeter_face.c
@@ -155,9 +155,19 @@ bool tachymeter_face_loop(movement_event_t event, movement_settings_t *settings,
             break;
         case EVENT_ALARM_LONG_PRESS:
             if (!state->running){
-                state->editing = true;
+                // Enter / exit distance editing mode
+                if (settings->bit.button_should_sound) {
+                    if (!state->editing) {
+                        watch_buzzer_play_note(BUZZER_NOTE_C7, 80);
+                        watch_buzzer_play_note(BUZZER_NOTE_C8, 80);
+                        //movement_illuminate_led();
+                    } else {
+                        watch_buzzer_play_note(BUZZER_NOTE_C8, 80);
+                        watch_buzzer_play_note(BUZZER_NOTE_C7, 80);
+                    }
+                }
+                state->editing = !state->editing;
             }
-
             break;
         case EVENT_TIMEOUT:
             // Your watch face will receive this event after a period of inactivity. If it makes sense to resign,

--- a/movement/watch_faces/complication/tachymeter_face.c
+++ b/movement/watch_faces/complication/tachymeter_face.c
@@ -58,7 +58,7 @@ static void _tachymeter_face_distance_lcd(movement_event_t event, tachymeter_sta
     char buf[11];
     // Distance from digits
     state->distance = _distance_from_struct(state->dist_digits);
-    sprintf(buf, "TC %c%06d", 'd',  state->distance);
+    sprintf(buf, "TC %c%06lu", 'd',  state->distance);
     // Blinking display when editing
     if (state->editing) {
         // Blink 'd'
@@ -76,9 +76,9 @@ static void _tachymeter_face_distance_lcd(movement_event_t event, tachymeter_sta
 static void _tachymeter_face_totals_lcd(tachymeter_state_t *state, bool show_time){
     char buf[11];
     if (!show_time){
-        sprintf(buf, "TC %c%6d", 'H',  state->total_speed);
+        sprintf(buf, "TC %c%6lu", 'H',  state->total_speed);
     } else {
-        sprintf(buf, "TC %c%6d", 't',  state->total_time);
+        sprintf(buf, "TC %c%6lu", 't',  state->total_time);
     }
     watch_display_string(buf, 0);
     if (!show_time){

--- a/movement/watch_faces/complication/tachymeter_face.c
+++ b/movement/watch_faces/complication/tachymeter_face.c
@@ -117,16 +117,19 @@ bool tachymeter_face_loop(movement_event_t event, movement_settings_t *settings,
             movement_move_to_next_face();
             break;
         case EVENT_LIGHT_BUTTON_UP:
-            if (!state->running){
+            if (state->editing){
+                // Edit distance
+                state->distance = (state->distance + 1);
+            } else {
+                movement_illuminate_led();
+            }
+            break;
+        case EVENT_LIGHT_LONG_PRESS:
+            if (!state->running && !state->editing){
                 // Clear results
-                if (!state->editing){
-                    state->total_seconds = 0;
-                    state->total_speed = 0;
-                    _tachymeter_face_distance_lcd(state);
-                } else {
-                    // Edit distance
-                    state->distance = (state->distance + 1);
-                }
+                state->total_seconds = 0;
+                state->total_speed = 0;
+                _tachymeter_face_distance_lcd(state);
             }
             break;
         case EVENT_ALARM_BUTTON_UP:

--- a/movement/watch_faces/complication/tachymeter_face.c
+++ b/movement/watch_faces/complication/tachymeter_face.c
@@ -93,9 +93,7 @@ bool tachymeter_face_loop(movement_event_t event, movement_settings_t *settings,
     switch (event.event_type) {
         case EVENT_ACTIVATE:
             // Show distance in UI
-            if (!state->running){
-                _tachymeter_face_distance_lcd(event, state);
-            }
+            _tachymeter_face_distance_lcd(event, state);
             break;
         case EVENT_TICK:
             // Show editing distance (blinking)

--- a/movement/watch_faces/complication/tachymeter_face.c
+++ b/movement/watch_faces/complication/tachymeter_face.c
@@ -58,7 +58,7 @@ static void _tachymeter_face_distance_lcd(movement_event_t event, tachymeter_sta
     char buf[11];
     // Distance from digits
     state->distance = _distance_from_struct(state->dist_digits);
-    sprintf(buf, "TC %c%06lu", 'd',  state->distance);
+    sprintf(buf, "TC %c%06lu", state->running ? ' ' : 'd',  state->distance);
     // Blinking display when editing
     if (state->editing) {
         // Blink 'd'
@@ -93,7 +93,9 @@ bool tachymeter_face_loop(movement_event_t event, movement_settings_t *settings,
     switch (event.event_type) {
         case EVENT_ACTIVATE:
             // Show distance in UI
-            _tachymeter_face_distance_lcd(event, state);
+            if (state->total_time == 0) {
+                _tachymeter_face_distance_lcd(event, state);
+            }
             break;
         case EVENT_TICK:
             // Show editing distance (blinking)

--- a/movement/watch_faces/complication/tachymeter_face.c
+++ b/movement/watch_faces/complication/tachymeter_face.c
@@ -76,7 +76,7 @@ static void _tachymeter_face_distance_lcd(movement_event_t event, tachymeter_sta
 static void _tachymeter_face_totals_lcd(tachymeter_state_t *state, bool show_time){
     char buf[11];
     if (!show_time){
-        sprintf(buf, "TC %c%6lu", 'H',  state->total_speed);
+        sprintf(buf, "TC %c%6lu", 'h',  state->total_speed);
     } else {
         sprintf(buf, "TC %c%6lu", 't',  state->total_time);
     }

--- a/movement/watch_faces/complication/tachymeter_face.c
+++ b/movement/watch_faces/complication/tachymeter_face.c
@@ -28,6 +28,7 @@
 #include "watch_utility.h"
 
 static uint32_t _distance_from_struct(distance_digits_t dist_digits) {
+    // distance from digitwise distance
     uint32_t retval = (dist_digits.thousands * 100000 +
                        dist_digits.hundreds  *  10000 +
                        dist_digits.tens      *   1000 +
@@ -55,7 +56,7 @@ void tachymeter_face_activate(movement_settings_t *settings, void *context) {
 
 static void _tachymeter_face_distance_lcd(movement_event_t event, tachymeter_state_t *state){
     char buf[11];
-    // distance from digits
+    // Distance from digits
     state->distance = _distance_from_struct(state->dist_digits);
     sprintf(buf, "TC %c%06d", 'd',  state->distance);
     // Blinking display when editing
@@ -81,6 +82,7 @@ static void _tachymeter_face_totals_lcd(tachymeter_state_t *state, bool show_tim
     }
     watch_display_string(buf, 0);
     if (!show_time){
+        // Show '/' besides 'H'
         watch_set_pixel(0, 9);
         watch_set_pixel(0, 10);
     }
@@ -88,16 +90,15 @@ static void _tachymeter_face_totals_lcd(tachymeter_state_t *state, bool show_tim
 
 bool tachymeter_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
     tachymeter_state_t *state = (tachymeter_state_t *)context;
-
     switch (event.event_type) {
         case EVENT_ACTIVATE:
-            // Show last distance in UI
+            // Show distance in UI
             if (!state->running){
                 _tachymeter_face_distance_lcd(event, state);
             }
             break;
         case EVENT_TICK:
-            // Editing should flash 'd'
+            // Show editing distance (blinking)
             if (state->editing) {
                 _tachymeter_face_distance_lcd(event, state);
             }
@@ -248,7 +249,6 @@ bool tachymeter_face_loop(movement_event_t event, movement_settings_t *settings,
         default:
             break;
     }
-
     // return true if the watch can enter standby mode. If you are PWM'ing an LED or buzzing the buzzer here,
     // you should return false since the PWM driver does not operate in standby mode.
     return true;
@@ -257,4 +257,3 @@ bool tachymeter_face_loop(movement_event_t event, movement_settings_t *settings,
 void tachymeter_face_resign(movement_settings_t *settings, void *context) {
     // handle any cleanup before your watch face goes off-screen.
 }
-

--- a/movement/watch_faces/complication/tachymeter_face.c
+++ b/movement/watch_faces/complication/tachymeter_face.c
@@ -1,0 +1,93 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 <#author_name#>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "tachymeter_face.h"
+
+void tachymeter_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {
+    (void) settings;
+    if (*context_ptr == NULL) {
+        *context_ptr = malloc(sizeof(tachymeter_state_t));
+        memset(*context_ptr, 0, sizeof(tachymeter_state_t));
+        // Do any one-time tasks in here; the inside of this conditional happens only at boot.
+    }
+    // Do any pin or peripheral setup here; this will be called whenever the watch wakes from deep sleep.
+}
+
+void tachymeter_face_activate(movement_settings_t *settings, void *context) {
+    (void) settings;
+    tachymeter_state_t *state = (tachymeter_state_t *)context;
+
+    // Handle any tasks related to your watch face coming on screen.
+}
+
+bool tachymeter_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
+    tachymeter_state_t *state = (tachymeter_state_t *)context;
+
+    switch (event.event_type) {
+        case EVENT_ACTIVATE:
+            // Show your initial UI here.
+            break;
+        case EVENT_TICK:
+            // If needed, update your display here.
+            break;
+        case EVENT_MODE_BUTTON_UP:
+            // You shouldn't need to change this case; Mode almost always moves to the next watch face.
+            movement_move_to_next_face();
+            break;
+        case EVENT_LIGHT_BUTTON_UP:
+            // If you have other uses for the Light button, you can opt not to illuminate the LED for this event.
+            movement_illuminate_led();
+            break;
+        case EVENT_ALARM_BUTTON_UP:
+            // Just in case you have need for another button.
+            break;
+        case EVENT_TIMEOUT:
+            // Your watch face will receive this event after a period of inactivity. If it makes sense to resign,
+            // you may uncomment this line to move back to the first watch face in the list:
+            // movement_move_to_face(0);
+            break;
+        case EVENT_LOW_ENERGY_UPDATE:
+            // If you did not resign in EVENT_TIMEOUT, you can use this event to update the display once a minute.
+            // Avoid displaying fast-updating values like seconds, since the display won't update again for 60 seconds.
+            // You should also consider starting the tick animation, to show the wearer that this is sleep mode:
+            // watch_start_tick_animation(500);
+            break;
+        default:
+            break;
+    }
+
+    // return true if the watch can enter standby mode. If you are PWM'ing an LED or buzzing the buzzer here,
+    // you should return false since the PWM driver does not operate in standby mode.
+    return true;
+}
+
+void tachymeter_face_resign(movement_settings_t *settings, void *context) {
+    (void) settings;
+    (void) context;
+
+    // handle any cleanup before your watch face goes off-screen.
+}
+

--- a/movement/watch_faces/complication/tachymeter_face.c
+++ b/movement/watch_faces/complication/tachymeter_face.c
@@ -38,8 +38,7 @@ void tachymeter_face_setup(movement_settings_t *settings, uint8_t watch_face_ind
 
 void tachymeter_face_activate(movement_settings_t *settings, void *context) {
     tachymeter_state_t *state = (tachymeter_state_t *)context;
-    // TODO improve tick frequency for Speed/Time display
-    movement_request_tick_frequency(2);
+    movement_request_tick_frequency(4);
 }
 
 static void _tachymeter_face_distance_lcd(tachymeter_state_t *state){
@@ -56,6 +55,10 @@ static void _tachymeter_face_totals_lcd(tachymeter_state_t *state, bool show_tim
         sprintf(buf, "TC %c%6d", 't',  state->total_seconds);
     }
     watch_display_string(buf, 0);
+    if (!show_time){
+        watch_set_pixel(0, 9);
+        watch_set_pixel(0, 10);
+    }
 }
 
 bool tachymeter_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
@@ -70,19 +73,35 @@ bool tachymeter_face_loop(movement_event_t event, movement_settings_t *settings,
             break;
         case EVENT_TICK:
             if (!state->running && state->total_seconds != 0) {
-                // Display results if finished and not cleared
-                if (event.subsecond % 2 == 0) {
-                    _tachymeter_face_totals_lcd(state, true);
+            // Display results if finished and not cleared
+                if (event.subsecond < 2) {
+                     _tachymeter_face_totals_lcd(state, true);
                 } else {
-                    _tachymeter_face_totals_lcd(state, false);
+                     _tachymeter_face_totals_lcd(state, false);
                 }
             } else if (state->running){
-                // TODO Improve UI when tachymeter is running
-                if (event.subsecond % 2 == 0) {
-                    watch_display_string("1 ", 2);
-                } else {
-                    watch_display_string(" 1", 2);
+                watch_display_string("  ", 2);
+                switch (state->animation_state) {
+                    case 0:
+                        watch_set_pixel(0, 7);
+                        break;
+                    case 1:
+                        watch_set_pixel(1, 7);
+                        break;
+                    case 2:
+                        watch_set_pixel(2, 7);
+                        break;
+                    case 3:
+                        watch_set_pixel(2, 6);
+                        break;
+                    case 4:
+                        watch_set_pixel(2, 8);
+                        break;
+                    case 5:
+                        watch_set_pixel(0, 8);
+                        break;
                 }
+                state->animation_state = (state->animation_state + 1) % 6;
             }
             break;
         case EVENT_MODE_BUTTON_UP:

--- a/movement/watch_faces/complication/tachymeter_face.h
+++ b/movement/watch_faces/complication/tachymeter_face.h
@@ -29,6 +29,7 @@
 
 typedef struct {
     bool running;               // tachymeter status
+    bool editing;               // editing distance
     uint8_t animation_state;    // running animation state
     watch_date_time start_time; // start_time
     uint32_t distance;          // distance

--- a/movement/watch_faces/complication/tachymeter_face.h
+++ b/movement/watch_faces/complication/tachymeter_face.h
@@ -29,6 +29,7 @@
 
 typedef struct {
     bool running;               // tachymeter status
+    uint8_t animation_state;    // running animation state
     watch_date_time start_time; // start_time
     uint32_t distance;          // distance
     uint32_t total_seconds;     // total_seconds = now - start_time

--- a/movement/watch_faces/complication/tachymeter_face.h
+++ b/movement/watch_faces/complication/tachymeter_face.h
@@ -28,13 +28,24 @@
 #include "movement.h"
 
 typedef struct {
-    bool running;               // tachymeter status
-    bool editing;               // editing distance
-    uint8_t animation_state;    // running animation state
-    watch_date_time start_time; // start_time
-    uint32_t distance;          // distance
-    uint32_t total_seconds;     // total_seconds = now - start_time
-    uint32_t total_speed;       // 3600 * distance / total_time
+    uint8_t thousands: 4;   // 0-9 (must wrap at 10)
+    uint8_t hundreds: 4;    // 0-9 (must wrap at 10)
+    uint8_t tens: 4;        // 0-9 (must wrap at 10)
+    uint8_t ones: 4;        // 0-9 (must wrap at 10)
+    uint8_t tenths: 4;      // 0-9 (must wrap at 10)
+    uint8_t hundredths: 4;  // 0-9 (must wrap at 10)
+} distance_digits_t;
+
+typedef struct {
+    bool running;                  // tachymeter status
+    bool editing;                  // editing distance
+    uint8_t active_digit;          // active digit at editing distance
+    uint8_t animation_state;       // running animation state
+    watch_date_time start_time;    // start_time
+    distance_digits_t dist_digits; // distance digitwise
+    uint32_t distance;             // distance
+    uint32_t total_seconds;        // total_seconds = now - start_time
+    uint32_t total_speed;          // 3600 * distance / total_time
 } tachymeter_state_t;
 
 void tachymeter_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr);

--- a/movement/watch_faces/complication/tachymeter_face.h
+++ b/movement/watch_faces/complication/tachymeter_face.h
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022 <#author_name#>
+ * Copyright (c) 2022 Raymundo Cassani
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,8 +28,11 @@
 #include "movement.h"
 
 typedef struct {
-    // Anything you need to keep track of, put it here!
-    uint8_t unused;
+    bool running;               // tachymeter status
+    watch_date_time start_time; // start_time
+    uint32_t distance;          // distance
+    uint32_t total_seconds;     // total_seconds = now - start_time
+    uint32_t total_speed;       // 3600 * distance / total_time
 } tachymeter_state_t;
 
 void tachymeter_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr);

--- a/movement/watch_faces/complication/tachymeter_face.h
+++ b/movement/watch_faces/complication/tachymeter_face.h
@@ -1,0 +1,49 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 <#author_name#>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef TACHYMETER_FACE_H_
+#define TACHYMETER_FACE_H_
+
+#include "movement.h"
+
+typedef struct {
+    // Anything you need to keep track of, put it here!
+    uint8_t unused;
+} tachymeter_state_t;
+
+void tachymeter_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr);
+void tachymeter_face_activate(movement_settings_t *settings, void *context);
+bool tachymeter_face_loop(movement_event_t event, movement_settings_t *settings, void *context);
+void tachymeter_face_resign(movement_settings_t *settings, void *context);
+
+#define tachymeter_face ((const watch_face_t){ \
+    tachymeter_face_setup, \
+    tachymeter_face_activate, \
+    tachymeter_face_loop, \
+    tachymeter_face_resign, \
+    NULL, \
+})
+
+#endif // TACHYMETER_FACE_H_
+

--- a/movement/watch_faces/complication/tachymeter_face.h
+++ b/movement/watch_faces/complication/tachymeter_face.h
@@ -41,11 +41,12 @@ typedef struct {
     bool editing;                  // editing distance
     uint8_t active_digit;          // active digit at editing distance
     uint8_t animation_state;       // running animation state
-    watch_date_time start_time;    // start_time
+    watch_date_time start_seconds; // start_seconds
+    int8_t start_subsecond;        // start_subsecond count (each count = 250 ms)
     distance_digits_t dist_digits; // distance digitwise
     uint32_t distance;             // distance
-    uint32_t total_seconds;        // total_seconds = now - start_time
-    uint32_t total_speed;          // 3600 * distance / total_time
+    uint32_t total_time;           // total_time = now - start_time (in cs)
+    uint32_t total_speed;          // 3600 * 100 * distance / total_time
 } tachymeter_state_t;
 
 void tachymeter_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr);


### PR DESCRIPTION
The Tachymeter complication emulates the [tachymeter](https://en.wikipedia.org/wiki/Tachymeter_(watch)) function often present in watches, that computes the average speed in [units per hour] for a given distance given in [units].

# Use case
1. User sets the distance
2. User starts the tachymeter when the trip begins
3. User stops the tachymeter when the trip ends
4. The watch presents the average speed and trip duration in seconds

## Use
1. Go to tachymeter face, `TC` is shown in the Weekday Digits 
2. A steady `d` in the Day Digits indicates the distance to be used. To edit the distance:
    1. Long-press the Alarm button, the distance edition page (`d` will blink)
    2. Use the Light button to change the editing (blinking) digit, and press Alarm to increase its value
    4. Once done, long-press the Alarm button to exit the distance edition page
3. Press the Alarm button to start the tachymeter. A running animation will appear in the Day Digits
4. Press the Alarm button to stop the tachymeter
6. The average speed and total time information will alternate. The average speed will be shown alongside `/h` in the Day Digits; and the total time will be shown alongside `t` in the Day Digits.
7. Long press the Light button to return to the distance `d` page, and restart the tachymeter from there.
    * Long-press the light button in the steady distance page to reset the distance to 1.00

## Pending design points

*. `movement_request_tick_frequency(4) is used to obtain a 4Hz ticking, thus having a time resolution of 250 ms. Not sure if using `event.subsecond` is the proper way to get the fractions of second for the start and final times.

*. For distance and average speed, the Second Digits (position 8 and 9) can be seen as decimals, thus possible to show distances as short as 0.01 km (or miles) and speeds as low as 0.01 km/h (or mph). However, if the same idea is used for the total time (showing hundredths), this limits the display to 9999.99 seconds (~2h:45m).