### PR TITLE
Restore long press on MODE to return to first watch face by adding a handler for unhandled events

### DIFF
--- a/movement/movement.c
+++ b/movement/movement.c
@@ -218,6 +218,26 @@ void movement_illuminate_led(void) {
     }
 }
 
+bool movement_default_loop_handler(movement_event_t event, movement_settings_t *settings) {
+    (void)settings;
+
+    switch (event.event_type) {
+        case EVENT_MODE_BUTTON_UP:
+            movement_move_to_next_face();
+            break;
+        case EVENT_LIGHT_BUTTON_DOWN:
+            movement_illuminate_led();
+            break;
+        case EVENT_MODE_LONG_PRESS:
+            movement_move_to_face(0);
+            break;
+        default:
+            break;
+    }
+
+    return true;
+}
+
 void movement_move_to_face(uint8_t watch_face_index) {
     movement_state.watch_face_changed = true;
     movement_state.next_watch_face = watch_face_index;

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -229,7 +229,11 @@ bool movement_default_loop_handler(movement_event_t event, movement_settings_t *
             movement_illuminate_led();
             break;
         case EVENT_MODE_LONG_PRESS:
-            movement_move_to_face(0);
+            if (MOVEMENT_SECONDARY_FACE_INDEX && movement_state.current_watch_face == 0) {
+                movement_move_to_face(MOVEMENT_SECONDARY_FACE_INDEX);
+            } else {
+                movement_move_to_face(0);
+            }
             break;
         default:
             break;
@@ -468,20 +472,6 @@ bool app_loop(void) {
     if (event.event_type) {
         event.subsecond = movement_state.subsecond;
         can_sleep = watch_faces[movement_state.current_watch_face].loop(event, &movement_state.settings, watch_face_contexts[movement_state.current_watch_face]);
-
-        // Long-pressing MODE brings one back to the first face, provided that the watch face hasn't decided to send them elsewhere
-        // (and we're not currently on the first face). If we're currently on the first face, a long press
-        // of MODE sends us to the secondary faces (if defined).
-        // Note that it's the face's responsibility to provide some way to get to the next face, so if EVENT_MODE_BUTTON_* is
-        // used for face functionality EVENT_MODE_LONG_PRESS should probably be handled and next_face() triggered in the face
-        // (which would effectively disable the normal 'long press to face 0' behaviour).
-        if (event.event_type == EVENT_MODE_LONG_PRESS 
-            && !movement_state.watch_face_changed) {
-            if (MOVEMENT_SECONDARY_FACE_INDEX && movement_state.current_watch_face == 0) {
-                movement_move_to_face(MOVEMENT_SECONDARY_FACE_INDEX);
-            }
-        }
-        event.event_type = EVENT_NONE;
     }
 
     // if we have timed out of our timeout countdown, give the app a hint that they can resign.

--- a/movement/movement.h
+++ b/movement/movement.h
@@ -285,6 +285,9 @@ typedef struct {
 
 void movement_move_to_face(uint8_t watch_face_index);
 void movement_move_to_next_face(void);
+
+bool movement_default_loop_handler(movement_event_t event, movement_settings_t *settings);
+
 void movement_illuminate_led(void);
 
 void movement_request_tick_frequency(uint8_t freq);

--- a/movement/template/template.c
+++ b/movement/template/template.c
@@ -81,8 +81,12 @@ bool <#watch_face_name#>_face_loop(movement_event_t event, movement_settings_t *
             return movement_default_loop_handler(event, settings);
     }
 
-    // return true if the watch can enter standby mode. If you are PWM'ing an LED or buzzing the buzzer here,
-    // you should return false since the PWM driver does not operate in standby mode.
+    // return true if the watch can enter standby mode. Generally speaking, you should always return true.
+    // Exceptions:
+    //  * If you are displaying a color using the low-level watch_set_led_color function, you should return false.
+    //  * If you are sounding the buzzer using the low-level watch_set_buzzer_on function, you should return false.
+    // Note that if you are driving the LED or buzzer using Movement functions like movement_illuminate_led or
+    // movement_play_alarm, you can still return true. This guidance only applies to the low-level watch_ functions.
     return true;
 }
 

--- a/movement/template/template.c
+++ b/movement/template/template.c
@@ -53,13 +53,10 @@ bool <#watch_face_name#>_face_loop(movement_event_t event, movement_settings_t *
         case EVENT_TICK:
             // If needed, update your display here.
             break;
-        case EVENT_MODE_BUTTON_UP:
-            // You shouldn't need to change this case; Mode almost always moves to the next watch face.
-            movement_move_to_next_face();
-            break;
         case EVENT_LIGHT_BUTTON_UP:
-            // If you have other uses for the Light button, you can opt not to illuminate the LED for this event.
-            movement_illuminate_led();
+            // You can use the Light button for your own purposes. Note that by default, Movement will also
+            // illuminatethe LED in response to EVENT_LIGHT_BUTTON_DOWN; to suppress that behavior, add an
+            // empty case for EVENT_LIGHT_BUTTON_DOWN.
             break;
         case EVENT_ALARM_BUTTON_UP:
             // Just in case you have need for another button.
@@ -76,7 +73,12 @@ bool <#watch_face_name#>_face_loop(movement_event_t event, movement_settings_t *
             // watch_start_tick_animation(500);
             break;
         default:
-            break;
+            // Movement's default loop handler will step in for any cases you don't handle above:
+            // * EVENT_LIGHT_BUTTON_DOWN lights the LED
+            // * EVENT_ALARM_BUTTON_UP moves to the next watch face in the list
+            // * EVENT_MODE_LONG_PRESS returns to the first watch face in the list
+            // You can override any of these behaviors by adding a case for these events to this switch statement.
+            return movement_default_loop_handler(event, settings);
     }
 
     // return true if the watch can enter standby mode. If you are PWM'ing an LED or buzzing the buzzer here,

--- a/movement/template/template.c
+++ b/movement/template/template.c
@@ -75,8 +75,8 @@ bool <#watch_face_name#>_face_loop(movement_event_t event, movement_settings_t *
         default:
             // Movement's default loop handler will step in for any cases you don't handle above:
             // * EVENT_LIGHT_BUTTON_DOWN lights the LED
-            // * EVENT_ALARM_BUTTON_UP moves to the next watch face in the list
-            // * EVENT_MODE_LONG_PRESS returns to the first watch face in the list
+            // * EVENT_MODE_BUTTON_UP moves to the next watch face in the list
+            // * EVENT_MODE_LONG_PRESS returns to the first watch face (or skips to the secondary watch face, if configured)
             // You can override any of these behaviors by adding a case for these events to this switch statement.
             return movement_default_loop_handler(event, settings);
     }

--- a/movement/template/template.c
+++ b/movement/template/template.c
@@ -55,7 +55,7 @@ bool <#watch_face_name#>_face_loop(movement_event_t event, movement_settings_t *
             break;
         case EVENT_LIGHT_BUTTON_UP:
             // You can use the Light button for your own purposes. Note that by default, Movement will also
-            // illuminatethe LED in response to EVENT_LIGHT_BUTTON_DOWN; to suppress that behavior, add an
+            // illuminate the LED in response to EVENT_LIGHT_BUTTON_DOWN; to suppress that behavior, add an
             // empty case for EVENT_LIGHT_BUTTON_DOWN.
             break;
         case EVENT_ALARM_BUTTON_UP:

--- a/movement/watch_faces/clock/beats_face.c
+++ b/movement/watch_faces/clock/beats_face.c
@@ -57,16 +57,8 @@ bool beats_face_loop(movement_event_t event, movement_settings_t *settings, void
 
             watch_display_string(buf, 0);
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
-        case EVENT_LIGHT_BUTTON_DOWN:
-            movement_illuminate_led();
-            break;
-        case EVENT_ALARM_BUTTON_DOWN:
-        case EVENT_ALARM_BUTTON_UP:
-        case EVENT_ALARM_LONG_PRESS:
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/clock/mars_time_face.c
+++ b/movement/watch_faces/clock/mars_time_face.c
@@ -129,9 +129,6 @@ bool mars_time_face_loop(movement_event_t event, movement_settings_t *settings, 
         case EVENT_TICK:
             _update(settings, state);
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
         case EVENT_LIGHT_BUTTON_UP:
             state->displaying_sol = !state->displaying_sol;
             _update(settings, state);
@@ -152,6 +149,7 @@ bool mars_time_face_loop(movement_event_t event, movement_settings_t *settings, 
             // watch_start_tick_animation(500);
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/clock/simple_clock_face.c
+++ b/movement/watch_faces/clock/simple_clock_face.c
@@ -128,12 +128,6 @@ bool simple_clock_face_loop(movement_event_t event, movement_settings_t *setting
             // handle alarm indicator
             if (state->alarm_enabled != settings->bit.alarm_enabled) _update_alarm_indicator(settings->bit.alarm_enabled, state);
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            return false;
-        case EVENT_LIGHT_BUTTON_DOWN:
-            movement_illuminate_led();
-            break;
         case EVENT_ALARM_LONG_PRESS:
             state->signal_enabled = !state->signal_enabled;
             if (state->signal_enabled) watch_set_indicator(WATCH_INDICATOR_BELL);
@@ -145,7 +139,7 @@ bool simple_clock_face_loop(movement_event_t event, movement_settings_t *setting
             movement_play_signal();
             break;
         default:
-            break;
+            return movement_default_loop_handler(event, settings);
     }
 
     return true;

--- a/movement/watch_faces/clock/weeknumber_clock_face.c
+++ b/movement/watch_faces/clock/weeknumber_clock_face.c
@@ -122,12 +122,6 @@ bool weeknumber_clock_face_loop(movement_event_t event, movement_settings_t *set
             // handle alarm indicator
             if (state->alarm_enabled != settings->bit.alarm_enabled) _update_alarm_indicator(settings->bit.alarm_enabled, state);
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            return false;
-        case EVENT_LIGHT_BUTTON_DOWN:
-            movement_illuminate_led();
-            break;
         case EVENT_ALARM_LONG_PRESS:
             state->signal_enabled = !state->signal_enabled;
             if (state->signal_enabled) watch_set_indicator(WATCH_INDICATOR_BELL);
@@ -149,6 +143,7 @@ bool weeknumber_clock_face_loop(movement_event_t event, movement_settings_t *set
             }
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/clock/world_clock_face.c
+++ b/movement/watch_faces/clock/world_clock_face.c
@@ -113,18 +113,12 @@ static bool world_clock_face_do_display_mode(movement_event_t event, movement_se
             }
             watch_display_string(buf, pos);
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            return false;
-        case EVENT_LIGHT_BUTTON_DOWN:
-            movement_illuminate_led();
-            break;
         case EVENT_ALARM_LONG_PRESS:
             movement_request_tick_frequency(4);
             state->current_screen = 1;
             break;
         default:
-            break;
+            return movement_default_loop_handler(event, settings);
     }
 
     return true;

--- a/movement/watch_faces/complication/alarm_face.c
+++ b/movement/watch_faces/complication/alarm_face.c
@@ -441,13 +441,11 @@ bool alarm_face_loop(movement_event_t event, movement_settings_t *settings, void
             _alarm_update_alarm_enabled(settings, state);
         }
         break;
-    case EVENT_MODE_BUTTON_UP:
-        movement_move_to_next_face();
-        break;
     case EVENT_TIMEOUT:
         movement_move_to_face(0);
         break;
     default:
+        movement_default_loop_handler(event, settings);
       break;
     }
 

--- a/movement/watch_faces/complication/astronomy_face.c
+++ b/movement/watch_faces/complication/astronomy_face.c
@@ -219,14 +219,6 @@ bool astronomy_face_loop(movement_event_t event, movement_settings_t *settings, 
         case EVENT_TICK:
             _astronomy_face_update(event, settings, state);
             break;
-        case EVENT_MODE_BUTTON_UP:
-            // You shouldn't need to change this case; Mode almost always moves to the next watch face.
-            movement_move_to_next_face();
-            break;
-        case EVENT_LIGHT_BUTTON_UP:
-            // If you have other uses for the Light button, you can opt not to illuminate the LED for this event.
-            movement_illuminate_led();
-            break;
         case EVENT_ALARM_BUTTON_UP:
             switch (state->mode) {
                 case ASTRONOMY_MODE_SELECTING_BODY:
@@ -267,6 +259,7 @@ bool astronomy_face_loop(movement_event_t event, movement_settings_t *settings, 
             // TODO?
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/complication/blinky_face.c
+++ b/movement/watch_faces/complication/blinky_face.c
@@ -57,9 +57,6 @@ bool blinky_face_loop(movement_event_t event, movement_settings_t *settings, voi
         case EVENT_ACTIVATE:
             _blinky_face_update_lcd(state);
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
         case EVENT_LIGHT_BUTTON_UP:
             if (!state->active) {
                 state->color = (state->color + 1) % 3;
@@ -93,7 +90,9 @@ bool blinky_face_loop(movement_event_t event, movement_settings_t *settings, voi
             break;
         case EVENT_TIMEOUT:
             if (!state->active) movement_move_to_face(0);
+            break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/complication/countdown_face.c
+++ b/movement/watch_faces/complication/countdown_face.c
@@ -160,9 +160,6 @@ bool countdown_face_loop(movement_event_t event, movement_settings_t *settings, 
             }
             draw(state, event.subsecond);
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
         case EVENT_LIGHT_BUTTON_UP:
             switch(state->mode) {
                 case cd_running:
@@ -216,8 +213,10 @@ bool countdown_face_loop(movement_event_t event, movement_settings_t *settings, 
             movement_move_to_face(0);
             break;
         case EVENT_LOW_ENERGY_UPDATE:
+            break;
         default:
-          break;
+            movement_default_loop_handler(event, settings);
+            break;
     }
 
     return true;

--- a/movement/watch_faces/complication/counter_face.c
+++ b/movement/watch_faces/complication/counter_face.c
@@ -47,12 +47,6 @@ bool counter_face_loop(movement_event_t event, movement_settings_t *settings, vo
     counter_state_t *state = (counter_state_t *)context;
 
     switch (event.event_type) {
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
-        case EVENT_LIGHT_BUTTON_DOWN:
-            movement_illuminate_led();
-            break;
         case EVENT_ALARM_BUTTON_UP:
             state->counter_idx++; // increment counter index
             if (state->counter_idx>99) { //0-99
@@ -72,6 +66,7 @@ bool counter_face_loop(movement_event_t event, movement_settings_t *settings, vo
             // ignore timeout
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/complication/databank_face.c
+++ b/movement/watch_faces/complication/databank_face.c
@@ -110,12 +110,6 @@ bool databank_face_loop(movement_event_t event, movement_settings_t *settings, v
             databank_state.current_word = 0;
             display();
             break;
-        case EVENT_MODE_BUTTON_UP:
-            // when the user presses 'mode', we tell movement to move to the next watch face.
-            // movement will call our resign function, clear the screen, and transfer control
-            // to the next watch face in the list.
-            movement_move_to_next_face();
-            break;
         case EVENT_ALARM_LONG_PRESS:
             databank_state.databank_page = (databank_state.databank_page + 1) % databank_num_pages;
             databank_state.current_word = 0;
@@ -141,7 +135,9 @@ bool databank_face_loop(movement_event_t event, movement_settings_t *settings, v
             // and it will do it long before the watch enters low energy mode. This ensures we
             // won't be on screen, and thus opts us out of getting the EVENT_LOW_ENERGY_UPDATE above.
             movement_move_to_face(0);
+            break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/complication/day_one_face.c
+++ b/movement/watch_faces/complication/day_one_face.c
@@ -123,9 +123,6 @@ bool day_one_face_loop(movement_event_t event, movement_settings_t *settings, vo
                 }
             }
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
         case EVENT_LIGHT_BUTTON_DOWN:
             // only illuminate if we're in display mode
             if (state->current_page == 0) movement_illuminate_led();
@@ -176,7 +173,9 @@ bool day_one_face_loop(movement_event_t event, movement_settings_t *settings, vo
             if (state->current_page != 0) {
                 movement_move_to_face(0);
             }
+            break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/complication/interval_face.c
+++ b/movement/watch_faces/complication/interval_face.c
@@ -664,14 +664,12 @@ bool interval_face_loop(movement_event_t event, movement_settings_t *settings, v
             watch_buzzer_play_sequence((int8_t *)_sound_seq_finish, NULL);
         }
         break;
-    case EVENT_MODE_BUTTON_UP:
-        movement_move_to_next_face();
-        break;
     case EVENT_TIMEOUT:
         if (state->face_state != interval_state_running) movement_move_to_face(0);
         break;
     default:
-      break;
+        movement_default_loop_handler(event, settings);
+        break;
     }
     return true;
 }

--- a/movement/watch_faces/complication/moon_phase_face.c
+++ b/movement/watch_faces/complication/moon_phase_face.c
@@ -155,12 +155,6 @@ bool moon_phase_face_loop(movement_event_t event, movement_settings_t *settings,
             watch_display_string("  ", 8);
             if (!watch_tick_animation_is_running()) watch_start_tick_animation(1000);
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
-        case EVENT_LIGHT_BUTTON_DOWN:
-            movement_illuminate_led();
-            break;
         case EVENT_ALARM_BUTTON_UP:
             // Pressing the alarm adds an offset of one day to the displayed value,
             // so you can see moon phases in the future.
@@ -171,7 +165,7 @@ bool moon_phase_face_loop(movement_event_t event, movement_settings_t *settings,
             // QUESTION: Should timeout reset offset to 0?
             break;
         default:
-            break;
+            return movement_default_loop_handler(event, settings);
     }
 
     return true;

--- a/movement/watch_faces/complication/orrery_face.c
+++ b/movement/watch_faces/complication/orrery_face.c
@@ -174,14 +174,6 @@ bool orrery_face_loop(movement_event_t event, movement_settings_t *settings, voi
         case EVENT_TICK:
             _orrery_face_update(event, settings, state);
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
-        case EVENT_LIGHT_BUTTON_DOWN:
-            movement_illuminate_led();
-            break;
-        case EVENT_LIGHT_BUTTON_UP:
-            break;
         case EVENT_ALARM_BUTTON_UP:
             switch (state->mode) {
                 case ORRERY_MODE_SELECTING_BODY:
@@ -219,6 +211,7 @@ bool orrery_face_loop(movement_event_t event, movement_settings_t *settings, voi
             movement_move_to_face(0);
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/complication/probability_face.c
+++ b/movement/watch_faces/complication/probability_face.c
@@ -141,9 +141,6 @@ bool probability_face_loop(movement_event_t event, movement_settings_t *settings
         case EVENT_TICK:
             display_dice_roll_animation(state);
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
         case EVENT_LIGHT_BUTTON_UP:
             // Change how many sides the die has
             for (int i = 0; i < NUM_DICE_TYPES; i++) {
@@ -170,6 +167,7 @@ bool probability_face_loop(movement_event_t event, movement_settings_t *settings
             watch_display_string("SLEEP ", 4);
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/complication/pulsometer_face.c
+++ b/movement/watch_faces/complication/pulsometer_face.c
@@ -46,12 +46,6 @@ bool pulsometer_face_loop(movement_event_t event, movement_settings_t *settings,
     pulsometer_state_t *pulsometer_state = (pulsometer_state_t *)context;
     char buf[14];
     switch (event.event_type) {
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
-        case EVENT_LIGHT_BUTTON_DOWN:
-            movement_illuminate_led();
-            break;
         case EVENT_ALARM_BUTTON_DOWN:
             pulsometer_state->measuring = true;
             pulsometer_state->pulse = 0xFFFF;
@@ -102,6 +96,7 @@ bool pulsometer_face_loop(movement_event_t event, movement_settings_t *settings,
             movement_move_to_face(0);
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/complication/ratemeter_face.c
+++ b/movement/watch_faces/complication/ratemeter_face.c
@@ -49,12 +49,6 @@ bool ratemeter_face_loop(movement_event_t event, movement_settings_t *settings, 
         case EVENT_ACTIVATE:
             watch_display_string("ra          ", 0);
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
-        case EVENT_LIGHT_BUTTON_DOWN:
-            movement_illuminate_led();
-            break;
         case EVENT_ALARM_BUTTON_DOWN:
             if (ratemeter_state->ticks != 0) {
                 ratemeter_state->rate = (int16_t)(60.0 / ((float)ratemeter_state->ticks / (float)RATEMETER_FACE_FREQUENCY));
@@ -85,6 +79,7 @@ bool ratemeter_face_loop(movement_event_t event, movement_settings_t *settings, 
             movement_move_to_face(0);
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/complication/rpn_calculator_alt_face.c
+++ b/movement/watch_faces/complication/rpn_calculator_alt_face.c
@@ -441,7 +441,9 @@ bool rpn_calculator_alt_face_loop(movement_event_t event, movement_settings_t *s
             movement_move_to_face(0);
             break;
         case EVENT_LOW_ENERGY_UPDATE:
+            break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/complication/rpn_calculator_face.c
+++ b/movement/watch_faces/complication/rpn_calculator_face.c
@@ -333,6 +333,7 @@ bool rpn_calculator_face_loop(movement_event_t event, movement_settings_t *setti
         case EVENT_LOW_ENERGY_UPDATE:
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/complication/sailing_face.c
+++ b/movement/watch_faces/complication/sailing_face.c
@@ -197,9 +197,6 @@ bool sailing_face_loop(movement_event_t event, movement_settings_t *settings, vo
             }
             draw(state, event.subsecond, settings);
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
         case EVENT_LIGHT_LONG_PRESS:
             if (state->mode == sl_running) {
                 reset(state);
@@ -258,8 +255,10 @@ bool sailing_face_loop(movement_event_t event, movement_settings_t *settings, vo
             }
             break;
         case EVENT_LOW_ENERGY_UPDATE:
+            break;
         default:
-          break;
+            movement_default_loop_handler(event, settings);
+            break;
     }
 
     return true;

--- a/movement/watch_faces/complication/stock_stopwatch_face.c
+++ b/movement/watch_faces/complication/stock_stopwatch_face.c
@@ -251,9 +251,6 @@ bool stock_stopwatch_face_loop(movement_event_t event, movement_settings_t *sett
         case EVENT_TICK:
             _draw();
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
         case EVENT_LIGHT_LONG_PRESS:
             // kind od hidden feature: long press toggles light on or off
             state->light_on_button = !state->light_on_button;
@@ -313,6 +310,7 @@ bool stock_stopwatch_face_loop(movement_event_t event, movement_settings_t *sett
             _draw();
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
     return true;

--- a/movement/watch_faces/complication/stopwatch_face.c
+++ b/movement/watch_faces/complication/stopwatch_face.c
@@ -107,9 +107,6 @@ bool stopwatch_face_loop(movement_event_t event, movement_settings_t *settings, 
                 _stopwatch_face_update_display(stopwatch_state, true);
             }
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
         case EVENT_LIGHT_BUTTON_DOWN:
             movement_illuminate_led();
             if (!stopwatch_state->running) {
@@ -161,7 +158,7 @@ bool stopwatch_face_loop(movement_event_t event, movement_settings_t *settings, 
             }
             break;
         default:
-            break;
+            return movement_default_loop_handler(event, settings);
     }
 
     return true;

--- a/movement/watch_faces/complication/sunrise_sunset_face.c
+++ b/movement/watch_faces/complication/sunrise_sunset_face.c
@@ -339,9 +339,6 @@ bool sunrise_sunset_face_loop(movement_event_t event, movement_settings_t *setti
                 _sunrise_sunset_face_update_settings_display(event, state);
             }
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
         case EVENT_LIGHT_BUTTON_DOWN:
             if (state->page) {
                 state->active_digit++;
@@ -359,8 +356,6 @@ bool sunrise_sunset_face_loop(movement_event_t event, movement_settings_t *setti
                 movement_request_tick_frequency(1);
                 _sunrise_sunset_face_update(settings, state);
             }
-            break;
-        case EVENT_LIGHT_BUTTON_UP:
             break;
         case EVENT_ALARM_BUTTON_UP:
             if (state->page) {
@@ -393,7 +388,7 @@ bool sunrise_sunset_face_loop(movement_event_t event, movement_settings_t *setti
             }
             break;
         default:
-            break;
+            return movement_default_loop_handler(event, settings);
     }
 
     return true;

--- a/movement/watch_faces/complication/tachymeter_face.c
+++ b/movement/watch_faces/complication/tachymeter_face.c
@@ -138,9 +138,6 @@ bool tachymeter_face_loop(movement_event_t event, movement_settings_t *settings,
                 state->animation_state = (state->animation_state + 1) % 6;
             }
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
         case EVENT_LIGHT_BUTTON_UP:
             if (state->editing){
                 // Go to next digit
@@ -254,6 +251,7 @@ bool tachymeter_face_loop(movement_event_t event, movement_settings_t *settings,
             // watch_start_tick_animation(500);
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
     // return true if the watch can enter standby mode. If you are PWM'ing an LED or buzzing the buzzer here,

--- a/movement/watch_faces/complication/tally_face.c
+++ b/movement/watch_faces/complication/tally_face.c
@@ -46,12 +46,6 @@ bool tally_face_loop(movement_event_t event, movement_settings_t *settings, void
     tally_state_t *state = (tally_state_t *)context;
     
     switch (event.event_type) {
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
-        case EVENT_LIGHT_BUTTON_DOWN:
-            movement_illuminate_led();
-	        break;
         case EVENT_ALARM_BUTTON_UP:
             // increment tally index
             state->tally_idx++;
@@ -79,6 +73,7 @@ bool tally_face_loop(movement_event_t event, movement_settings_t *settings, void
             // ignore timeout
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/complication/tarot_face.c
+++ b/movement/watch_faces/complication/tarot_face.c
@@ -248,9 +248,6 @@ bool tarot_face_loop(movement_event_t event, movement_settings_t *settings, void
         case EVENT_TICK:
             display_animation(state);
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
         case EVENT_LIGHT_BUTTON_UP:
             if (state->drawn_cards[0] == 0xff) {
                 // deck is inited; cycle through # cards to draw
@@ -287,11 +284,8 @@ bool tarot_face_loop(movement_event_t event, movement_settings_t *settings, void
         case EVENT_LOW_ENERGY_UPDATE:
             watch_display_string("SLEEP ", 4);
             break;
-        case EVENT_MODE_LONG_PRESS:
-            // since we ignore timeouts, provide a convenient way to jump back to the start
-            movement_move_to_face(0);
-            break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/complication/tempchart_face.c
+++ b/movement/watch_faces/complication/tempchart_face.c
@@ -89,12 +89,6 @@ bool tempchart_face_loop(movement_event_t event, movement_settings_t *settings, 
         case EVENT_TICK:
             // on activate and tick, if we are animating,
             break;
-        case EVENT_MODE_BUTTON_UP:
-            // when the user presses 'mode', we tell movement to move to the next watch face.
-            // movement will call our resign function, clear the screen, and transfer control
-            // to the next watch face in the list.
-            movement_move_to_next_face();
-            break;
         case EVENT_LOW_ENERGY_UPDATE:
             // This low energy mode update occurs once a minute, if the watch face is in the
             // foreground when Movement enters low energy mode. We have the option of supporting
@@ -133,6 +127,7 @@ bool tempchart_face_loop(movement_event_t event, movement_settings_t *settings, 
             break;
 
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/complication/tomato_face.c
+++ b/movement/watch_faces/complication/tomato_face.c
@@ -142,9 +142,6 @@ bool tomato_face_loop(movement_event_t event, movement_settings_t *settings, voi
             }
             tomato_draw(state);
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
         case EVENT_LIGHT_BUTTON_UP:
             movement_illuminate_led();
             if (state->mode == tomato_ready) {
@@ -179,6 +176,7 @@ bool tomato_face_loop(movement_event_t event, movement_settings_t *settings, voi
             movement_move_to_face(0);
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/complication/totp_face.c
+++ b/movement/watch_faces/complication/totp_face.c
@@ -79,12 +79,6 @@ bool totp_face_loop(movement_event_t event, movement_settings_t *settings, void 
 
             watch_display_string(buf, 0);
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
-        case EVENT_LIGHT_BUTTON_DOWN:
-            movement_illuminate_led();
-            break;
         case EVENT_TIMEOUT:
             movement_move_to_face(0);
             break;
@@ -101,7 +95,9 @@ bool totp_face_loop(movement_event_t event, movement_settings_t *settings, void 
             break;
         case EVENT_ALARM_BUTTON_DOWN:
         case EVENT_ALARM_LONG_PRESS:
+            break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/complication/totp_face_lfs.c
+++ b/movement/watch_faces/complication/totp_face_lfs.c
@@ -242,12 +242,6 @@ bool totp_face_lfs_loop(movement_event_t event, movement_settings_t *settings, v
         case EVENT_ACTIVATE:
             totp_face_display(totp_state);
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
-        case EVENT_LIGHT_BUTTON_DOWN:
-            movement_illuminate_led();
-            break;
         case EVENT_TIMEOUT:
             movement_move_to_face(0);
             break;
@@ -257,7 +251,9 @@ bool totp_face_lfs_loop(movement_event_t event, movement_settings_t *settings, v
             break;
         case EVENT_ALARM_BUTTON_DOWN:
         case EVENT_ALARM_LONG_PRESS:
+            break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/complication/wake_face.c
+++ b/movement/watch_faces/complication/wake_face.c
@@ -144,15 +144,14 @@ bool wake_face_loop(movement_event_t event, movement_settings_t *settings, void 
         movement_play_alarm();
             // 2022-07-23: Thx @joeycastillo for the dedicated “alarm” signal
         break;
-    case EVENT_MODE_BUTTON_UP:
-        movement_move_to_next_face();
-        break;
     case EVENT_TIMEOUT:
         movement_move_to_face(0);
         break;
     case EVENT_LOW_ENERGY_UPDATE:
+        break;
     default:
-      break;
+        movement_default_loop_handler(event, settings);
+        break;
     }
 
     return true;

--- a/movement/watch_faces/demo/character_set_face.c
+++ b/movement/watch_faces/demo/character_set_face.c
@@ -45,12 +45,6 @@ bool character_set_face_loop(movement_event_t event, movement_settings_t *settin
     char *c = (char *)context;
     char buf[11];
     switch (event.event_type) {
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
-        case EVENT_LIGHT_BUTTON_DOWN:
-            movement_illuminate_led();
-            break;
         case EVENT_ALARM_BUTTON_UP:
             *c = (*c) + 1;
             if (*c & 0x80) *c = ' ';
@@ -63,6 +57,7 @@ bool character_set_face_loop(movement_event_t event, movement_settings_t *settin
             movement_move_to_face(0);
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/demo/demo_face.c
+++ b/movement/watch_faces/demo/demo_face.c
@@ -65,12 +65,6 @@ bool demo_face_loop(movement_event_t event, movement_settings_t *settings, void 
     (void) settings;
     demo_face_index_t *screen = (demo_face_index_t *)context;
     switch (event.event_type) {
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
-        case EVENT_LIGHT_BUTTON_DOWN:
-            movement_illuminate_led();
-            break;
         case EVENT_ALARM_BUTTON_UP:
             *screen = ((*screen) + 1) % DEMO_FACE_NUM_FACES;
             // fall through
@@ -129,6 +123,7 @@ bool demo_face_loop(movement_event_t event, movement_settings_t *settings, void 
             // ignore timeout
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/demo/frequency_correction_face.c
+++ b/movement/watch_faces/demo/frequency_correction_face.c
@@ -96,9 +96,6 @@ bool frequency_correction_face_loop(movement_event_t event, movement_settings_t 
             break;
         case EVENT_TICK:
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
         case EVENT_LIGHT_BUTTON_UP:
             freqcorr = RTC->MODE2.FREQCORR.reg;
             if (freqcorr < 127) {
@@ -126,6 +123,7 @@ bool frequency_correction_face_loop(movement_event_t event, movement_settings_t 
             watch_start_tick_animation(500);
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/demo/hello_there_face.c
+++ b/movement/watch_faces/demo/hello_there_face.c
@@ -66,18 +66,6 @@ bool hello_there_face_loop(movement_event_t event, movement_settings_t *settings
                 state->current_word = (state->current_word + 1) % 2;
             }
             break;
-        case EVENT_LIGHT_BUTTON_UP:
-            // when the user presses 'light', we illuminate the LED. We could override this if
-            // our UI needed an additional button for input, consuming the light button press
-            // but not illuminating the LED.
-            movement_illuminate_led();
-            break;
-        case EVENT_MODE_BUTTON_UP:
-            // when the user presses 'mode', we tell movement to move to the next watch face.
-            // movement will call our resign function, clear the screen, and transfer control
-            // to the next watch face in the list.
-            movement_move_to_next_face();
-            break;
         case EVENT_ALARM_BUTTON_UP:
             // when the user presses 'alarm', we toggle the state of the animation. If animating,
             // we stop; if stopped, we resume.
@@ -97,7 +85,9 @@ bool hello_there_face_loop(movement_event_t event, movement_settings_t *settings
             // and it will do it long before the watch enters low energy mode. This ensures we
             // won't be on screen, and thus opts us out of getting the EVENT_LOW_ENERGY_UPDATE above.
             movement_move_to_face(0);
+            break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/demo/lis2dw_logging_face.c
+++ b/movement/watch_faces/demo/lis2dw_logging_face.c
@@ -146,12 +146,6 @@ bool lis2dw_logging_face_loop(movement_event_t event, movement_settings_t *setti
     lis2dw_interrupt_source interrupt_source = 0;
 
     switch (event.event_type) {
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
-        case EVENT_LIGHT_LONG_PRESS:
-            movement_illuminate_led();
-            break;
         case EVENT_LIGHT_BUTTON_DOWN:
             logger_state->axis_index = (logger_state->axis_index + 1) % 4;
             logger_state->log_ticks = 255;
@@ -187,6 +181,7 @@ bool lis2dw_logging_face_loop(movement_event_t event, movement_settings_t *setti
             _lis2dw_logging_face_log_data(logger_state);
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/demo/voltage_face.c
+++ b/movement/watch_faces/demo/voltage_face.c
@@ -55,12 +55,6 @@ bool voltage_face_loop(movement_event_t event, movement_settings_t *settings, vo
     (void) context;
     watch_date_time date_time;
     switch (event.event_type) {
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
-        case EVENT_LIGHT_BUTTON_DOWN:
-            movement_illuminate_led();
-            break;
         case EVENT_ACTIVATE:
             _voltage_face_update_display();
             break;
@@ -78,6 +72,7 @@ bool voltage_face_loop(movement_event_t event, movement_settings_t *settings, vo
             watch_display_string("BA  SLEEP ", 0);
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/sensor/accelerometer_data_acquisition_face.c
+++ b/movement/watch_faces/sensor/accelerometer_data_acquisition_face.c
@@ -159,9 +159,6 @@ bool accelerometer_data_acquisition_face_loop(movement_event_t event, movement_s
                     break;
             }
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
         case EVENT_LIGHT_BUTTON_UP:
             switch (state->mode) {
                 case ACCELEROMETER_DATA_ACQUISITION_MODE_IDLE:
@@ -218,6 +215,7 @@ bool accelerometer_data_acquisition_face_loop(movement_event_t event, movement_s
             }
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/sensor/thermistor_logging_face.c
+++ b/movement/watch_faces/sensor/thermistor_logging_face.c
@@ -94,9 +94,6 @@ bool thermistor_logging_face_loop(movement_event_t event, movement_settings_t *s
         case EVENT_TIMEOUT:
             movement_move_to_face(0);
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
         case EVENT_LIGHT_LONG_PRESS:
             // light button shows the timestamp, but if you need the light, long press it.
             movement_illuminate_led();
@@ -121,6 +118,7 @@ bool thermistor_logging_face_loop(movement_event_t event, movement_settings_t *s
             _thermistor_logging_face_log_data(logger_state);
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/sensor/thermistor_readout_face.c
+++ b/movement/watch_faces/sensor/thermistor_readout_face.c
@@ -57,12 +57,6 @@ bool thermistor_readout_face_loop(movement_event_t event, movement_settings_t *s
     (void) context;
     watch_date_time date_time = watch_rtc_get_date_time();
     switch (event.event_type) {
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
-        case EVENT_LIGHT_BUTTON_DOWN:
-            movement_illuminate_led();
-            break;
         case EVENT_ALARM_BUTTON_DOWN:
             settings->bit.use_imperial_units = !settings->bit.use_imperial_units;
             _thermistor_readout_face_update_display(settings->bit.use_imperial_units);
@@ -86,6 +80,7 @@ bool thermistor_readout_face_loop(movement_event_t event, movement_settings_t *s
             watch_display_string("TE  SLEEP ", 0);
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/sensor/thermistor_testing_face.c
+++ b/movement/watch_faces/sensor/thermistor_testing_face.c
@@ -64,9 +64,6 @@ void thermistor_testing_face_activate(movement_settings_t *settings, void *conte
 bool thermistor_testing_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
     (void) context;
     switch (event.event_type) {
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
         case EVENT_ALARM_BUTTON_DOWN:
             settings->bit.use_imperial_units = !settings->bit.use_imperial_units;
             _thermistor_testing_face_update_display(settings->bit.use_imperial_units);
@@ -76,6 +73,7 @@ bool thermistor_testing_face_loop(movement_event_t event, movement_settings_t *s
             _thermistor_testing_face_update_display(settings->bit.use_imperial_units);
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/settings/finetune_face.c
+++ b/movement/watch_faces/settings/finetune_face.c
@@ -239,6 +239,7 @@ bool finetune_face_loop(movement_event_t event, movement_settings_t *settings, v
             break;
 
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/settings/nanosec_face.c
+++ b/movement/watch_faces/settings/nanosec_face.c
@@ -365,6 +365,7 @@ bool nanosec_face_loop(movement_event_t event, movement_settings_t *settings, vo
             apply_RTC_correction(correction);
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/settings/preferences_face.c
+++ b/movement/watch_faces/settings/preferences_face.c
@@ -56,11 +56,15 @@ void preferences_face_activate(movement_settings_t *settings, void *context) {
 bool preferences_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
     uint8_t current_page = *((uint8_t *)context);
     switch (event.event_type) {
+        case EVENT_TICK:
+        case EVENT_ACTIVATE:
+            // Do nothing; handled below.
+            break;
         case EVENT_MODE_BUTTON_UP:
             watch_set_led_off();
             movement_move_to_next_face();
             return false;
-        case EVENT_LIGHT_BUTTON_UP:
+        case EVENT_LIGHT_BUTTON_DOWN:
             current_page = (current_page + 1) % PREFERENCES_FACE_NUM_PREFEFENCES;
             *((uint8_t *)context) = current_page;
             break;
@@ -93,7 +97,7 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
             movement_move_to_face(0);
             break;
         default:
-            break;
+            return movement_default_loop_handler(event, settings);
     }
 
     watch_display_string((char *)preferences_face_titles[current_page], 0);

--- a/movement/watch_faces/settings/set_time_face.c
+++ b/movement/watch_faces/settings/set_time_face.c
@@ -128,7 +128,7 @@ bool set_time_face_loop(movement_event_t event, movement_settings_t *settings, v
             movement_move_to_face(0);
             break;
         default:
-            break;
+            return movement_default_loop_handler(event, settings);
     }
 
     char buf[11];

--- a/movement/watch_faces/settings/set_time_hackwatch_face.c
+++ b/movement/watch_faces/settings/set_time_hackwatch_face.c
@@ -201,6 +201,7 @@ bool set_time_hackwatch_face_loop(movement_event_t event, movement_settings_t *s
             movement_move_to_face(0);
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 


### PR DESCRIPTION
This PR adds a new `movement_default_loop_handler` function that takes care of standard Movement behaviors. The intent behind this refactor is to have all watch faces call the default loop handler in the `default:` case of their `watch_face_loop` functions. 

At this time, the default handler handles three events: 

* `EVENT_MODE_BUTTON_UP` advances to the next watch face.
* `EVENT_LIGHT_BUTTON_DOWN` illuminates the LED.
* `EVENT_MODE_LONG_PRESS` returns to the first watch face.

This reduces the amount of boilerplate code in watch faces: by simply omitting cases for these events, the switch falls through to the default case, and the default handler implements the desired behavior. It also allows watch faces to override certain behaviors: a watch face that really needs the MODE button can simply implement a case for `EVENT_MODE_BUTTON_UP` or `EVENT_MODE_LONG_PRESS`, and the default handler will not be called. 

At this time the PR only makes this change in the watch faces in the standard firmware. It should be backwards compatible, since all watch faces that don't implement the new handler currently *do* implement the default behaviors, just in their own cases in the switch statement. 

Anyway, opening this PR up for comment before making the change to the remaining watch faces.