### PR TITLE
Added option to use_iso_8601_weeknumber

### DIFF
--- a/watch-library/shared/watch/watch_utility.c
+++ b/watch-library/shared/watch/watch_utility.c
@@ -46,7 +46,11 @@ uint8_t watch_utility_get_weeknumber(uint16_t year, uint8_t month, uint8_t day) 
     uint8_t weekday;
     uint16_t days;
 
-    weekday = watch_utility_get_iso8601_weekday_number(year, month, day) % 7;
+    if (use_iso_8601_weeknumber == 1) {
+        weekday = ((watch_utility_get_iso8601_weekday_number(year, month, day) + 5) % 7) + 1;
+    } else {
+        weekday = watch_utility_get_iso8601_weekday_number(year, month, day) % 7;
+    }
     days = watch_utility_days_since_new_year(year, month, day);
 
 	int val = (days + 7U - (weekday+6U)%7) / 7;

--- a/watch-library/shared/watch/watch_utility.h
+++ b/watch-library/shared/watch/watch_utility.h
@@ -26,6 +26,11 @@
 #define _WATCH_UTILITY_H_INCLUDED
 ////< @file watch_utility.h
 
+/*
+ * Define use_iso_8601_weeknumber as 1 to let weeknumbers start on Monday, 0 to start on Sunday.
+ */
+#define use_iso_8601_weeknumber 0
+
 #include "watch.h"
 
 /** @addtogroup utility Utility Functions


### PR DESCRIPTION
As per our [discussion](https://github.com/joeycastillo/Sensor-Watch/discussions/181) I have added the use_iso_8601_weeknumber option. Not to the week clockace but to `watch_utility.h`.