### PR TITLE
Fix lengthBytesUTF8 not a function

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -18,7 +18,7 @@ $(BUILD)/$(BIN).html: $(OBJS)
 	@echo HTML $@
 	@$(CC) $(LDFLAGS) $(OBJS) $(LIBS) -o $@ \
 		-s ASYNCIFY=1 \
-		-s EXPORTED_RUNTIME_METHODS=lengthBytesUTF8 \
+		-s EXPORTED_RUNTIME_METHODS=lengthBytesUTF8,printErr \
 		-s EXPORTED_FUNCTIONS=_main \
 		--shell-file=$(TOP)/watch-library/simulator/shell.html
 

--- a/rules.mk
+++ b/rules.mk
@@ -18,6 +18,7 @@ $(BUILD)/$(BIN).html: $(OBJS)
 	@echo HTML $@
 	@$(CC) $(LDFLAGS) $(OBJS) $(LIBS) -o $@ \
 		-s ASYNCIFY=1 \
+		-s EXPORTED_RUNTIME_METHODS=lengthBytesUTF8 \
 		-s EXPORTED_FUNCTIONS=_main \
 		--shell-file=$(TOP)/watch-library/simulator/shell.html
 


### PR DESCRIPTION
I was not able to run the simulator due to `lengthBytesUTF8 not a function` error in the console being spammed. Related: https://github.com/emscripten-core/emscripten/issues/16098

I do not know what caused this error, but someone in discord had the same problem so might be more widespread than just myself.