### PR TITLE
restore old light button behavior

### DIFF
--- a/movement/watch_faces/clock/mars_time_face.c
+++ b/movement/watch_faces/clock/mars_time_face.c
@@ -148,6 +148,9 @@ bool mars_time_face_loop(movement_event_t event, movement_settings_t *settings, 
             // TODO: low energy update
             // watch_start_tick_animation(500);
             break;
+        case EVENT_LIGHT_BUTTON_DOWN:
+            // don't light up every time light is hit
+            break;
         default:
             movement_default_loop_handler(event, settings);
             break;

--- a/movement/watch_faces/complication/alarm_face.c
+++ b/movement/watch_faces/complication/alarm_face.c
@@ -444,6 +444,9 @@ bool alarm_face_loop(movement_event_t event, movement_settings_t *settings, void
     case EVENT_TIMEOUT:
         movement_move_to_face(0);
         break;
+    case EVENT_LIGHT_BUTTON_DOWN:
+        // don't light up every time light is hit
+        break;
     default:
         movement_default_loop_handler(event, settings);
         break;

--- a/movement/watch_faces/complication/blinky_face.c
+++ b/movement/watch_faces/complication/blinky_face.c
@@ -57,7 +57,7 @@ bool blinky_face_loop(movement_event_t event, movement_settings_t *settings, voi
         case EVENT_ACTIVATE:
             _blinky_face_update_lcd(state);
             break;
-        case EVENT_LIGHT_BUTTON_UP:
+        case EVENT_LIGHT_BUTTON_DOWN:
             if (!state->active) {
                 state->color = (state->color + 1) % 3;
                 _blinky_face_update_lcd(state);

--- a/movement/watch_faces/complication/countdown_face.c
+++ b/movement/watch_faces/complication/countdown_face.c
@@ -225,7 +225,7 @@ bool countdown_face_loop(movement_event_t event, movement_settings_t *settings, 
             abort_quick_ticks(state);
             movement_move_to_next_face();
             break;
-        case EVENT_LIGHT_BUTTON_UP:
+        case EVENT_LIGHT_BUTTON_DOWN:
             switch(state->mode) {
                 case cd_running:
                     movement_illuminate_led();

--- a/movement/watch_faces/complication/databank_face.c
+++ b/movement/watch_faces/complication/databank_face.c
@@ -136,6 +136,9 @@ bool databank_face_loop(movement_event_t event, movement_settings_t *settings, v
             // won't be on screen, and thus opts us out of getting the EVENT_LOW_ENERGY_UPDATE above.
             movement_move_to_face(0);
             break;
+        case EVENT_LIGHT_BUTTON_DOWN:
+            // don't light up every time light is hit
+            break;
         default:
             movement_default_loop_handler(event, settings);
             break;

--- a/movement/watch_faces/complication/interval_face.c
+++ b/movement/watch_faces/complication/interval_face.c
@@ -667,6 +667,9 @@ bool interval_face_loop(movement_event_t event, movement_settings_t *settings, v
     case EVENT_TIMEOUT:
         if (state->face_state != interval_state_running) movement_move_to_face(0);
         break;
+    case EVENT_LIGHT_BUTTON_DOWN:
+        // don't light up every time light is hit
+        break;
     default:
         movement_default_loop_handler(event, settings);
         break;

--- a/movement/watch_faces/complication/morsecalc_face.c
+++ b/movement/watch_faces/complication/morsecalc_face.c
@@ -376,6 +376,12 @@ bool morsecalc_face_loop(movement_event_t event, movement_settings_t *settings, 
 				settings->bit.led_green_color ? (0xF | settings->bit.led_green_color << 4) : 0);
 		}
         break;
+    case EVENT_LIGHT_BUTTON_DOWN:
+        // don't light up every time light is hit
+        break;
+    default:
+        movement_default_loop_handler(event, settings);
+        break;
 	}
     
     return true;

--- a/movement/watch_faces/complication/probability_face.c
+++ b/movement/watch_faces/complication/probability_face.c
@@ -141,7 +141,7 @@ bool probability_face_loop(movement_event_t event, movement_settings_t *settings
         case EVENT_TICK:
             display_dice_roll_animation(state);
             break;
-        case EVENT_LIGHT_BUTTON_UP:
+        case EVENT_LIGHT_BUTTON_DOWN:
             // Change how many sides the die has
             for (int i = 0; i < NUM_DICE_TYPES; i++) {
                 if (DICE_TYPES[i] == state->dice_sides) {

--- a/movement/watch_faces/complication/rpn_calculator_alt_face.c
+++ b/movement/watch_faces/complication/rpn_calculator_alt_face.c
@@ -402,7 +402,7 @@ bool rpn_calculator_alt_face_loop(movement_event_t event, movement_settings_t *s
                 return false;
             }
             break;
-        case EVENT_LIGHT_BUTTON_UP:
+        case EVENT_LIGHT_BUTTON_DOWN:
             proposed_stack_size = s->stack_size - functions[s->fn_index].input;
 
             if (s->mode == CALC_NUMBER) {

--- a/movement/watch_faces/complication/rpn_calculator_face.c
+++ b/movement/watch_faces/complication/rpn_calculator_face.c
@@ -280,7 +280,7 @@ bool rpn_calculator_face_loop(movement_event_t event, movement_settings_t *setti
                 break;
             }
             break;
-        case EVENT_LIGHT_BUTTON_UP:
+        case EVENT_LIGHT_BUTTON_DOWN:
             switch (state->mode) {
                 case rpn_calculator_waiting:
                     state->mode = rpn_calculator_op;

--- a/movement/watch_faces/complication/sailing_face.c
+++ b/movement/watch_faces/complication/sailing_face.c
@@ -255,6 +255,9 @@ bool sailing_face_loop(movement_event_t event, movement_settings_t *settings, vo
             break;
         case EVENT_LOW_ENERGY_UPDATE:
             break;
+        case EVENT_LIGHT_BUTTON_DOWN:
+            // don't light up every time light is hit
+            break;
         default:
             movement_default_loop_handler(event, settings);
             break;

--- a/movement/watch_faces/complication/ships_bell_face.c
+++ b/movement/watch_faces/complication/ships_bell_face.c
@@ -92,12 +92,6 @@ bool ships_bell_face_loop(movement_event_t event, movement_settings_t *settings,
         case EVENT_TICK:
             ships_bell_draw(state);
             break;
-        case EVENT_MODE_BUTTON_UP:
-            movement_move_to_next_face();
-            break;
-        case EVENT_LIGHT_BUTTON_UP:
-            movement_illuminate_led();
-            break;
         case EVENT_ALARM_BUTTON_UP:
             state->bell_enabled = !state->bell_enabled;
             if (state->bell_enabled) watch_set_indicator(WATCH_INDICATOR_BELL);
@@ -122,6 +116,7 @@ bool ships_bell_face_loop(movement_event_t event, movement_settings_t *settings,
             }
             break;
         default:
+            movement_default_loop_handler(event, settings);
             break;
     }
 

--- a/movement/watch_faces/complication/tachymeter_face.c
+++ b/movement/watch_faces/complication/tachymeter_face.c
@@ -250,6 +250,9 @@ bool tachymeter_face_loop(movement_event_t event, movement_settings_t *settings,
             // You should also consider starting the tick animation, to show the wearer that this is sleep mode:
             // watch_start_tick_animation(500);
             break;
+        case EVENT_LIGHT_BUTTON_DOWN:
+            // don't light up every time light is hit
+            break;
         default:
             movement_default_loop_handler(event, settings);
             break;

--- a/movement/watch_faces/complication/tarot_face.c
+++ b/movement/watch_faces/complication/tarot_face.c
@@ -284,6 +284,9 @@ bool tarot_face_loop(movement_event_t event, movement_settings_t *settings, void
         case EVENT_LOW_ENERGY_UPDATE:
             watch_display_string("SLEEP ", 4);
             break;
+        case EVENT_LIGHT_BUTTON_DOWN:
+            // don't light up every time light is hit
+            break;
         default:
             movement_default_loop_handler(event, settings);
             break;

--- a/movement/watch_faces/complication/tomato_face.c
+++ b/movement/watch_faces/complication/tomato_face.c
@@ -142,7 +142,7 @@ bool tomato_face_loop(movement_event_t event, movement_settings_t *settings, voi
             }
             tomato_draw(state);
             break;
-        case EVENT_LIGHT_BUTTON_UP:
+        case EVENT_LIGHT_BUTTON_DOWN:
             movement_illuminate_led();
             if (state->mode == tomato_ready) {
                 if (state->kind == tomato_break) {

--- a/movement/watch_faces/complication/wake_face.c
+++ b/movement/watch_faces/complication/wake_face.c
@@ -149,6 +149,9 @@ bool wake_face_loop(movement_event_t event, movement_settings_t *settings, void 
         break;
     case EVENT_LOW_ENERGY_UPDATE:
         break;
+    case EVENT_LIGHT_BUTTON_DOWN:
+        // don't light up every time light is hit
+        break;
     default:
         movement_default_loop_handler(event, settings);
         break;

--- a/movement/watch_faces/demo/frequency_correction_face.c
+++ b/movement/watch_faces/demo/frequency_correction_face.c
@@ -96,7 +96,7 @@ bool frequency_correction_face_loop(movement_event_t event, movement_settings_t 
             break;
         case EVENT_TICK:
             break;
-        case EVENT_LIGHT_BUTTON_UP:
+        case EVENT_LIGHT_BUTTON_DOWN:
             freqcorr = RTC->MODE2.FREQCORR.reg;
             if (freqcorr < 127) {
                 RTC->MODE2.FREQCORR.reg++;

--- a/movement/watch_faces/sensor/accelerometer_data_acquisition_face.c
+++ b/movement/watch_faces/sensor/accelerometer_data_acquisition_face.c
@@ -214,6 +214,9 @@ bool accelerometer_data_acquisition_face_loop(movement_event_t event, movement_s
                 update_settings(state);
             }
             break;
+        case EVENT_LIGHT_BUTTON_DOWN:
+            // don't light up every time light is hit
+            break;
         default:
             movement_default_loop_handler(event, settings);
             break;

--- a/movement/watch_faces/settings/finetune_face.c
+++ b/movement/watch_faces/settings/finetune_face.c
@@ -238,6 +238,9 @@ bool finetune_face_loop(movement_event_t event, movement_settings_t *settings, v
             // watch_start_tick_animation(500);
             break;
 
+        case EVENT_LIGHT_BUTTON_DOWN:
+            // don't light up every time light is hit
+            break;
         default:
             movement_default_loop_handler(event, settings);
             break;

--- a/movement/watch_faces/settings/nanosec_face.c
+++ b/movement/watch_faces/settings/nanosec_face.c
@@ -364,6 +364,9 @@ bool nanosec_face_loop(movement_event_t event, movement_settings_t *settings, vo
 
             apply_RTC_correction(correction);
             break;
+        case EVENT_LIGHT_BUTTON_DOWN:
+            // don't light up every time light is hit
+            break;
         default:
             movement_default_loop_handler(event, settings);
             break;

--- a/movement/watch_faces/settings/set_time_face.c
+++ b/movement/watch_faces/settings/set_time_face.c
@@ -115,7 +115,7 @@ bool set_time_face_loop(movement_event_t event, movement_settings_t *settings, v
             _abort_quick_ticks();
             movement_move_to_next_face();
             return false;
-        case EVENT_LIGHT_BUTTON_UP:
+        case EVENT_LIGHT_BUTTON_DOWN:
             current_page = (current_page + 1) % SET_TIME_FACE_NUM_SETTINGS;
             *((uint8_t *)context) = current_page;
             break;

--- a/movement/watch_faces/settings/set_time_hackwatch_face.c
+++ b/movement/watch_faces/settings/set_time_hackwatch_face.c
@@ -200,6 +200,9 @@ bool set_time_hackwatch_face_loop(movement_event_t event, movement_settings_t *s
         case EVENT_TIMEOUT:
             movement_move_to_face(0);
             break;
+        case EVENT_LIGHT_BUTTON_DOWN:
+            // don't light up every time light is hit
+            break;
         default:
             movement_default_loop_handler(event, settings);
             break;


### PR DESCRIPTION
watch faces that handle EVENT_LIGHT_BUTTON_UP but not EVENT_LIGHT_BUTTON_DOWN probably don't want the default EVENT_LIGHT_BUTTON_DOWN LED activation behavior