### PR TITLE
movement: add custom hourly chime tunes

### DIFF
--- a/movement/movement.c
+++ b/movement/movement.c
@@ -292,9 +292,13 @@ void movement_request_wake() {
 }
 
 void movement_play_signal(void) {
+#ifdef SIGNAL_TUNE_DEFAULT
     watch_buzzer_play_note(BUZZER_NOTE_C8, 75);
     watch_buzzer_play_note(BUZZER_NOTE_REST, 100);
     watch_buzzer_play_note(BUZZER_NOTE_C8, 100);
+#else
+    watch_buzzer_play_sequence(signal_tune, NULL);
+#endif
 }
 
 void movement_play_alarm(void) {

--- a/movement/movement_custom_signal_tunes.h
+++ b/movement/movement_custom_signal_tunes.h
@@ -22,32 +22,40 @@
  * SOFTWARE.
  */
 
-#ifndef MOVEMENT_CONFIG_H_
-#define MOVEMENT_CONFIG_H_
+#ifndef MOVEMENT_CUSTOM_SIGNAL_TUNES_H_
+#define MOVEMENT_CUSTOM_SIGNAL_TUNES_H_
 
-#include "movement_faces.h"
-
-const watch_face_t watch_faces[] = {
-    simple_clock_face,
-    world_clock_face,
-    sunrise_sunset_face,
-    moon_phase_face,
-    stopwatch_face,
-    preferences_face,
-    set_time_face,
+#ifdef SIGNAL_TUNE_ZELDA_SECRET
+int8_t signal_tune[] = {
+    BUZZER_NOTE_G5, 10,
+    BUZZER_NOTE_F5SHARP_G5FLAT, 10,
+    BUZZER_NOTE_D5SHARP_E5FLAT, 10,
+    BUZZER_NOTE_A4, 10,
+    BUZZER_NOTE_G4SHARP_A4FLAT, 10,
+    BUZZER_NOTE_E5, 10,
+    BUZZER_NOTE_G5SHARP_A5FLAT, 10,
+    BUZZER_NOTE_C6, 10,
+    0
 };
+#endif // SIGNAL_TUNE_ZELDA_SECRET
 
-#define MOVEMENT_NUM_FACES (sizeof(watch_faces) / sizeof(watch_face_t))
+#ifdef SIGNAL_TUNE_MARIO_THEME
+int8_t signal_tune[] = {
+    BUZZER_NOTE_E6, 8,
+    BUZZER_NOTE_REST, 1,
+    BUZZER_NOTE_E6, 8,
+    BUZZER_NOTE_REST, 10,
+    BUZZER_NOTE_E6, 6,
+    BUZZER_NOTE_REST, 10,
+    BUZZER_NOTE_C6, 8,
+    BUZZER_NOTE_REST, 1,
+    BUZZER_NOTE_E6, 6,
+    BUZZER_NOTE_REST, 10,
+    BUZZER_NOTE_G6, 8,
+    BUZZER_NOTE_REST, 30,
+    BUZZER_NOTE_G5, 8,
+    0
+};
+#endif // SIGNAL_TUNE_MARIO_THEME
 
-/* Determines what face to go to from the first face if you've already set 
- * a mode long press to go to the first face in preferences, and
- * excludes these faces from the normal rotation.
- * Usually it makes sense to set this to the preferences face.
- */
-#define MOVEMENT_SECONDARY_FACE_INDEX 0 // or (MOVEMENT_NUM_FACES - 2)
-
-/* Custom hourly chime tune. Check movement_custom_signal_tunes.h for options */
-#define SIGNAL_TUNE_DEFAULT
-#include "movement_custom_signal_tunes.h"
-
-#endif // MOVEMENT_CONFIG_H_
+#endif // MOVEMENT_CUSTOM_SIGNAL_TUNES_H_


### PR DESCRIPTION
Default movement behavior is completely unchanged unless one of the SIGNAL_TUNE_* defines are used. Battery impact is currently unknown, but the tunes are at least short (less than ~3 seconds long).