### PR TITLE
Movement: fix behavior of fast_tick_enabled

### DIFF
--- a/movement/movement.c
+++ b/movement/movement.c
@@ -142,6 +142,7 @@ static inline void _movement_enable_fast_tick_if_needed(void) {
     if (!movement_state.fast_tick_enabled) {
         movement_state.fast_ticks = 0;
         watch_rtc_register_periodic_callback(cb_fast_tick, 128);
+        movement_state.fast_tick_enabled = true;
     }
 }
 
@@ -605,7 +606,10 @@ void cb_fast_tick(void) {
             event.event_type = EVENT_ALARM_LONG_PRESS;
     // this is just a fail-safe; fast tick should be disabled as soon as the button is up, the LED times out, and/or the alarm finishes.
     // but if for whatever reason it isn't, this forces the fast tick off after 20 seconds.
-    if (movement_state.fast_ticks >= 128 * 20) watch_rtc_disable_periodic_callback(128);
+    if (movement_state.fast_ticks >= 128 * 20) {
+        watch_rtc_disable_periodic_callback(128);
+        movement_state.fast_tick_enabled = false;
+    }
 }
 
 void cb_tick(void) {


### PR DESCRIPTION
This should fix issue #166 and maybe some other oddities regarding _LONG_PRESS events. The fast ticks timing has obviously been messed up each time the function `_movement_enable_fast_tick_if_needed()` was invoked.

I will test this in the next couple of days, when my replacement sensor watch board has arrived :-)

Until then, I will keep this pr in draft state. If anyone feels the urge to jump in regarding testing: feel free!