### PR TITLE
Bug: Event race condition

### DIFF
--- a/movement/make/Makefile
+++ b/movement/make/Makefile
@@ -118,6 +118,7 @@ SRCS += \
   ../watch_faces/complication/flashlight_face.c \
   ../watch_faces/clock/decimal_time_face.c \
   ../watch_faces/clock/wyoscan_face.c \
+  ../watch_faces/demo/event_race_face.c \
 # New watch faces go above this line.
 
 # Leave this line at the bottom of the file; it has all the targets for making your project.

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -632,7 +632,6 @@ void cb_fast_tick(void) {
 }
 
 void cb_tick(void) {
-    event.event_type = EVENT_TICK;
     watch_date_time date_time = watch_rtc_get_date_time();
     if (date_time.unit.second != movement_state.last_second) {
         // TODO: can we consolidate these two ticks?
@@ -644,4 +643,8 @@ void cb_tick(void) {
     } else {
         movement_state.subsecond++;
     }
+    if (event.event_type != EVENT_NONE) {
+        return;
+    }
+    event.event_type = EVENT_TICK;
 }

--- a/movement/movement_faces.h
+++ b/movement/movement_faces.h
@@ -95,6 +95,7 @@
 #include "flashlight_face.h"
 #include "decimal_time_face.h"
 #include "wyoscan_face.h"
+#include "event_race_face.h"
 // New includes go above this line.
 
 #endif // MOVEMENT_FACES_H_

--- a/movement/watch_faces/demo/event_race_face.c
+++ b/movement/watch_faces/demo/event_race_face.c
@@ -1,0 +1,67 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 <#author_name#>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include "event_race_face.h"
+
+void event_race_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {
+    (void) settings;
+    if (*context_ptr == NULL) *context_ptr = malloc(sizeof(uint8_t));
+}
+
+void event_race_face_activate(movement_settings_t *settings, void *context) {
+    (void) settings;
+    *((uint8_t *)context) = 0;
+    movement_request_tick_frequency(64);
+}
+
+static void _disp_ctr(uint8_t ctr) {
+    char* buf = " ";
+    buf[0] = '0' + ctr;
+    watch_display_string(buf, 7);
+}
+
+bool event_race_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
+    uint8_t* ctr_ptr = (uint8_t *)context;
+
+    switch (event.event_type) {
+        case EVENT_ACTIVATE:
+            _disp_ctr(*ctr_ptr);
+            break;
+        case EVENT_TICK:
+            break;
+        case EVENT_ALARM_BUTTON_UP:
+            *ctr_ptr = (*ctr_ptr + 1) % 10;
+            _disp_ctr(*ctr_ptr);
+            break;
+    }
+
+    return true;
+}
+
+void event_race_face_resign(movement_settings_t *settings, void *context) {
+    (void) settings;
+    (void) context;
+}
+

--- a/movement/watch_faces/demo/event_race_face.h
+++ b/movement/watch_faces/demo/event_race_face.h
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022 Joey Castillo
+ * Copyright (c) 2023 <#author_name#>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,26 +22,23 @@
  * SOFTWARE.
  */
 
-#ifndef MOVEMENT_CONFIG_H_
-#define MOVEMENT_CONFIG_H_
+#ifndef EVENT_RACE_FACE_H_
+#define EVENT_RACE_FACE_H_
 
-#include "movement_faces.h"
+#include "movement.h"
 
-const watch_face_t watch_faces[] = {
-    event_race_face
-};
+void event_race_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr);
+void event_race_face_activate(movement_settings_t *settings, void *context);
+bool event_race_face_loop(movement_event_t event, movement_settings_t *settings, void *context);
+void event_race_face_resign(movement_settings_t *settings, void *context);
 
-#define MOVEMENT_NUM_FACES (sizeof(watch_faces) / sizeof(watch_face_t))
+#define event_race_face ((const watch_face_t){ \
+    event_race_face_setup, \
+    event_race_face_activate, \
+    event_race_face_loop, \
+    event_race_face_resign, \
+    NULL, \
+})
 
-/* Determines what face to go to from the first face on long press of the Mode button.
- * Also excludes these faces from the normal rotation.
- * In the default firmware, this lets you access temperature and battery voltage with a long press of Mode.
- * Some folks also like to use this to hide the preferences and time set faces from the normal rotation.
- * If you don't want any faces to be excluded, set this to 0 and a long Mode press will have no effect.
- */
-#define MOVEMENT_SECONDARY_FACE_INDEX (0) // or (0)
+#endif // EVENT_RACE_FACE_H_
 
-/* Custom hourly chime tune. Check movement_custom_signal_tunes.h for options */
-#define SIGNAL_TUNE_DEFAULT
-
-#endif // MOVEMENT_CONFIG_H_


### PR DESCRIPTION
I've noticed that button presses are sometimes "skipped", i.e. I press a button and no `BUTTON_UP` event arrives to the face's loop function. I've also noticed that the higher the requested `tick_frequency`, the more often buttons presses are skipped.

I've created this PR to demonstrate the issue, with a simple face that runs at a 64 Hz tick frequency, and counts up on each press of the alarm button, or at least it should. When running in the simulator, for 10 presses of the button, the counter only goes up by around 3 to 5, so more than half of the button presses are skipped.

What I _think_ happens, is that:
* the button press makes the button interrupt handler and callback run
* the global `event.event_type` is set to the correct `BUTTON` event
* but, the face's loop function is not called immediately, and before it is called...
* a tick happens, the tick handler sets the `event.event_type` to `TICK`, "overwriting" the `BUTTON` event into oblivion
* finally the face's loop is called with the `TICK` event

I've added a naive fix in which the tick handler avoids overwriting the event if it's not empty. This seems to fix the counter face: 10 button presses now reliably increment the counter 10 times.

I don't expect this fix to be the best way to fix the issue, so I don't expect this PR to be merged, I just wanted to demonstrate the bug and give weight to the race condition theory above with a simple fix.

I imagine a proper fix may be to add a stack of pending events and call the face's loop multiple times in a row if there are multiple pending events. Maybe the tick events also need to be handled differently than the other ones: if we are falling behind tick events, we don't want to replay them all, we usually want only the "latest" tick event.

I should also say that I don't have the actual board yet, so these observations are made with the simulator. But since I think this bug is in `movement.c` and not in the watch library, I expect the same bug to be exhibited by the hardware board. Unless there's something different with how interrupts are handled.