### PR TITLE
countdown_face: implement holding light to reset the currently edited timer value (and everything below it)

### DIFF
--- a/movement/watch_faces/complication/countdown_face.c
+++ b/movement/watch_faces/complication/countdown_face.c
@@ -278,6 +278,21 @@ bool countdown_face_loop(movement_event_t event, movement_settings_t *settings, 
                 movement_request_tick_frequency(8);
             }
             break;
+        case EVENT_LIGHT_LONG_PRESS:
+            if (state->mode == cd_setting) {
+                switch (state->selection) {
+                    case 0:
+                        state->hours = 0;
+                        // intentional fallthrough
+                    case 1:
+                        state->minutes = 0;
+                        // intentional fallthrough
+                    case 2:
+                        state->seconds = 0;
+                        break;
+                }
+            }
+            break;
         case EVENT_ALARM_LONG_UP:
             abort_quick_ticks(state);
             break;
@@ -289,6 +304,8 @@ bool countdown_face_loop(movement_event_t event, movement_settings_t *settings, 
             movement_move_to_face(0);
             break;
         case EVENT_LOW_ENERGY_UPDATE:
+        // intentionally squelch the light default event; we only show the light when cd is running
+        case EVENT_LIGHT_BUTTON_DOWN:
             break;
         default:
             movement_default_loop_handler(event, settings);


### PR DESCRIPTION
an alternative implementation could have us resetting *only* the currently edited value position and nothing else by replacing the `// intentional fallthrough` comments with `break;`'s