### PR TITLE
Minor enhancements for the countdown face

### DIFF
--- a/movement/watch_faces/complication/countdown_face.c
+++ b/movement/watch_faces/complication/countdown_face.c
@@ -1,6 +1,7 @@
 /*
  * MIT License
  *
+ * Copyright (c) 2023 Konrad Rieck
  * Copyright (c) 2022 Wesley Ellis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -30,6 +31,24 @@
 #include "watch.h"
 #include "watch_utility.h"
 
+/*
+    Slight extension of the original countdown face by Wesley Ellis.
+
+    - The countdown can be paused using the alarm button, similar to
+      the stopwatch face.
+
+    - The state of the countdown is indicated in the top right: 
+      "P" = pause, "S" = setting, " " = running
+
+    - The last entered countdown can be restored by long pressing the
+      light button in setting or waiting (pause) mode.
+
+    - The countdown can be reset to zero by long pressing the
+      alarm button in setting or waiting (pause) mode.
+
+    - Once the countdown reaches 0, it automatically switches back
+      to the last entered value and pauses.
+*/
 
 #define CD_SELECTIONS 3
 #define DEFAULT_MINUTES 3
@@ -37,6 +56,26 @@
 
 static inline int32_t get_tz_offset(movement_settings_t *settings) {
     return movement_timezone_offsets[settings->bit.time_zone] * 60;
+}
+
+static inline void store_countdown(countdown_state_t *state) {
+    /* Store set countdown time */
+    state->set_hours = state->hours;
+    state->set_minutes = state->minutes;
+    state->set_seconds = state->seconds;
+}
+
+static inline void load_countdown(countdown_state_t *state) {
+    /* Load set countdown time */
+    state->hours = state->set_hours;
+    state->minutes = state->set_minutes;
+    state->seconds = state->set_seconds;
+}
+
+static inline void reset_countdown(countdown_state_t *state) {
+    state->hours = 0;
+    state->minutes = 0;
+    state->seconds = 0;
 }
 
 static void start(countdown_state_t *state, movement_settings_t *settings) {
@@ -55,24 +94,22 @@ static void draw(countdown_state_t *state, uint8_t subsecond) {
 
     uint32_t delta;
     div_t result;
-    uint8_t hour, min, sec;
 
     switch (state->mode) {
         case cd_running:
             delta = state->target_ts - state->now_ts;
             result = div(delta, 60);
-            sec = result.rem;
+            state->seconds = result.rem;
             result = div(result.quot, 60);
-            hour = result.quot;
-            min = result.rem;
-
-            sprintf(buf, "CD  %2d%02d%02d", hour, min, sec);
+            state->hours = result.quot;
+            state->minutes = result.rem;
+            sprintf(buf, "CD  %2d%02d%02d", state->hours, state->minutes, state->seconds);
             break;
         case cd_waiting:
-            sprintf(buf, "CD  %2d%02d%02d", state->hours, state->minutes, state->seconds);
+            sprintf(buf, "CD P%2d%02d%02d", state->hours, state->minutes, state->seconds);
             break;
         case cd_setting:
-            sprintf(buf, "CD  %2d%02d%02d", state->hours, state->minutes, state->seconds);
+            sprintf(buf, "CD S%2d%02d%02d", state->hours, state->minutes, state->seconds);
             if (subsecond % 2) {
                 switch(state->selection) {
                     case 0:
@@ -93,7 +130,7 @@ static void draw(countdown_state_t *state, uint8_t subsecond) {
     watch_display_string(buf, 0);
 }
 
-static void reset(countdown_state_t *state) {
+static void pause(countdown_state_t *state) {
     state->mode = cd_waiting;
     movement_cancel_background_task();
     watch_clear_indicator(WATCH_INDICATOR_BELL);
@@ -101,7 +138,8 @@ static void reset(countdown_state_t *state) {
 
 static void ring(countdown_state_t *state) {
     movement_play_alarm();
-    reset(state);
+    load_countdown(state);
+    pause(state);
 }
 
 static void settings_increment(countdown_state_t *state) {
@@ -131,6 +169,7 @@ void countdown_face_setup(movement_settings_t *settings, uint8_t watch_face_inde
         countdown_state_t *state = (countdown_state_t *)*context_ptr;
         memset(*context_ptr, 0, sizeof(countdown_state_t));
         state->minutes = DEFAULT_MINUTES;
+        store_countdown(state);
     }
 }
 
@@ -177,6 +216,7 @@ bool countdown_face_loop(movement_event_t event, movement_settings_t *settings, 
                     if(state->selection >= CD_SELECTIONS) {
                         state->selection = 0;
                         state->mode = cd_waiting;
+                        store_countdown(state);
                         movement_request_tick_frequency(1);
                     }
                     break;
@@ -186,7 +226,7 @@ bool countdown_face_loop(movement_event_t event, movement_settings_t *settings, 
         case EVENT_ALARM_BUTTON_UP:
             switch(state->mode) {
                 case cd_running:
-                    reset(state);
+                    pause(state);
                     break;
                 case cd_waiting:
                     if (!(state->hours == 0 && state->minutes == 0 && state->seconds == 0)) {
@@ -203,13 +243,18 @@ bool countdown_face_loop(movement_event_t event, movement_settings_t *settings, 
         case EVENT_BACKGROUND_TASK:
             ring(state);
             break;
+        case EVENT_LIGHT_LONG_PRESS:
+            if (state->mode == cd_setting || state->mode == cd_waiting) {
+                load_countdown(state);
+                draw(state, event.subsecond);
+                break;
+            }
+            break;
         case EVENT_ALARM_LONG_PRESS:
-            if (state->mode == cd_setting) {
-                    state->hours = 0;
-                    state->minutes = 0;
-                    state->seconds = 0;
-                    draw(state, event.subsecond);
-                    break;
+            if (state->mode == cd_setting || state->mode == cd_waiting) {
+                reset_countdown(state);
+                draw(state, event.subsecond);
+                break;
             }
             break;
         case EVENT_TIMEOUT:
@@ -229,5 +274,6 @@ void countdown_face_resign(movement_settings_t *settings, void *context) {
     if (state->mode == cd_setting) {
         state->selection = 0;
         state->mode = cd_waiting;
+        store_countdown(state);
     }
 }

--- a/movement/watch_faces/complication/countdown_face.h
+++ b/movement/watch_faces/complication/countdown_face.h
@@ -51,6 +51,9 @@ typedef struct {
     uint8_t hours;
     uint8_t minutes;
     uint8_t seconds;
+    uint8_t set_hours;
+    uint8_t set_minutes;
+    uint8_t set_seconds;
     uint8_t selection;
     countdown_mode_t mode;
 } countdown_state_t;


### PR DESCRIPTION
First of all, I like to thank you all for this project. It is so much fun working with the watch and the firmware. While playing with the different faces, I noticed that the countdown face behaved slightly differently than expected. I think it should work similarly to the stopwatch and support _pausing_ as well as _resetting_ to the entered countdown value. Therefore, I wrote a few minor enhancements:

- The countdown can be paused using the alarm button, similar to the stopwatch face.

- The state of the countdown face is indicated in the top right: `P` = pause, `S` = setting, ` ` = running

- The last entered countdown can be restored by long pressing the light button in setting or waiting (pause) mode.

- The countdown can be reset to zero by long pressing the alarm button in setting or waiting (pause) mode.

- Once the countdown reaches 0, it automatically switches back to the last entered value and pauses.

I'm not sure if this is a useful extension, but I thought I'd prepare a pull request anyway ;-)