### PR TITLE
Turn on the funky segment of pos 0 for char '@'

### DIFF
--- a/watch-library/shared/watch/watch_private_display.c
+++ b/watch-library/shared/watch/watch_private_display.c
@@ -93,7 +93,7 @@ void watch_display_character(uint8_t character, uint8_t position) {
     }
 
     if (character == 'T' && position == 1) watch_set_pixel(1, 12); // add descender
-    else if (position == 0 && (character == 'B' || character == 'D')) watch_set_pixel(0, 15); // add funky ninth segment
+    else if (position == 0 && (character == 'B' || character == 'D' || character == '@')) watch_set_pixel(0, 15); // add funky ninth segment
     else if (position == 1 && (character == 'B' || character == 'D' || character == '@')) watch_set_pixel(0, 12); // add funky ninth segment
 }
 


### PR DESCRIPTION
The `@` character's purpose is specifically to turn on all segments of a given position. That's confirmed by the comment in the `Character_Set` array says: `0b11111111, // @ (all segments on)`

Moreover, the position 1 has its "funky ninth segment" turned on with `@`.

So, I think `@` should also turn on the funky segment of position 0.

I did a quick search of the faces and didn't see a lot of use for the `@` character, so I don't think this would break anything (and it's a tiny segment anyway :) )