### PR TITLE
Print memory percentages

### DIFF
--- a/make.mk
+++ b/make.mk
@@ -62,6 +62,7 @@ CFLAGS += -MD -MP -MT $(BUILD)/$(*F).o -MF $(BUILD)/$(@F).d
 LDFLAGS += -mcpu=cortex-m0plus -mthumb
 LDFLAGS += -Wl,--gc-sections
 LDFLAGS += -Wl,--script=$(TOP)/watch-library/hardware/linker/saml22j18.ld
+LDFLAGS += -Wl,--print-memory-usage
 
 LIBS += -lm
 


### PR DESCRIPTION
### Summary
This simple addition prints out the ROM and RAM used in percentages, making it easier to see at a glance the delta variations when iterating on some watch faces. 

### Example
```
navaneeth@raptor:make$ make
git submodule update --init
CC build/movement.o
LD build/watch.elf
Memory region         Used Size  Region Size  %age Used
      bootloader:          0 GB         8 KB      0.00%
             rom:      149476 B       240 KB     60.82%
          eeprom:          0 GB         8 KB      0.00%
             ram:       13352 B        32 KB     40.75%
OBJCOPY build/watch.hex
OBJCOPY build/watch.bin
size:
   text    data     bss     dec     hex filename
 149476    2856   10496  162828   27c0c build/watch.elf
 149476    2856   10496  162828   27c0c (TOTALS)
UF2CONV build/watch.uf2
Converting to uf2, output size: 305152, start address: 0x2000
Wrote 305152 bytes to build/watch.uf2
```