### PR TITLE
Make emulator compatible with emscripten version 3.1.35 

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -19,6 +19,7 @@ $(BUILD)/$(BIN).html: $(OBJS)
 	@$(CC) $(LDFLAGS) $(OBJS) $(LIBS) -o $@ \
 		-s ASYNCIFY=1 \
 		-s EXPORTED_FUNCTIONS=_main \
+		-s EXPORTED_RUNTIME_METHODS=lengthBytesUTF8 \
 		--shell-file=$(TOP)/watch-library/simulator/shell.html
 
 $(BUILD)/$(BIN).elf: $(OBJS)


### PR DESCRIPTION
After updating emscripten recently I found that the emulator would consistently hang and throw console error `lengthBytesUTF8 is not a function` .

After trying a few different versions of emscripten and narrowing the issue down to version 3.1.35, I found the following in ChangeLog.md:
```
- The following JavaScript runtime functions were converted to JavaScript
  library functions:
   - UTF8ArrayToString
   - UTF8ToString
   - stringToUTF8Array
   - stringToUTF8
   - lengthBytesUTF8
```
(Hindsight is 20/20 after all)

`lengthBytesUTF8()` appears in movement.c:531
alongside `stringToUTF8()` on line 533.
I don't know why only `lengthBytesUTF8` threw an error and not `stringToUTF8`, which makes me mildly uneasy.

But hopefully at least this PR can point someone more knowledgeable than me in the right direction if it doesn't hit the mark.

I'm also not familiar with emscripten so please scrutinise my approach and feel free to edit/reject this as needed. 👍