### PR TITLE
Some kind of serial buffering fix

### DIFF
--- a/movement/filesystem.c
+++ b/movement/filesystem.c
@@ -223,7 +223,6 @@ bool filesystem_append_file(char *filename, char *text, int32_t length) {
 }
 
 void filesystem_process_command(char *line) {
-    printf("$ %s", line);
     char *command = strtok(line, " \n");
     
     if (strcmp(command, "ls") == 0) {


### PR DESCRIPTION
Addresses #117 

Removes the intermediate buffer entirely and make movement.c responsible for calling read. I'm not sure if anything bad happens if you _don't_ call tud_cdc_n_read, and this PR has problems with the initial display of '$' that I'm not sure how to work around well.

I'm raising it as a draft for comment since I lack confidence in its sanity.