### PR TITLE
Wyoscan .5 hz watchface

### DIFF
--- a/movement/make/Makefile
+++ b/movement/make/Makefile
@@ -116,6 +116,7 @@ SRCS += \
   ../watch_faces/complication/geomancy_face.c \
   ../watch_faces/clock/simple_clock_bin_led_face.c \
   ../watch_faces/complication/flashlight_face.c \
+  ../watch_faces/clock/wyoscan_face.c \
 # New watch faces go above this line.
 
 # Leave this line at the bottom of the file; it has all the targets for making your project.

--- a/movement/movement_config.h
+++ b/movement/movement_config.h
@@ -28,6 +28,7 @@
 #include "movement_faces.h"
 
 const watch_face_t watch_faces[] = {
+    wyoscan_face,
     simple_clock_face,
     world_clock_face,
     sunrise_sunset_face,

--- a/movement/movement_config.h
+++ b/movement/movement_config.h
@@ -28,7 +28,6 @@
 #include "movement_faces.h"
 
 const watch_face_t watch_faces[] = {
-    wyoscan_face,
     simple_clock_face,
     world_clock_face,
     sunrise_sunset_face,

--- a/movement/movement_faces.h
+++ b/movement/movement_faces.h
@@ -93,6 +93,7 @@
 #include "dual_timer_face.h"
 #include "simple_clock_bin_led_face.h"
 #include "flashlight_face.h"
+#include "wyoscan_face.h"
 // New includes go above this line.
 
 #endif // MOVEMENT_FACES_H_

--- a/movement/watch_faces/clock/wyoscan_face.c
+++ b/movement/watch_faces/clock/wyoscan_face.c
@@ -46,13 +46,13 @@ You and your watch are now in tune.
 
 
 static char *segment_map[] = {
-    "AFBGECD",  // 0
+    "AFBECD",  // 0
     "BC",       // 1
     "ABGED",    // 2
     "ABGCD",    // 3
     "FGBC",     // 4
     "AFGCD",    // 5
-    "AFGEDC",   // 6
+    "AFGECD",   // 6
     "ABC",      // 7
     "AFBGECD",  // 8
     "AFBGCD"    // 9
@@ -125,7 +125,7 @@ bool wyoscan_face_loop(movement_event_t event, movement_settings_t *settings, vo
                 state->start = 0; 
                 state->end = 0;
                 state->animation = 0;
-                state->total_frames = 7 * 6 + MAX_ILLUMINATED_SEGMENTS;
+                state->total_frames = 7 * 3 + 6 * 3 + MAX_ILLUMINATED_SEGMENTS;
                 state->animate = true;
                 state->time_digits[0] = date_time.unit.hour / 10;
                 state->time_digits[1] = date_time.unit.hour % 10;

--- a/movement/watch_faces/clock/wyoscan_face.c
+++ b/movement/watch_faces/clock/wyoscan_face.c
@@ -107,7 +107,7 @@ void wyoscan_face_setup(movement_settings_t *settings, uint8_t watch_face_index,
 }
 
 void wyoscan_face_activate(movement_settings_t *settings, void *context) {
-    movement_request_tick_frequency(32);
+    movement_request_tick_frequency(16);
 }
 
 uint8_t i;

--- a/movement/watch_faces/clock/wyoscan_face.c
+++ b/movement/watch_faces/clock/wyoscan_face.c
@@ -26,14 +26,6 @@
 #include <string.h>
 #include "wyoscan_face.h"
 #include "watch_private_display.h"
-#if __EMSCRIPTEN__
-#include <emscripten.h>
-#include <emscripten/html5.h>
-#else
-#include "../../../watch-library/hardware/include/saml22j18a.h"
-#include "../../../watch-library/hardware/include/component/tc.h"
-#include "../../../watch-library/hardware/hri/hri_tc_l22.h"
-#endif
 
 /*
 Slowly render the current time from left to right, 
@@ -46,22 +38,43 @@ You’ll notice that reading this watch requires more attention than usual,
 as the seven segments of each digit are lit one by one across its display. 
 This speed may be adjusted until it reaches the limits of your perception. 
 You and your watch are now in tune.
+
+This is a relatively generic way of animating a time display.
+If you want to modify the animation, you can change the segment_map
+the A-F are corresponding to the segments on the watch face
+  A  
+F   B
+  G
+E   C
+  D
+the X's are the frames that will be skipped in the animation
+This particular segment_map allocates 8 frames to display each number
+this is to achieve the 2 second cycle time.
+8 frames per number * 6 numbers + the trailing 16 frames = 64 frames
+at 32 frames per second, this is a 2 second cycle time.
+
+I tried to make the animation of each number display similar to if you were 
+to draw the number on the watch face with a pen, pausing with 'X'
+when your pen might turn a corner or when you might cross over 
+a line you've already drawn. It is vaguely top to bottom and counter,
+clockwise when possible.
 */
-
-
 static char *segment_map[] = {
-    "AFBECD",  // 0
-    "BC",       // 1
-    "ABGED",    // 2
-    "ABGCD",    // 3
-    "FGBC",     // 4
-    "AFGCD",    // 5
-    "AFGECD",   // 6
-    "ABC",      // 7
-    "AFBGECD",  // 8
-    "AFBGCD"    // 9
+    "AXFEDCBX",  // 0
+    "BXXXCXXX",  // 1
+    "ABGEXXXD",  // 2
+    "ABGXXXCD",  // 3
+    "FXGBXXXC",  // 4
+    "AXFXGXCD",  // 5
+    "AXFEDCXG",  // 6
+    "AXXBXXCX",  // 7
+    "AFGCDEXB",  // 8
+    "AFGBXXCD"   // 9
 };
 
+/*
+This is the mapping of input to the watch_set_pixel() function
+for each position in hhmmss it defines the 2 dimention input at each of A-F*/
 static const int32_t clock_mapping[6][7][2] = {
     // hour 1
     {{1,18}, {2,19}, {0,19}, {1,18}, {0,18}, {2,18}, {1,19}},
@@ -77,46 +90,6 @@ static const int32_t clock_mapping[6][7][2] = {
     {{2,4}, {2,5}, {1,6}, {0,6}, {0,5}, {1,4}, {1,5}},
 };
 
-static bool colon_state;
-static long colon_interval_id = -1;
-
-#if __EMSCRIPTEN__
-
-static void watch_invoke_colon_callback(void *userData) {
-    (void) userData;
-    colon_state = !colon_state;
-    if (colon_state) {
-        watch_set_colon();
-    } else {
-        watch_clear_colon();
-    }
-}
-
-static bool watch_colon_animation_is_running(void) {
-    return colon_interval_id != -1;
-}
-
-static void watch_start_colon_animation(uint32_t duration) {
-    if (colon_interval_id != -1) return;
-    colon_state = true;
-    colon_interval_id = emscripten_set_interval(watch_invoke_colon_callback, (double)duration, NULL);
-}
-
-#else
-
-static void watch_start_colon_animation(uint32_t duration) {
-    watch_set_colon();
-    const uint32_t segs[] = { SLCD_SEGID(1, 16)};
-    slcd_sync_start_animation(&SEGMENT_LCD_0, segs, 1, duration);
-}
-
-static bool watch_colon_animation_is_running(void) {
-    return hri_slcd_get_CTRLD_CSREN_bit(SLCD);
-}
-
-#endif
-
-
 void wyoscan_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {
     (void) settings;
     if (*context_ptr == NULL) {
@@ -128,10 +101,9 @@ void wyoscan_face_setup(movement_settings_t *settings, uint8_t watch_face_index,
 }
 
 void wyoscan_face_activate(movement_settings_t *settings, void *context) {
+    wyoscan_state_t *state = (wyoscan_state_t *)context;
     movement_request_tick_frequency(32);
-    if (!watch_colon_animation_is_running()) {
-        watch_start_colon_animation(1000);
-    }
+    state->total_frames = 64;
 }
 
 bool wyoscan_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
@@ -147,7 +119,6 @@ bool wyoscan_face_loop(movement_event_t event, movement_settings_t *settings, vo
                 state->start = 0; 
                 state->end = 0;
                 state->animation = 0;
-                state->total_frames = 7 * 3 + 6 * 3 + MAX_ILLUMINATED_SEGMENTS;
                 state->animate = true;
                 state->time_digits[0] = date_time.unit.hour / 10;
                 state->time_digits[1] = date_time.unit.hour % 10;
@@ -157,39 +128,59 @@ bool wyoscan_face_loop(movement_event_t event, movement_settings_t *settings, vo
                 state->time_digits[5] = date_time.unit.second % 10;
             }
             if ( state->animate ) {
+                // if we have reached the max number of illuminated segments, we clear the oldest one
+                if ((state->end + 1) % MAX_ILLUMINATED_SEGMENTS == state->start) {
+                    // clear the oldest pixel if it's not 'X'
+                    if (state->illuminated_segments[state->start][0] != 99 && state->illuminated_segments[state->start][1] != 99) {
+                        watch_clear_pixel(state->illuminated_segments[state->start][0], state->illuminated_segments[state->start][1]);
+                    }
+                    // increment the start index to point to the next oldest pixel
+                    state->start = (state->start + 1) % MAX_ILLUMINATED_SEGMENTS;
+                }
                 if (state->animation < state->total_frames - MAX_ILLUMINATED_SEGMENTS) {
+                    if (state->animation % 32 == 0) {
+                        if (state->colon) {
+                            watch_set_colon();
+                        } else {
+                            watch_clear_colon();
+                        }
+                        state->colon = !state->colon;
+                    }
+                    
                     // calculate the start position for the current frame
-                    state->position = (state->animation / 7) % 6;
+                    state->position = (state->animation / 8) % 6;
                     // calculate the current segment for the current digit
                     state->segment = state->animation % strlen(segment_map[state->time_digits[state->position]]);
                     // get the segments for the current digit
                     state->segments = segment_map[state->time_digits[state->position]];
+                    
+                    if (state->segments[state->segment] == 'X') {
+                        // if 'X', skip this frame
+                        state->illuminated_segments[state->end][0] = 99;
+                        state->illuminated_segments[state->end][1] = 99;
+                        state->end = (state->end + 1) % MAX_ILLUMINATED_SEGMENTS;
+                        state->animation = (state->animation + 1);
+                        break;
+                    }
+
                     // calculate the animation frame
                     state->x = clock_mapping[state->position][state->segments[state->segment]-'A'][0];
                     state->y = clock_mapping[state->position][state->segments[state->segment]-'A'][1];
                     
-                    // if we have reached the max number of illuminated segments, we clear the oldest one
-                    if ((state->end + 1) % MAX_ILLUMINATED_SEGMENTS == state->start) {
-                        // clear the oldest pixel
-                        watch_clear_pixel(state->illuminated_segments[state->start][0], state->illuminated_segments[state->start][1]);
-                        // increment the start index to point to the next oldest pixel
-                        state->start = (state->start + 1) % MAX_ILLUMINATED_SEGMENTS;
-                    }
-                    
                     // set the new pixel
                     watch_set_pixel(state->x, state->y);
+                    
                     // store this pixel in the buffer
                     state->illuminated_segments[state->end][0] = state->x;
                     state->illuminated_segments[state->end][1] = state->y;
                     // increment the end index to the next position
                     state->end = (state->end + 1) % MAX_ILLUMINATED_SEGMENTS;
-                } else if (state->animation < state->total_frames) {
-                    // clear the oldest pixel
-                    watch_clear_pixel(state->illuminated_segments[state->start][0], state->illuminated_segments[state->start][1]);
-                    // increment the start index to point to the next oldest pixel
-                    state->start = (state->start + 1) % MAX_ILLUMINATED_SEGMENTS;
-                } else {
-                    // reset the animation state and request for tick frequency 1
+                } 
+                else if (state->animation >= state->total_frames - MAX_ILLUMINATED_SEGMENTS && state->animation < state->total_frames) {
+                    state->end = (state->end + 1) % MAX_ILLUMINATED_SEGMENTS;
+                }
+                else {
+                    // reset the animation state
                     state->animate = false;
                 }
                 state->animation = (state->animation + 1);

--- a/movement/watch_faces/clock/wyoscan_face.c
+++ b/movement/watch_faces/clock/wyoscan_face.c
@@ -25,6 +25,122 @@
 #include <stdlib.h>
 #include <string.h>
 #include "wyoscan_face.h"
+#include "watch_private_display.h"
+#include <emscripten.h>
+#include <emscripten/html5.h>
+
+/*
+Slowly render the current time from left to right, 
+scanning across its liquid crystal face, completing 1 cycle every 2 seconds.
+
+Created to mimic the wyoscan watch that was produced by Halmos and designed by Dexter Sinister
+
+You’ll notice that reading this watch requires more attention than usual, 
+as the seven segments of each digit are lit one by one across its display. 
+This speed may be adjusted until it reaches the limits of your perception. 
+You and your watch are now in tune.
+*/
+
+
+char *segment_map[] = {
+    "AFBGECD",  // 0
+    "BC",       // 1
+    "ABGED",    // 2
+    "ABGCD",    // 3
+    "FGBC",     // 4
+    "AFGCD",    // 5
+    "AFGEDC",   // 6
+    "ABC",      // 7
+    "AFBGECD",  // 8
+    "AFBGCD"    // 9
+};
+uint32_t clock_mapping[6][7][2] = {
+    // hour 1
+    {{1,18}, {2,19}, {0,19}, {1,18}, {0,18}, {2,18}, {1,19}},
+    // hour 2
+    {{2,20}, {2,21}, {1,21}, {0,21}, {0,20}, {1,17}, {1,20}},
+    // minute 1
+    {{0,22}, {2,23}, {0,23}, {0,22}, {1,22}, {2,22}, {1,23}},
+    // minute 2
+    {{2,1}, {2,10}, {0,1}, {0,0}, {1,0}, {2,0}, {1,1}},
+    // second 1
+    {{2,2}, {2,3}, {0,4}, {0,3}, {0,2}, {1,2}, {1,3}},
+    // second 2
+    {{2,2}, {2,3}, {0,4}, {0,6}, {0,5}, {1,4}, {1,5}},
+};
+
+static bool colon_state;
+static long colon_interval_id = -1;
+
+static void _wyoscan_animation(wyoscan_state_t *state) {
+    uint32_t position, segment;
+    char *segments;
+    state->start = 0, 
+    state->end = 0;     
+    
+    // Calculate total_frames
+    state->total_frames += MAX_ILLUMINATED_SEGMENTS; // for clearing
+    
+    movement_request_tick_frequency(16);
+    
+    if (state->animation < state->total_frames - MAX_ILLUMINATED_SEGMENTS) {
+        // calculate the start position for the current frame
+        position = (state->animation / 7) % 6;
+        // calculate the current segment for the current digit
+        segment = state->animation % strlen(segment_map[state->time_digits[position]]);
+        // get the segments for the current digit
+        segments = segment_map[state->time_digits[position]];
+        // calculate the animation frame
+        uint32_t x = clock_mapping[position][segments[segment]-'A'][0];
+        uint32_t y = clock_mapping[position][segments[segment]-'A'][1];
+        
+        // if we have reached the max number of illuminated segments, we clear the oldest one
+        if ((state->end + 1) % MAX_ILLUMINATED_SEGMENTS == state->start) {
+            // clear the oldest pixel
+            watch_clear_pixel(state->illuminated_segments[state->start][0], state->illuminated_segments[state->start][1]);
+            // increment the start index to point to the next oldest pixel
+            state->start = (state->start + 1) % MAX_ILLUMINATED_SEGMENTS;
+        }
+        
+        // set the new pixel
+        watch_set_pixel(x, y);
+        // store this pixel in the buffer
+        state->illuminated_segments[state->end][0] = x;
+        state->illuminated_segments[state->end][1] = y;
+        // increment the end index to the next position
+        state->end = (state->end + 1) % MAX_ILLUMINATED_SEGMENTS;
+    } else if (state->animation < state->total_frames) {
+        // clear the oldest pixel
+        watch_clear_pixel(state->illuminated_segments[state->start][0], state->illuminated_segments[state->start][1]);
+        // increment the start index to point to the next oldest pixel
+        state->start = (state->start + 1) % MAX_ILLUMINATED_SEGMENTS;
+    } else {
+        // reset the animation state and request for tick frequency 1
+        state->animation = 0;
+        state->animate = false;
+    }
+}
+
+static void watch_invoke_colon_callback(void *userData) {
+    colon_state = !colon_state;
+    if (colon_state) {
+        watch_set_colon();
+    } else {
+        watch_clear_colon();
+    }
+}
+
+static bool watch_colon_animation_is_running(void) {
+    return colon_interval_id != -1;
+}
+
+static void watch_start_colon_animation(uint32_t duration) {
+    if (colon_interval_id != -1) return;
+    watch_display_character(' ', 8);
+
+    colon_state = true;
+    colon_interval_id = emscripten_set_interval(watch_invoke_colon_callback, (double)duration, NULL);
+}
 
 void wyoscan_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {
     (void) settings;
@@ -37,56 +153,48 @@ void wyoscan_face_setup(movement_settings_t *settings, uint8_t watch_face_index,
 }
 
 void wyoscan_face_activate(movement_settings_t *settings, void *context) {
-    (void) settings;
-    wyoscan_state_t *state = (wyoscan_state_t *)context;
+    // wyoscan_state_t *state = (wyoscan_state_t *)context;
 
-    // Handle any tasks related to your watch face coming on screen.
 }
 
 bool wyoscan_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
     wyoscan_state_t *state = (wyoscan_state_t *)context;
 
+    watch_date_time date_time;
     switch (event.event_type) {
         case EVENT_ACTIVATE:
-            // Show your initial UI here.
-            break;
         case EVENT_TICK:
-            // If needed, update your display here.
-            break;
-        case EVENT_LIGHT_BUTTON_UP:
-            // You can use the Light button for your own purposes. Note that by default, Movement will also
-            // illuminate the LED in response to EVENT_LIGHT_BUTTON_DOWN; to suppress that behavior, add an
-            // empty case for EVENT_LIGHT_BUTTON_DOWN.
-            break;
-        case EVENT_ALARM_BUTTON_UP:
-            // Just in case you have need for another button.
-            break;
-        case EVENT_TIMEOUT:
-            // Your watch face will receive this event after a period of inactivity. If it makes sense to resign,
-            // you may uncomment this line to move back to the first watch face in the list:
-            // movement_move_to_face(0);
+            if ( state->animate ) {
+                _wyoscan_animation(state);
+                state->animation = (state->animation + 1);
+            } 
             break;
         case EVENT_LOW_ENERGY_UPDATE:
-            // If you did not resign in EVENT_TIMEOUT, you can use this event to update the display once a minute.
-            // Avoid displaying fast-updating values like seconds, since the display won't update again for 60 seconds.
-            // You should also consider starting the tick animation, to show the wearer that this is sleep mode:
-            // watch_start_tick_animation(500);
+            date_time = watch_rtc_get_date_time();
+            int i=0;
+            if (date_time.unit.second % 2 && !state->animate) {
+                state->total_frames = 0;
+                for(i = 0; i < 6; i++) {
+                    state->total_frames += strlen(segment_map[state->time_digits[i]]);
+                }
+                state->animate = true;
+                state->time_digits[0] = date_time.unit.hour / 10;
+                state->time_digits[1] = date_time.unit.hour % 10;
+                state->time_digits[2] = date_time.unit.minute / 10;
+                state->time_digits[3] = date_time.unit.minute % 10;
+                state->time_digits[4] = date_time.unit.second / 10;
+                state->time_digits[5] = date_time.unit.second % 10;
+            }
+            if (!watch_colon_animation_is_running()) watch_start_colon_animation(1000);
+            break;
+        case EVENT_ALARM_LONG_PRESS:
+            break;
+        case EVENT_BACKGROUND_TASK:
             break;
         default:
-            // Movement's default loop handler will step in for any cases you don't handle above:
-            // * EVENT_LIGHT_BUTTON_DOWN lights the LED
-            // * EVENT_MODE_BUTTON_UP moves to the next watch face in the list
-            // * EVENT_MODE_LONG_PRESS returns to the first watch face (or skips to the secondary watch face, if configured)
-            // You can override any of these behaviors by adding a case for these events to this switch statement.
             return movement_default_loop_handler(event, settings);
     }
 
-    // return true if the watch can enter standby mode. Generally speaking, you should always return true.
-    // Exceptions:
-    //  * If you are displaying a color using the low-level watch_set_led_color function, you should return false.
-    //  * If you are sounding the buzzer using the low-level watch_set_buzzer_on function, you should return false.
-    // Note that if you are driving the LED or buzzer using Movement functions like movement_illuminate_led or
-    // movement_play_alarm, you can still return true. This guidance only applies to the low-level watch_ functions.
     return true;
 }
 
@@ -95,5 +203,15 @@ void wyoscan_face_resign(movement_settings_t *settings, void *context) {
     (void) context;
 
     // handle any cleanup before your watch face goes off-screen.
+}
+
+bool wyoscan_face_wants_background_task(movement_settings_t *settings, void *context) {
+    (void) settings;
+    wyoscan_state_t *state = (wyoscan_state_t *)context;
+    if (!state->signal_enabled) return false;
+
+    watch_date_time date_time = watch_rtc_get_date_time();
+
+    return date_time.unit.minute == 0;
 }
 

--- a/movement/watch_faces/clock/wyoscan_face.c
+++ b/movement/watch_faces/clock/wyoscan_face.c
@@ -92,6 +92,7 @@ static const int32_t clock_mapping[6][7][2] = {
 
 void wyoscan_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {
     (void) settings;
+    (void) watch_face_index;
     if (*context_ptr == NULL) {
         *context_ptr = malloc(sizeof(wyoscan_state_t));
         memset(*context_ptr, 0, sizeof(wyoscan_state_t));
@@ -101,6 +102,7 @@ void wyoscan_face_setup(movement_settings_t *settings, uint8_t watch_face_index,
 }
 
 void wyoscan_face_activate(movement_settings_t *settings, void *context) {
+    (void) settings;
     wyoscan_state_t *state = (wyoscan_state_t *)context;
     movement_request_tick_frequency(32);
     state->total_frames = 64;

--- a/movement/watch_faces/clock/wyoscan_face.c
+++ b/movement/watch_faces/clock/wyoscan_face.c
@@ -1,0 +1,99 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 <#author_name#>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "wyoscan_face.h"
+
+void wyoscan_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {
+    (void) settings;
+    if (*context_ptr == NULL) {
+        *context_ptr = malloc(sizeof(wyoscan_state_t));
+        memset(*context_ptr, 0, sizeof(wyoscan_state_t));
+        // Do any one-time tasks in here; the inside of this conditional happens only at boot.
+    }
+    // Do any pin or peripheral setup here; this will be called whenever the watch wakes from deep sleep.
+}
+
+void wyoscan_face_activate(movement_settings_t *settings, void *context) {
+    (void) settings;
+    wyoscan_state_t *state = (wyoscan_state_t *)context;
+
+    // Handle any tasks related to your watch face coming on screen.
+}
+
+bool wyoscan_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
+    wyoscan_state_t *state = (wyoscan_state_t *)context;
+
+    switch (event.event_type) {
+        case EVENT_ACTIVATE:
+            // Show your initial UI here.
+            break;
+        case EVENT_TICK:
+            // If needed, update your display here.
+            break;
+        case EVENT_LIGHT_BUTTON_UP:
+            // You can use the Light button for your own purposes. Note that by default, Movement will also
+            // illuminate the LED in response to EVENT_LIGHT_BUTTON_DOWN; to suppress that behavior, add an
+            // empty case for EVENT_LIGHT_BUTTON_DOWN.
+            break;
+        case EVENT_ALARM_BUTTON_UP:
+            // Just in case you have need for another button.
+            break;
+        case EVENT_TIMEOUT:
+            // Your watch face will receive this event after a period of inactivity. If it makes sense to resign,
+            // you may uncomment this line to move back to the first watch face in the list:
+            // movement_move_to_face(0);
+            break;
+        case EVENT_LOW_ENERGY_UPDATE:
+            // If you did not resign in EVENT_TIMEOUT, you can use this event to update the display once a minute.
+            // Avoid displaying fast-updating values like seconds, since the display won't update again for 60 seconds.
+            // You should also consider starting the tick animation, to show the wearer that this is sleep mode:
+            // watch_start_tick_animation(500);
+            break;
+        default:
+            // Movement's default loop handler will step in for any cases you don't handle above:
+            // * EVENT_LIGHT_BUTTON_DOWN lights the LED
+            // * EVENT_MODE_BUTTON_UP moves to the next watch face in the list
+            // * EVENT_MODE_LONG_PRESS returns to the first watch face (or skips to the secondary watch face, if configured)
+            // You can override any of these behaviors by adding a case for these events to this switch statement.
+            return movement_default_loop_handler(event, settings);
+    }
+
+    // return true if the watch can enter standby mode. Generally speaking, you should always return true.
+    // Exceptions:
+    //  * If you are displaying a color using the low-level watch_set_led_color function, you should return false.
+    //  * If you are sounding the buzzer using the low-level watch_set_buzzer_on function, you should return false.
+    // Note that if you are driving the LED or buzzer using Movement functions like movement_illuminate_led or
+    // movement_play_alarm, you can still return true. This guidance only applies to the low-level watch_ functions.
+    return true;
+}
+
+void wyoscan_face_resign(movement_settings_t *settings, void *context) {
+    (void) settings;
+    (void) context;
+
+    // handle any cleanup before your watch face goes off-screen.
+}
+

--- a/movement/watch_faces/clock/wyoscan_face.h
+++ b/movement/watch_faces/clock/wyoscan_face.h
@@ -34,22 +34,36 @@
  *
  */
 
+#define MAX_ILLUMINATED_SEGMENTS 7
+
 typedef struct {
-    // Anything you need to keep track of, put it here!
-    uint8_t unused;
+    uint32_t previous_date_time;
+    uint8_t last_battery_check;
+    uint8_t watch_face_index;
+    bool signal_enabled;
+    bool battery_low;
+    bool alarm_enabled;
+    uint8_t animation;
+    bool animate;
+    uint32_t start;
+    uint32_t end;
+    uint32_t total_frames;
+    uint32_t time_digits[6];
+    uint32_t illuminated_segments[MAX_ILLUMINATED_SEGMENTS][2]; 
 } wyoscan_state_t;
 
 void wyoscan_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr);
 void wyoscan_face_activate(movement_settings_t *settings, void *context);
 bool wyoscan_face_loop(movement_event_t event, movement_settings_t *settings, void *context);
 void wyoscan_face_resign(movement_settings_t *settings, void *context);
+bool wyoscan_face_wants_background_task(movement_settings_t *settings, void *context);
 
 #define wyoscan_face ((const watch_face_t){ \
     wyoscan_face_setup, \
     wyoscan_face_activate, \
     wyoscan_face_loop, \
     wyoscan_face_resign, \
-    NULL, \
+    wyoscan_face_wants_background_task, \
 })
 
 #endif // WYOSCAN_FACE_H_

--- a/movement/watch_faces/clock/wyoscan_face.h
+++ b/movement/watch_faces/clock/wyoscan_face.h
@@ -1,0 +1,56 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 <#author_name#>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef WYOSCAN_FACE_H_
+#define WYOSCAN_FACE_H_
+
+#include "movement.h"
+
+/*
+ * A DESCRIPTION OF YOUR WATCH FACE
+ *
+ * and a description of how use it
+ *
+ */
+
+typedef struct {
+    // Anything you need to keep track of, put it here!
+    uint8_t unused;
+} wyoscan_state_t;
+
+void wyoscan_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr);
+void wyoscan_face_activate(movement_settings_t *settings, void *context);
+bool wyoscan_face_loop(movement_event_t event, movement_settings_t *settings, void *context);
+void wyoscan_face_resign(movement_settings_t *settings, void *context);
+
+#define wyoscan_face ((const watch_face_t){ \
+    wyoscan_face_setup, \
+    wyoscan_face_activate, \
+    wyoscan_face_loop, \
+    wyoscan_face_resign, \
+    NULL, \
+})
+
+#endif // WYOSCAN_FACE_H_
+

--- a/movement/watch_faces/clock/wyoscan_face.h
+++ b/movement/watch_faces/clock/wyoscan_face.h
@@ -34,7 +34,7 @@
  *
  */
 
-#define MAX_ILLUMINATED_SEGMENTS 7
+#define MAX_ILLUMINATED_SEGMENTS 14
 
 typedef struct {
     uint32_t previous_date_time;
@@ -48,6 +48,9 @@ typedef struct {
     uint32_t start;
     uint32_t end;
     uint32_t total_frames;
+    uint8_t position, segment;
+    char *segments;
+    uint8_t x, y;
     uint32_t time_digits[6];
     uint32_t illuminated_segments[MAX_ILLUMINATED_SEGMENTS][2]; 
 } wyoscan_state_t;
@@ -63,7 +66,7 @@ bool wyoscan_face_wants_background_task(movement_settings_t *settings, void *con
     wyoscan_face_activate, \
     wyoscan_face_loop, \
     wyoscan_face_resign, \
-    wyoscan_face_wants_background_task, \
+    NULL, \
 })
 
 #endif // WYOSCAN_FACE_H_

--- a/movement/watch_faces/clock/wyoscan_face.h
+++ b/movement/watch_faces/clock/wyoscan_face.h
@@ -34,7 +34,7 @@
  *
  */
 
-#define MAX_ILLUMINATED_SEGMENTS 14
+#define MAX_ILLUMINATED_SEGMENTS 16
 
 typedef struct {
     uint32_t previous_date_time;
@@ -48,6 +48,7 @@ typedef struct {
     uint32_t start;
     uint32_t end;
     uint32_t total_frames;
+    bool colon;
     uint8_t position, segment;
     char *segments;
     uint8_t x, y;


### PR DESCRIPTION
This is a recreation of the Wyoscan watch, which was a $175 watch in 2014. It was an f-91w pcb replacement.

https://github.com/joeycastillo/Sensor-Watch/assets/1795778/e07f0ed1-e328-4337-a654-fa1ee65d883f

Here is more information on it:
https://artmetropole.com/shop/11460

a demo of what it looks like:
https://www.o-r-g.com/apps/wyoscan

8 frames per number * 6 numbers + the trailing 16 frames = 64 frames
at 32 frames per second, this is a 2-second cycle time or 0.5 Hz.

It is giving me a stack overflow after about 2.5 cycles of the time display in the emulator but it works fine on the watch.

![image](https://github.com/joeycastillo/Sensor-Watch/assets/1795778/8ce28a1f-15fb-4f54-babf-b3a631a46da6)

I'd like to make something for the low energy mode, but I haven't thought about how that might work, right now it just freezes in low energy mode until you press the 12-24HR button.

