### PR TITLE
tarot: fix compiler warning

### DIFF
--- a/movement/watch_faces/complication/tarot_face.c
+++ b/movement/watch_faces/complication/tarot_face.c
@@ -75,7 +75,7 @@ static void init_deck(tarot_state_t *state) {
 }
 
 static void tarot_display(tarot_state_t *state) {
-    char buf[9];
+    char buf[10];
     uint8_t card;
     bool flipped;
 


### PR DESCRIPTION
didn't catch this because I only tested in the simulator and emscripten didn't throw any warnings. lesson learned.