### PR TITLE
Add documentation to x_face.h template to encourage more docs

### DIFF
--- a/movement/template/template.h
+++ b/movement/template/template.h
@@ -27,6 +27,13 @@
 
 #include "movement.h"
 
+/*
+ * A DESCRIPTION OF YOUR WATCH FACE
+ *
+ * and a description of how use it
+ *
+ */
+
 typedef struct {
     // Anything you need to keep track of, put it here!
     uint8_t unused;


### PR DESCRIPTION
Hi!

I love my new sensor watch! I was very excited to build my firmware with the watch faces of my choosing, and was _**delighted**_ to find that many had been added beyond what's listed in the online docs.

That said, I had a hard time knowing what all of them were at a glance, as the names were not always fully descriptive.

I appreciated the description I saw in the tally_face, and I saw that author too was [helped by a description](https://github.com/joeycastillo/Sensor-Watch/pull/160#issuecomment-1374906736) in the source code:

> I saw counter_face and assumed it was a tally counter, not a lap counter for jogging. I was perplexed by the functionality of counter_face until I saw the description in the source header



Perhaps adding this to the template will:
- Encourage authors to document their faces
- Make it easy for anyone to more quickly know what faces do


😄 