### PR TITLE
fix nanosec_face correction_profile bounds from going negative

### DIFF
--- a/movement/watch_faces/settings/nanosec_face.c
+++ b/movement/watch_faces/settings/nanosec_face.c
@@ -249,6 +249,10 @@ static void value_increase(int16_t delta) {
             break;
         case 4: // Profile
             nanosec_state.correction_profile = (nanosec_state.correction_profile + delta) % nanosec_profile_count;
+            // if ALARM decreases profile below 0, roll back around
+            if (nanosec_state.correction_profile < 0) {
+                nanosec_state.correction_profile += nanosec_profile_count;
+            }
             break;
         case 5: // Cadence
             switch (nanosec_state.correction_cadence) {
@@ -330,7 +334,11 @@ bool nanosec_face_loop(movement_event_t event, movement_settings_t *settings, vo
             value_increase(-1);
             break;
         case EVENT_ALARM_LONG_PRESS:
-            value_increase(-50);
+            if (nanosec_screen == 4) { // If we are in profile - still decrease by 1
+                value_increase(-1);
+            } else {
+                value_increase(-50);
+            }
             break;
         case EVENT_TIMEOUT:
             // Your watch face will receive this event after a period of inactivity. If it makes sense to resign,


### PR DESCRIPTION
The new nanosec_face has a `nanosec_state.correction_profile` of type `int8_t`, and can turn negative when ALARM is pressed from profile `P0`. From there the setting screen will display a cryptic `P-`, until the modulo arithmetic brings the profile back around to P0 again.

This makes two minor bugfixes to enforce bounds on `correction_profile`:

- roll around the `correction_profile` back to the highest profile when ALARM is pressed from P0 (based on `#define nanosec_profile_count`)
- prevent long press of ALARM from decrementing by 50 while on the profile screen - instead the behavior should still be to decrement by 1.