### PR TITLE
Face settings: A fairly easy way to store watch face data persistently

### DIFF
--- a/movement/face_settings.c
+++ b/movement/face_settings.c
@@ -1,0 +1,193 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Andreas Nebinger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include "watch.h"
+#include "movement.h"
+#include "filesystem.h"
+#include "face_settings.h"
+
+#define FACE_DATA_FILENAME_LEN 17
+
+// face_data_details items are implemented as a linked list
+static face_data_item_t *_item_head = NULL;
+
+/// @brief Quick and easy hash function.
+static uint32_t DJBHash(const char* str, uint16_t length)
+{
+   uint32_t hash = 5381;
+   uint16_t i = 0;
+   for (i = 0; i < length; ++str, ++i) {
+        hash = ((hash << 5) + hash) + (*str);
+   }
+   return hash;
+}
+
+static void _set_filename(char *filename, uint32_t hash_value, uint8_t schema_version) {
+    sprintf(filename, "data_%08x_%02x", hash_value, schema_version);
+}
+
+/// @brief Retrieve a pointer to the face data details of a given face data structure pointer.
+/// @param context Pointer to the face data structure
+/// @return Pointer to the face datails struct of type face_data_details_t or NULL if there was an error
+static face_data_details_t * _get_face_data_details(void *context) {
+    // find the corresponding details entry or append one
+    face_data_item_t *previous_item = NULL;
+    face_data_item_t *current_item = _item_head;
+    while (current_item != NULL) {
+        if (current_item->details->context_data == context) return current_item->details;
+        previous_item = current_item;
+        current_item = current_item->next_item;
+    }
+    // nothing found so far - add a new data item
+    current_item = malloc(sizeof(face_data_item_t));
+    if (current_item == NULL) return NULL;
+    if (_item_head == NULL) _item_head = current_item;
+    current_item->next_item = NULL;
+    current_item->details = malloc(sizeof(face_data_details_t));
+    if (current_item->details == NULL) return NULL;
+    memset(current_item->details, 0, sizeof(face_data_details_t));
+    current_item->details->context_data = context;
+    if (previous_item != NULL) previous_item->next_item = current_item;
+    return current_item->details;
+}
+
+bool face_data_init(const char* watch_face_identifier, 
+                    uint8_t schema_version, 
+                    void *context, 
+                    uint16_t context_length,
+                    face_data_save_callback_t save_callback,
+                    face_data_version_callback_t version_callback) {
+    
+    face_data_details_t *face_data_details = _get_face_data_details(context);
+    if (face_data_details == NULL) return false;
+
+    printf("face_data_init: callbacks %d, %d\n", save_callback, version_callback);
+
+    // set face data details
+    face_data_details->schema_version = schema_version;
+    face_data_details->identifier_hash = DJBHash(watch_face_identifier, (uint16_t)strlen(watch_face_identifier));
+    face_data_details->context_hash = 0;
+    face_data_details->context_length = context_length;
+    face_data_details->save_callback = save_callback;
+    printf("face_data_init: details pointer %d, identifier hash %08x, content hash %04x, length %d, context pointer %d, version callback %d\n",
+        face_data_details,
+        face_data_details->identifier_hash,
+        face_data_details->context_hash, 
+        face_data_details->context_length,
+        face_data_details->context_data, version_callback);
+
+    // look for data file (current schema version)
+    char filename[FACE_DATA_FILENAME_LEN];
+    _set_filename(filename, face_data_details->identifier_hash, schema_version);
+    if (filesystem_file_exists(filename)) {
+        // we have a context file
+        if (filesystem_read_file(filename, face_data_details->context_data, face_data_details->context_length)) {
+            face_data_details->context_hash = DJBHash(face_data_details->context_data, face_data_details->context_length);
+            printf("face_data_init: file %s loaded, hash updated to %04x\n", filename, face_data_details->context_hash);
+            return true;
+        }
+    } 
+
+    if (version_callback && schema_version) {
+        printf("face_data_init: file not read yet, callback is: %d\n", version_callback);
+        // check if there is an older data file version
+        for (uint8_t i = schema_version - 1; i != UINT8_MAX; i--) {
+            _set_filename(filename, face_data_details->identifier_hash, i);
+            printf("face_data_init: check for file %s, callback is %d\n", filename, version_callback);
+            if (filesystem_file_exists(filename)) {
+                printf("face_data_init: file %s exists, callback is %d\n", filename, version_callback);
+                bool erase_file = true;
+                // load data to temporary buffer
+                uint32_t file_len = filesystem_get_file_size(filename);
+                void *data_buffer = malloc(file_len);
+                if (data_buffer != NULL) {
+                    printf("face_data_init: file not read yet, callback is %d\n", version_callback);
+                    filesystem_read_file(filename, data_buffer, file_len);
+                    printf("face_data_init: previous file %s read / callback fn: %d\n", filename, version_callback);
+                    // and invoke callback function
+                    version_callback(data_buffer, i, context, &erase_file); // void *context_old, uint8_t schema_version, void *context, bool *erase_data
+                    free(data_buffer);
+                    if (erase_file) filesystem_rm(filename);
+                    printf("face_data_init: return value %d\n", erase_file);
+                    return true;
+                }
+                break;
+            }
+        }
+    }
+    return false;
+}
+
+bool face_data_save(void *context) {
+
+    face_data_details_t *face_data_details = _get_face_data_details(context);
+    if (face_data_details == NULL) return false;
+
+    printf("face_data_save: details pointer %d, identifier hash %08x, content hash %04x, length %d, context pointer %d, save callback %d\n",
+        face_data_details,
+        face_data_details->identifier_hash,
+        face_data_details->context_hash, 
+        face_data_details->context_length,
+        face_data_details->context_data,
+        face_data_details->save_callback);
+
+    // handle the save callback function, if set
+    void *data_buffer = NULL;
+    if (face_data_details->save_callback) {
+        data_buffer = malloc(face_data_details->context_length);
+        if (data_buffer != NULL) {
+            memcpy(data_buffer, face_data_details->context_data, face_data_details->context_length);
+            face_data_details->save_callback(data_buffer);
+           free(data_buffer); 
+        }
+    } else {
+        data_buffer = face_data_details->context_data;
+    }
+    uint32_t mem_hash = DJBHash(data_buffer, face_data_details->context_length);
+    if (face_data_details->context_hash) {
+        // abort if hashes are identical
+        printf("face_data_save: hash file %04x, hash mem %04x\n", face_data_details->context_hash, mem_hash);
+        if (mem_hash == face_data_details->context_hash) {
+            printf("face_data_save: no changes in data, nothing saved.\n");
+            return false;
+        }
+    } else {
+        printf("face_data_save: hash equals zero.\n");
+    }
+    // save current data to file
+    char filename[FACE_DATA_FILENAME_LEN];
+    _set_filename(filename, face_data_details->identifier_hash, face_data_details->schema_version);
+    printf("face_data_save: save file %s\n", filename);
+    if (filesystem_write_file(filename, data_buffer, face_data_details->context_length)) {
+        face_data_details->context_hash = mem_hash;
+        printf("face_data_save: hash updated to %04x\n", face_data_details->context_hash);
+        return true;
+    } else {
+        return false;
+    }
+}

--- a/movement/face_settings.h
+++ b/movement/face_settings.h
@@ -1,0 +1,103 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Andreas Nebinger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef FACE_SETTINGS_H_
+#define FACE_SETTINGS_H_
+#include <stdio.h>
+#include <stdbool.h>
+#include "watch.h"
+
+/** @brief A function that is invoked when a previous version of a data file is detected.
+  * @param context_old A pointer to the structure corresponding to the older version's data file.
+  * @param schema_version The schema version of the older structure.
+  * @param context A pointer to the current data structure of the watch face.
+  * @param erase_data Pointer to a flag indicating if the old data file will be erased. If you want to 
+  *                   keep the file set this to false. The default value is true. 
+  * @note You can use this function to import data from an older schema version and transfer it to
+  *       the current version of your watch face. This function is only called once time in 
+  *       the context of using face_data_init(). 
+  */
+typedef void (*face_data_version_callback_t)(void *context_old, uint8_t schema_version, void *context, bool *erase_data);
+
+/** @brief A function that is invoked before writing the watch face data to a file.
+  * @param context A pointer to a copy of the current data structure of the watch face.
+  * @note You can use this function to perform some "cleaning up" before data is written.
+  *       E. g. if you have some properties that do not need to be saved permanently, you should
+  *       set these to zero (or any other useful value), thus avoiding unnecessary write operations
+  *       on the flash storage. You can savely alter the structure pointed at by context_ptr, since
+  *       it will be a copy of the original data structure. 
+  */
+ typedef void (*face_data_save_callback_t)(void *context);
+
+typedef struct {
+    uint32_t identifier_hash;
+    uint8_t schema_version;
+    void *context_data;
+    uint16_t context_length;
+    uint32_t context_hash;
+    face_data_save_callback_t save_callback;
+} face_data_details_t;
+
+typedef struct face_data_item {
+  face_data_details_t *details;
+  struct face_data_item *next_item;
+} face_data_item_t;
+
+/** @brief Connects the given details with the given watch face context pointer, to make subsequent calls of face_save_data()
+ *         easier and tries to load a data file.
+ *  @param watch_face_identifier A short string identifying the watch face. Must be unique within the whole project!
+ *  @param schema_version A version number. Helps identifying outdated data files from previous versions of the watch face.
+ *  @param context Pointer to the watch face data buffer/structure.
+ *  @param context_length Number of bytes to load into the buffer and to write to the persistent data file.
+ *  @param save_callback Pointer to a callback function that will be invoked each time the face_data_save() function is used.
+ *  @param init_callback Pointer to a callback function that will be invoked if an older version of a data file is found.
+ *  @return True when a data file has been found and loaded, false otherwise.
+ *  @note Data is stored as a file named 'data_[hash of identifier string]_[schema_version]'. If a corresponding file is 
+ *        found, it will be loaded immediately. If there is no such file and the parameter version_callback is set,
+ *        the function look for previous versions of data files named like 'data_[hash of identifier string]_[schema_version - n]'.
+ *        If such a file is found, the callback function is invoked and the previous data file will be erased (unless the
+ *        callback function indicates otherwise).
+ */
+bool face_data_init(const char* watch_face_identifier, 
+    uint8_t schema_version, 
+    void *context, 
+    uint16_t context_length,
+    face_data_save_callback_t save_callback,
+    face_data_version_callback_t version_callback);
+
+/** @brief Save watch face data to the filesystem.
+ *  @param context Pointer to the data structure that needs to be saved. Must be the same as given at
+ *                 the preceding call of face_data_init().  
+ *  @return True, if a file has been saved. False, if there was no need to save the data (again).
+ *  @note The file will only be saved if the data has changed since the last call. If save_data_init()
+ *        has been provided a save callback function, the latter will be called right before checking for
+ *        data modifications since the last call of face_data_save(). You can use the save data callback
+ *        to set some less relevant data details to default values before saving the whole data structure.
+ *        This way you can fine-tune what is saved persistently while minimizing write operations, since
+ *        data will only be written to the flash storage when relevant parts have changed.
+ */
+bool face_data_save(void *context);
+
+
+#endif // FACE_SETTINGS_H_

--- a/movement/filesystem.c
+++ b/movement/filesystem.c
@@ -6,6 +6,9 @@
 #include "watch.h"
 #include "lfs.h"
 #include "hpl_flash.h"
+#if __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
 
 int lfs_storage_read(const struct lfs_config *cfg, lfs_block_t block, lfs_off_t off, void *buffer, lfs_size_t size);
 int lfs_storage_prog(const struct lfs_config *cfg, lfs_block_t block, lfs_off_t off, const void *buffer, lfs_size_t size);
@@ -53,25 +56,54 @@ static lfs_t lfs;
 static lfs_file_t file;
 static struct lfs_info info;
 
+#if __EMSCRIPTEN__
+static uint8_t _str_len(const char *string) {
+    uint8_t len;
+    for (len = 0; len < UINT8_MAX; len++) {
+        if (string[len] == 0) break;
+    }
+    return ++len;
+}
+#else
 static int _traverse_df_cb(void *p, lfs_block_t block) {
     (void) block;
 	uint32_t *nb = p;
 	*nb += 1;
 	return 0;
 }
+#endif
 
 int32_t filesystem_get_free_space(void) {
-	int err;
+#if __EMSCRIPTEN__
+    // *** emulator version ***
+    int val = EM_ASM_INT({
+        if ('localStorage' in window && window['localStorage'] !== null) {
+            var available = 8192;   // max capacity
+            for (let i = 0; i < localStorage.length; i++) {
+                var fileContent = localStorage.getItem(localStorage.key(i));
+                var strData = fileContent.split(",");
+                available -= strData.length;
+            }
+            console.log("filesystem_get_free_space: %d (raw value)", available);
+            return available < 0 ? 0 : available;
+        } else {
+            console.log("localStorage not supported in this browser!");
+            return -1;
+        }
+    });
+    return (int32_t)val;
+#else
+    // *** hardware version ***
+    int err;
 
 	uint32_t free_blocks = 0;
 	err = lfs_fs_traverse(&lfs, _traverse_df_cb, &free_blocks);
-	if(err < 0){
-		return err;
-	}
+	if (err < 0) return err;
 
 	uint32_t available = cfg.block_count * cfg.block_size - free_blocks * cfg.block_size;
 
 	return (int32_t)available;
+#endif
 }
 
 static int filesystem_ls(lfs_t *lfs, const char *path) {
@@ -112,6 +144,19 @@ static int filesystem_ls(lfs_t *lfs, const char *path) {
 }
 
 bool filesystem_init(void) {
+#if __EMSCRIPTEN__
+    // *** emulator version ***
+    int err = EM_ASM_INT(
+        var error = 0;
+        if (!('localStorage' in window && window['localStorage'] !== null)) { 
+            // local storage not supported!
+            error = -10; 
+        }
+        console.log("filesystem_init() result: %d", error);
+        return error;
+    );
+#else
+    // *** hardware version ***
     int err = lfs_mount(&lfs, &cfg);
 
     // reformat if we can't mount the filesystem
@@ -123,17 +168,55 @@ bool filesystem_init(void) {
         err = lfs_mount(&lfs, &cfg) == LFS_ERR_OK;
         printf("Filesystem mounted with %ld bytes free.\n", filesystem_get_free_space());
     }
-
+#endif
     return err == LFS_ERR_OK;
 }
 
 bool filesystem_file_exists(char *filename) {
+#if __EMSCRIPTEN__
+    // *** emulator version ***
+    uint8_t len = _str_len(filename);
+    int val = EM_ASM_INT({
+        if ('localStorage' in window && window['localStorage'] !== null) {
+            var fileStr = UTF8ArrayToString(HEAPU8.subarray($0, $0 + $1), 0, $1);
+            console.log("filesystem_file_exists(%s)", fileStr);
+            return (localStorage.getItem(fileStr) !== null);
+        } else {
+            console.log("localStorage not supported in this browser!");
+            return -1;
+        }
+    }, filename, len);
+    return val == 1;
+#else
+    // *** hardware version ***
     info.type = 0;
     lfs_stat(&lfs, filename, &info);
     return info.type == LFS_TYPE_REG;
+#endif
 }
 
 bool filesystem_rm(char *filename) {
+#if __EMSCRIPTEN__
+    // *** emulator version ***
+    uint8_t filename_len = _str_len(filename);
+    int val = EM_ASM_INT({
+        if ('localStorage' in window && window['localStorage'] !== null) {
+            var fileStr = UTF8ArrayToString(HEAPU8.subarray($0, $0 + $1), 0, $1);
+            var value = -2;
+            if (localStorage.getItem(fileStr) !== null) {
+                localStorage.removeItem(fileStr);
+                value = 0;
+            }
+            console.log("filesystem_rm: %d", value);
+            return value;
+        } else {
+            console.log("localStorage not supported in this browser!");
+            return -1;
+        }
+    }, filename, filename_len);
+    return val == 0;
+#else
+    // *** hardware version ***
     info.type = 0;
     lfs_stat(&lfs, filename, &info);
     if (filesystem_file_exists(filename)) {
@@ -142,18 +225,70 @@ bool filesystem_rm(char *filename) {
         printf("rm: %s: No such file\n", filename);
         return false;
     }
+#endif
 }
 
 int32_t filesystem_get_file_size(char *filename) {
+#if __EMSCRIPTEN__
+    // *** emulator version ***
+    uint8_t filename_len = _str_len(filename);
+    int val = EM_ASM_INT({
+        if ('localStorage' in window && window['localStorage'] !== null) {
+            var fileStr = UTF8ArrayToString(HEAPU8.subarray($0, $0 + $1), 0, $1);
+            var fileContent = localStorage.getItem(fileStr);
+            if (fileContent !== null) {
+                var strData = fileContent.split(",");
+                console.log("filesystem_get_file_size: %d", strData.length);
+                return strData.length;
+            } else {
+                return -2;
+            }
+        } else {
+            console.log("localStorage not supported in this browser!");
+            return -1;
+        }
+    }, filename, filename_len);
+    if (val >= 0)
+        return (int32_t)val;
+    else
+        return -1;
+#else
+    // *** hardware version ***
     if (filesystem_file_exists(filename)) {
         return info.size; // info struct was just populated by filesystem_file_exists
     }
 
     return -1;
+#endif
 }
 
 bool filesystem_read_file(char *filename, char *buf, int32_t length) {
     memset(buf, 0, length);
+#if __EMSCRIPTEN__
+    // *** emulator version ***
+    uint8_t filename_len = _str_len(filename);
+    int val = EM_ASM_INT({
+        if ('localStorage' in window && window['localStorage'] !== null) {
+            var fileStr = UTF8ArrayToString(HEAPU8.subarray($0, $0 + $1), 0, $1);
+            var fileContent = localStorage.getItem(fileStr);
+            if (fileContent !== null) {
+                var strData = fileContent.split(",");
+                for (let i = 0; i < strData.length && i < $3; i++) {
+                    Module.HEAPU8[i + $2] = parseInt(strData[i]);
+                }
+                console.log("filesystem_read_file: %s", fileContent);
+                return 1;
+            } else {
+                return -2;
+            }
+        } else {
+            console.log("localStorage not supported in this browser!");
+            return -1;
+        }
+    }, filename, filename_len, buf, length);
+    return val == 1;
+#else
+    // *** hardware version ***
     int32_t file_size = filesystem_get_file_size(filename);
     if (file_size > 0) {
         int err = lfs_file_open(&lfs, &file, filename, LFS_O_RDONLY);
@@ -162,12 +297,52 @@ bool filesystem_read_file(char *filename, char *buf, int32_t length) {
         if (err < 0) return false;
         return lfs_file_close(&lfs, &file) == LFS_ERR_OK;
     }
-
     return false;
+#endif
 }
 
 bool filesystem_read_line(char *filename, char *buf, int32_t *offset, int32_t length) {
     memset(buf, 0, length + 1);
+#if __EMSCRIPTEN__
+    // *** emulator version ***
+    uint8_t filename_len = _str_len(filename);
+    int val = EM_ASM_INT({
+        if ('localStorage' in window && window['localStorage'] !== null) {
+            var fileStr = UTF8ArrayToString(HEAPU8.subarray($0, $0 + $1), 0, $1);
+            var fileContent = localStorage.getItem(fileStr);
+            if (fileContent !== null) {
+                var strData = fileContent.split(",");
+                if ($3 > strData.length) {
+                    console.log("filesystem_read_line: given offset is bigger than file size!");
+                    return -3;
+                }
+                for (let i = 0; i < strData.length - $3 && i < $4; i++) {
+                    Module.HEAPU8[i + $2] = parseInt(strData[i + $3]);
+                }
+                console.log("filesystem_read_line: %s", fileContent);
+                return 1;
+            } else {
+                return -2;
+            }
+        } else {
+            console.log("localStorage not supported in this browser!");
+            return -1;
+        }
+    }, filename, filename_len, buf, *offset, length);
+    if (val == 1) {
+        for(int i = 0; i < length; i++) {
+            (*offset)++;
+            if (buf[i] == '\n' || buf[i] == 0) {
+                buf[i] = 0;
+                break;
+            }
+        }
+        return true;
+    } else {
+        return false;
+    }
+#else
+    // *** hardware version ***
     int32_t file_size = filesystem_get_file_size(filename);
     if (file_size > 0) {
         int err = lfs_file_open(&lfs, &file, filename, LFS_O_RDONLY);
@@ -178,7 +353,7 @@ bool filesystem_read_line(char *filename, char *buf, int32_t *offset, int32_t le
         if (err < 0) return false;
         for(int i = 0; i < length; i++) {
             (*offset)++;
-            if (buf[i] == '\n') {
+            if (buf[i] == '\n' || buf[i] == 0) {
                 buf[i] = 0;
                 break;
             }
@@ -187,6 +362,7 @@ bool filesystem_read_line(char *filename, char *buf, int32_t *offset, int32_t le
     }
 
     return false;
+#endif
 }
 
 static void filesystem_cat(char *filename) {
@@ -208,11 +384,30 @@ static void filesystem_cat(char *filename) {
 }
 
 bool filesystem_write_file(char *filename, char *text, int32_t length) {
+#if __EMSCRIPTEN__
+    // *** emulator version ***
+    uint8_t filename_len = _str_len(filename);
+    int val = EM_ASM_INT({
+        if ('localStorage' in window && window['localStorage'] !== null) {
+            var fileStr = UTF8ArrayToString(HEAPU8.subarray($0, $0 + $1), 0, $1);
+            var fileContent = HEAPU8.subarray($2, $2 + $3);
+            console.log("filesystem_write_file: %s", fileContent);
+            localStorage.setItem(fileStr, fileContent);
+            return 1;
+        } else {
+            console.log("localStorage not supported in this browser!");
+            return -1;
+        }
+    }, filename, filename_len, text, length);
+    return val == 1;
+#else
+    // *** hardware version ***
     int err = lfs_file_open(&lfs, &file, filename, LFS_O_RDWR | LFS_O_CREAT | LFS_O_TRUNC);
     if (err < 0) return false;
     err = lfs_file_write(&lfs, &file, text, length);
     if (err < 0) return false;
     return lfs_file_close(&lfs, &file) == LFS_ERR_OK;
+#endif
 }
 
 bool filesystem_append_file(char *filename, char *text, int32_t length) {

--- a/movement/filesystem.c
+++ b/movement/filesystem.c
@@ -84,10 +84,8 @@ int32_t filesystem_get_free_space(void) {
                 var strData = fileContent.split(",");
                 available -= strData.length;
             }
-            console.log("filesystem_get_free_space: %d (raw value)", available);
             return available < 0 ? 0 : available;
         } else {
-            console.log("localStorage not supported in this browser!");
             return -1;
         }
     });
@@ -152,7 +150,6 @@ bool filesystem_init(void) {
             // local storage not supported!
             error = -10; 
         }
-        console.log("filesystem_init() result: %d", error);
         return error;
     );
 #else
@@ -179,10 +176,8 @@ bool filesystem_file_exists(char *filename) {
     int val = EM_ASM_INT({
         if ('localStorage' in window && window['localStorage'] !== null) {
             var fileStr = UTF8ArrayToString(HEAPU8.subarray($0, $0 + $1), 0, $1);
-            console.log("filesystem_file_exists(%s)", fileStr);
             return (localStorage.getItem(fileStr) !== null);
         } else {
-            console.log("localStorage not supported in this browser!");
             return -1;
         }
     }, filename, len);
@@ -207,10 +202,8 @@ bool filesystem_rm(char *filename) {
                 localStorage.removeItem(fileStr);
                 value = 0;
             }
-            console.log("filesystem_rm: %d", value);
             return value;
         } else {
-            console.log("localStorage not supported in this browser!");
             return -1;
         }
     }, filename, filename_len);
@@ -238,13 +231,11 @@ int32_t filesystem_get_file_size(char *filename) {
             var fileContent = localStorage.getItem(fileStr);
             if (fileContent !== null) {
                 var strData = fileContent.split(",");
-                console.log("filesystem_get_file_size: %d", strData.length);
                 return strData.length;
             } else {
                 return -2;
             }
         } else {
-            console.log("localStorage not supported in this browser!");
             return -1;
         }
     }, filename, filename_len);
@@ -276,13 +267,11 @@ bool filesystem_read_file(char *filename, char *buf, int32_t length) {
                 for (let i = 0; i < strData.length && i < $3; i++) {
                     Module.HEAPU8[i + $2] = parseInt(strData[i]);
                 }
-                console.log("filesystem_read_file: %s", fileContent);
                 return 1;
             } else {
                 return -2;
             }
         } else {
-            console.log("localStorage not supported in this browser!");
             return -1;
         }
     }, filename, filename_len, buf, length);
@@ -313,19 +302,16 @@ bool filesystem_read_line(char *filename, char *buf, int32_t *offset, int32_t le
             if (fileContent !== null) {
                 var strData = fileContent.split(",");
                 if ($3 > strData.length) {
-                    console.log("filesystem_read_line: given offset is bigger than file size!");
                     return -3;
                 }
                 for (let i = 0; i < strData.length - $3 && i < $4; i++) {
                     Module.HEAPU8[i + $2] = parseInt(strData[i + $3]);
                 }
-                console.log("filesystem_read_line: %s", fileContent);
                 return 1;
             } else {
                 return -2;
             }
         } else {
-            console.log("localStorage not supported in this browser!");
             return -1;
         }
     }, filename, filename_len, buf, *offset, length);
@@ -391,11 +377,9 @@ bool filesystem_write_file(char *filename, char *text, int32_t length) {
         if ('localStorage' in window && window['localStorage'] !== null) {
             var fileStr = UTF8ArrayToString(HEAPU8.subarray($0, $0 + $1), 0, $1);
             var fileContent = HEAPU8.subarray($2, $2 + $3);
-            console.log("filesystem_write_file: %s", fileContent);
             localStorage.setItem(fileStr, fileContent);
             return 1;
         } else {
-            console.log("localStorage not supported in this browser!");
             return -1;
         }
     }, filename, filename_len, text, length);

--- a/movement/make/Makefile
+++ b/movement/make/Makefile
@@ -49,6 +49,7 @@ SRCS += \
   ../../littlefs/lfs_util.c \
   ../movement.c \
   ../filesystem.c \
+  ../face_settings.c \
   ../watch_faces/clock/simple_clock_face.c \
   ../watch_faces/clock/world_clock_face.c \
   ../watch_faces/clock/beats_face.c \

--- a/movement/watch_faces/complication/alarm_face.c
+++ b/movement/watch_faces/complication/alarm_face.c
@@ -215,8 +215,6 @@ static void _alarm_update_alarm_enabled(movement_settings_t *settings, alarm_sta
         }
     }
     settings->bit.alarm_enabled = active_alarms;
-    // save alarm settings to flash storage if needed
-    face_data_save(state);
 }
 
 static void _alarm_play_short_beep(uint8_t pitch_idx) {
@@ -307,6 +305,8 @@ bool alarm_face_wants_background_task(movement_settings_t *settings, void *conte
     state->alarm_handled_minute = -1;
     // update the movement's alarm indicator five times an hour
     if (now.unit.minute % 12 == 0) _alarm_update_alarm_enabled(settings, state);
+    // check if we should save settings every 2 hours
+    if (now.unit.minute == 0 && (now.unit.hour % 2) == 0) face_data_save(state);
     return false;
 }
 


### PR DESCRIPTION
In this PR, I have put together a solution for persting data of a watch face trying to keep the logic for storing and reading the data files as encapsulated as possible: `file_settings.c` & `file_settings.h` implementing two functions `face_settings_init()` and `face_settings_save()`.

- You can use the `face_settings_init()` function to initialize the details about the data structure belonging to your particular watch face. The function takes an identifying string for your watch face (must be unique) and a pointer to the data structure that will be saved to flash storage. You can also specify two callback functions (see below). It also checks whether a data file for your watch face already exists and if so, it loads it into the data structure.
- There is also basic logic for dealing with different versions of a watch face and possible changes in data structures. The data scheme version number is used to check if there are data files for previous versions present. If so, the old structure is being loaded to a temporary buffer and the version callback function is invoked, so you have a chance to transfer information from the previous version to the current one. The file belonging to the older data scheme version is erased afterwards (unless you specify otherwise by setting the `erase_file` variable to `false`).
- The format of the data files is pretty straightforward: The naming scheme is `data_[hash of identifier string]_[data scheme version]`. The file's content is a binary copy of the data structure.
- Whenever the watch face wants to persist it’s settings, it can call `face_settings_save()`. The current settings will only be saved when it’s contents have changed compared to the last call of `face_settings_save()`. This comparison is done by calculating a (hopefully) unique 4-byte hash value over the content of the data structure.
- Often, it is not feasible to simply write out the whole data structure as it is. For example, if the structure contain temporary properties that do not need to be saved. To handle this, and to further minimize the writing operations you can specify a 'save callback function' that will be invoked right before this hash comparison is done. Within this callback function, you can set irrelevant properties to a default value, so that changes in these properties do not lead to writing out a new data file.

The implementation of persistent storage for the **alarm face** looks like this:
- add `#include "face_settings.h"`, of course
- in `alarm_face_setup()` there is only one line added:
`face_data_init("alarm_face", 0, *context_ptr, sizeof(alarm_state_t), _face_save_data, NULL);`
- `_face_save_data()` is the function dealing with 'cleaning up' the data structure before saving it. It sets some properties to their defaults and looks like this:
```/// @brief default some data before saving to flash storage
static void _face_save_data(void *context) {
    alarm_state_t *state = (alarm_state_t *)context;
    state->alarm_idx = 0;
    state->alarm_playing_idx = 0;
    state->alarm_quick_ticks = false;
    state->alarm_handled_minute = -1;
    // default all one time alarms
    for (uint8_t i = 0; i < ALARM_ALARMS; i++) {
        if (state->alarm[i].day == ALARM_DAY_ONE_TIME) {
            state->alarm[i].day = ALARM_DAY_EACH_DAY;
            state->alarm[i].beeps = 5;
            state->alarm[i].pitch = 1;
            state->alarm[i].enabled = false;
            state->alarm[i].minute = 0;
            state->alarm[i].hour = 0;
        }
    }
}
```
- finally, the data is being checked for storing every two hours. This is done in `alarm_face_wants_background_task()` like so: `if (now.unit.minute == 0 && (now.unit.hour % 2) == 0) face_data_save(state);`

So far, everything looks fine in the emulator. I did not test it on hardware yet, but I guess I will give it a try later today.

P.S.: I had to heavily alter the filesystem.c, too, so that it now uses the browser's localStorage to save and load files. This is due to easier debugging and to get persistence at all in the emulator.
