### PR TITLE
simple watch binary light: show current time by flashing the LED as binary code

### DIFF
--- a/movement/make/Makefile
+++ b/movement/make/Makefile
@@ -114,6 +114,7 @@ SRCS += \
   ../watch_faces/complication/randonaut_face.c \
   ../watch_faces/complication/toss_up_face.c \
   ../watch_faces/complication/geomancy_face.c \
+  ../watch_faces/clock/simple_clock_bin_led_face.c \
 # New watch faces go above this line.
 
 # Leave this line at the bottom of the file; it has all the targets for making your project.

--- a/movement/movement_faces.h
+++ b/movement/movement_faces.h
@@ -91,6 +91,7 @@
 #include "toss_up_face.h"
 #include "geomancy_face.h"
 #include "dual_timer_face.h"
+#include "simple_clock_bin_led_face.h"
 // New includes go above this line.
 
 #endif // MOVEMENT_FACES_H_

--- a/movement/watch_faces/clock/simple_clock_bin_led_face.c
+++ b/movement/watch_faces/clock/simple_clock_bin_led_face.c
@@ -1,0 +1,232 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Andreas Nebinger, based on Joey Castillo's simple clock face
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "simple_clock_bin_led_face.h"
+#include "watch.h"
+#include "watch_utility.h"
+#include "watch_private_display.h"
+
+static void _update_alarm_indicator(bool settings_alarm_enabled, simple_clock_bin_led_state_t *state) {
+    state->alarm_enabled = settings_alarm_enabled;
+    if (state->alarm_enabled) watch_set_indicator(WATCH_INDICATOR_SIGNAL);
+    else watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
+}
+
+static void _display_left_aligned(uint8_t value) {
+    if (value >= 10) {
+        watch_display_character('0' + value / 10, 4);
+        watch_display_character('0' + value % 10, 5);
+    } else {
+        watch_display_character('0' + value, 4);
+        watch_display_character(' ', 5);
+    }
+}
+
+void simple_clock_bin_led_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {
+    (void) settings;
+    if (*context_ptr == NULL) {
+        *context_ptr = malloc(sizeof(simple_clock_bin_led_state_t));
+        memset(*context_ptr, 0, sizeof(simple_clock_bin_led_state_t));
+        simple_clock_bin_led_state_t *state = (simple_clock_bin_led_state_t *)*context_ptr;
+        state->watch_face_index = watch_face_index;
+    }
+}
+
+void simple_clock_bin_led_face_activate(movement_settings_t *settings, void *context) {
+    simple_clock_bin_led_state_t *state = (simple_clock_bin_led_state_t *)context;
+
+    if (watch_tick_animation_is_running()) watch_stop_tick_animation();
+
+    if (settings->bit.clock_mode_24h) watch_set_indicator(WATCH_INDICATOR_24H);
+
+    // handle chime indicator
+    if (state->signal_enabled) watch_set_indicator(WATCH_INDICATOR_BELL);
+    else watch_clear_indicator(WATCH_INDICATOR_BELL);
+
+    // show alarm indicator if there is an active alarm
+    _update_alarm_indicator(settings->bit.alarm_enabled, state);
+
+    watch_set_colon();
+
+    // this ensures that none of the timestamp fields will match, so we can re-render them all.
+    state->previous_date_time = 0xFFFFFFFF;
+}
+
+bool simple_clock_bin_led_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
+    simple_clock_bin_led_state_t *state = (simple_clock_bin_led_state_t *)context;
+    char buf[11];
+    uint8_t pos;
+
+    watch_date_time date_time;
+    uint32_t previous_date_time;
+    switch (event.event_type) {
+        case EVENT_ACTIVATE:
+        case EVENT_TICK:
+        case EVENT_LOW_ENERGY_UPDATE:
+            date_time = watch_rtc_get_date_time();
+            if (state->flashing_state > 0) {
+                if (state->ticks) {
+                    state->ticks--;
+                } else {
+                    
+                    if (state->flashing_state & 64) {
+                        // start led on for current bit
+                        state->flashing_state &= 63;
+                        state->ticks = (state->flashing_value & 1 ? 7 : 1);
+                        movement_illuminate_led();
+                    } else {
+                        // indicate first or switch to next bit
+                        watch_set_led_off();
+                        if ((state->flashing_state & 128) == 0) state->flashing_value = state->flashing_value >> 1;
+                        if (state->flashing_value || (state->flashing_state & 128)) {
+                            state->flashing_state &= 127;
+                            state->flashing_state |= 64;
+                            state->ticks = 6;
+                        } else if (state->flashing_state & 1) {
+                            // transition to minutes
+                            state->flashing_state = 2 + 128;
+                            state->flashing_value = date_time.unit.minute;
+                            _display_left_aligned(state->flashing_value);
+                            state->ticks = 9;
+                        } else {
+                            // end flashing
+                            state->flashing_state = 0;
+                            state->previous_date_time = 0xFFFFFFFF;
+                            movement_request_tick_frequency(1);
+                            watch_set_colon();
+                        }
+                    }
+                }
+            } else {
+                previous_date_time = state->previous_date_time;
+                state->previous_date_time = date_time.reg;
+
+                // check the battery voltage once a day...
+                if (date_time.unit.day != state->last_battery_check) {
+                    state->last_battery_check = date_time.unit.day;
+                    watch_enable_adc();
+                    uint16_t voltage = watch_get_vcc_voltage();
+                    watch_disable_adc();
+                    // 2.2 volts will happen when the battery has maybe 5-10% remaining?
+                    // we can refine this later.
+                    state->battery_low = (voltage < 2200);
+                }
+
+                // ...and set the LAP indicator if low.
+                if (state->battery_low) watch_set_indicator(WATCH_INDICATOR_LAP);
+
+                if ((date_time.reg >> 6) == (previous_date_time >> 6) && event.event_type != EVENT_LOW_ENERGY_UPDATE) {
+                    // everything before seconds is the same, don't waste cycles setting those segments.
+                    watch_display_character_lp_seconds('0' + date_time.unit.second / 10, 8);
+                    watch_display_character_lp_seconds('0' + date_time.unit.second % 10, 9);
+                    break;
+                } else if ((date_time.reg >> 12) == (previous_date_time >> 12) && event.event_type != EVENT_LOW_ENERGY_UPDATE) {
+                    // everything before minutes is the same.
+                    pos = 6;
+                    sprintf(buf, "%02d%02d", date_time.unit.minute, date_time.unit.second);
+                } else {
+                    // other stuff changed; let's do it all.
+                    if (!settings->bit.clock_mode_24h) {
+                        // if we are in 12 hour mode, do some cleanup.
+                        if (date_time.unit.hour < 12) {
+                            watch_clear_indicator(WATCH_INDICATOR_PM);
+                        } else {
+                            watch_set_indicator(WATCH_INDICATOR_PM);
+                        }
+                        date_time.unit.hour %= 12;
+                        if (date_time.unit.hour == 0) date_time.unit.hour = 12;
+                    }
+                    pos = 0;
+                    if (event.event_type == EVENT_LOW_ENERGY_UPDATE) {
+                        if (!watch_tick_animation_is_running()) watch_start_tick_animation(500);
+                        sprintf(buf, "%s%2d%2d%02d  ", watch_utility_get_weekday(date_time), date_time.unit.day, date_time.unit.hour, date_time.unit.minute);
+                    } else {
+                        sprintf(buf, "%s%2d%2d%02d%02d", watch_utility_get_weekday(date_time), date_time.unit.day, date_time.unit.hour, date_time.unit.minute, date_time.unit.second);
+                    }
+                }
+                watch_display_string(buf, pos);
+                // handle alarm indicator
+                if (state->alarm_enabled != settings->bit.alarm_enabled) _update_alarm_indicator(settings->bit.alarm_enabled, state);
+            }
+            break;
+        case EVENT_ALARM_LONG_PRESS:
+            state->signal_enabled = !state->signal_enabled;
+            if (state->signal_enabled) watch_set_indicator(WATCH_INDICATOR_BELL);
+            else watch_clear_indicator(WATCH_INDICATOR_BELL);
+            break;
+        case EVENT_BACKGROUND_TASK:
+            // uncomment this line to snap back to the clock face when the hour signal sounds:
+            // movement_move_to_face(state->watch_face_index);
+            if (watch_is_buzzer_or_led_enabled()) {
+                // if we are in the foreground, we can just beep.
+                movement_play_signal();
+            } else {
+                // if we were in the background, we need to enable the buzzer peripheral first,
+                watch_enable_buzzer();
+                // beep quickly (this call blocks for 275 ms),
+                movement_play_signal();
+                // and then turn the buzzer peripheral off again.
+                watch_disable_buzzer();
+            }
+            break;
+        case EVENT_LIGHT_LONG_PRESS:
+            if (state->flashing_state == 0) {
+                date_time = watch_rtc_get_date_time();
+                state->flashing_state = 1 + 128;
+                state->ticks = 4;
+                if (!settings->bit.clock_mode_24h) {
+                    date_time.unit.hour %= 12;
+                    if (date_time.unit.hour == 0) date_time.unit.hour = 12;
+                }
+                watch_display_string("      ", 4);
+                _display_left_aligned(date_time.unit.hour);
+                state->flashing_value = date_time.unit.hour > 12 ? date_time.unit.hour - 12 : date_time.unit.hour;
+                watch_set_led_off();
+                watch_clear_colon();
+                movement_request_tick_frequency(8);
+            }
+            break;
+        default:
+            return movement_default_loop_handler(event, settings);
+    }
+
+    return true;
+}
+
+void simple_clock_bin_led_face_resign(movement_settings_t *settings, void *context) {
+    (void) settings;
+    (void) context;
+}
+
+bool simple_clock_bin_led_face_wants_background_task(movement_settings_t *settings, void *context) {
+    (void) settings;
+    simple_clock_bin_led_state_t *state = (simple_clock_bin_led_state_t *)context;
+    if (!state->signal_enabled) return false;
+
+    watch_date_time date_time = watch_rtc_get_date_time();
+
+    return date_time.unit.minute == 0;
+}

--- a/movement/watch_faces/clock/simple_clock_bin_led_face.h
+++ b/movement/watch_faces/clock/simple_clock_bin_led_face.h
@@ -1,0 +1,80 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Andreas Nebinger, based on Joey Castillo's simple clock face
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef SIIMPLE_CLOCK_BIN_LED_FACE_H_
+#define SIIMPLE_CLOCK_BIN_LED_FACE_H_
+
+#include "movement.h"
+
+/*
+ * A "fork" of the simple clock face, which provides the functionality of showing 
+ * the current time by flashing the LED using binary representation.
+ *
+ * This feature serves as a practical solution to compensate for the admittedly 
+ * subpar backlight of the F91w watch and is especially useful if your eyesight
+ * is not the best. By pressing and holding the light button long enough, the
+ * watch will illuminate the LED to showcase the current time.
+ *
+ * How to interpret the flashing led:
+ * - Firstly, the hour is presented as a binary number, with the lowest bit displayed
+ *   first. A short flash signifies 0, while a longer flash represents 1. If you use
+ *   the watch in 24h mode, please note that the indicated value may be decreased 
+ *   by 12, to keep things simple and short. For example, 22h would be translated
+ *   to 10h.
+ * - After showing the hour, a lengthier  pause indicates that minutes will be shown 
+ *   next.
+ * - Similar to the hour representation, minutes are displayed in binary format, 
+ *   starting with the lowest bits. A short flash denotes 0, a longer flash 
+ *   represents 1.
+ */
+
+typedef struct {
+    uint32_t previous_date_time;
+    uint8_t last_battery_check;
+    uint8_t watch_face_index;
+    bool signal_enabled;
+    bool battery_low;
+    bool alarm_enabled;
+    uint8_t flashing_state; // bitmap representing the flashing state. Bit 0 = hours showing, bit 1 = minutes showing,
+                            // bit 6 = short break between flashing bits, bit 7 = long break between hours and minutes
+    uint8_t flashing_value;
+    uint8_t ticks;
+} simple_clock_bin_led_state_t;
+
+void simple_clock_bin_led_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr);
+void simple_clock_bin_led_face_activate(movement_settings_t *settings, void *context);
+bool simple_clock_bin_led_face_loop(movement_event_t event, movement_settings_t *settings, void *context);
+void simple_clock_bin_led_face_resign(movement_settings_t *settings, void *context);
+bool simple_clock_bin_led_face_wants_background_task(movement_settings_t *settings, void *context);
+
+#define simple_clock_bin_led_face ((const watch_face_t){ \
+    simple_clock_bin_led_face_setup, \
+    simple_clock_bin_led_face_activate, \
+    simple_clock_bin_led_face_loop, \
+    simple_clock_bin_led_face_resign, \
+    simple_clock_bin_led_face_wants_background_task, \
+})
+
+#endif // SIIMPLE_CLOCK_BIN_LED_FACE_H_
+


### PR DESCRIPTION
This is a "fork" of the simple clock face, which provides the functionality of showing the current time by flashing the LED using binary representation.

This serves as a practical solution to compensate for the weak backlight of the F91w and can also be useful if your eyesight is not the best. By pressing and holding the light button long enough, the watch will illuminate the LED to showcase the current time.

How to interpret the flashing led:

- Firstly, the hour is presented as a binary number, with the lowest bit displayed first. A short flash signifies 0, while a longer flash represents 1. If you use the watch in 24h mode, please note that the indicated value may be decreased by 12, to keep things simple and short. For example, 22h would be translated to 10h.
- After showing the hour, a lengthier pause indicates that minutes will be shown next.
- Similar to the hour representation, minutes are displayed in binary format, starting with the lowest bits. A short flash denotes 0, a longer flash represents 1.

Side note: There seems to be a problem with the simulator. At least for me, it is only possible to check the functionality one time. After going through the flashing sequence once, the simulator does not react to any buttons any more, and you have to reload the page. This, of course, is only related to the simulator and does not affect the functionality on hardware.