### PR TITLE
movement: Add "instant" led_duration option.

### DIFF
--- a/movement/movement.c
+++ b/movement/movement.c
@@ -213,12 +213,22 @@ void movement_request_tick_frequency(uint8_t freq) {
 }
 
 void movement_illuminate_led(void) {
-    if (movement_state.settings.bit.led_duration) {
+    if (movement_state.settings.bit.led_duration != 0b111) {
         watch_set_led_color(movement_state.settings.bit.led_red_color ? (0xF | movement_state.settings.bit.led_red_color << 4) : 0,
                             movement_state.settings.bit.led_green_color ? (0xF | movement_state.settings.bit.led_green_color << 4) : 0);
-        movement_state.light_ticks = (movement_state.settings.bit.led_duration * 2 - 1) * 128;
+        if (movement_state.settings.bit.led_duration == 0) {
+            movement_state.light_ticks = 1;
+        } else {
+            movement_state.light_ticks = (movement_state.settings.bit.led_duration * 2 - 1) * 128;
+        }
         _movement_enable_fast_tick_if_needed();
     }
+}
+
+static void _movement_led_off(void) {
+    watch_set_led_off();
+    movement_state.light_ticks = -1;
+    _movement_disable_fast_tick_if_possible();
 }
 
 bool movement_default_loop_handler(movement_event_t event, movement_settings_t *settings) {
@@ -230,6 +240,11 @@ bool movement_default_loop_handler(movement_event_t event, movement_settings_t *
             break;
         case EVENT_LIGHT_BUTTON_DOWN:
             movement_illuminate_led();
+            break;
+        case EVENT_LIGHT_BUTTON_UP:
+            if (movement_state.settings.bit.led_duration == 0) {
+                _movement_led_off();
+            }
             break;
         case EVENT_MODE_LONG_PRESS:
             if (MOVEMENT_SECONDARY_FACE_INDEX && movement_state.current_watch_face == 0) {
@@ -465,9 +480,7 @@ bool app_loop(void) {
         if (watch_get_pin_level(BTN_LIGHT)) {
             movement_state.light_ticks = 1;
         } else {
-            watch_set_led_off();
-            movement_state.light_ticks = -1;
-            _movement_disable_fast_tick_if_possible();
+            _movement_led_off();
         }
     }
 

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -364,7 +364,7 @@ void app_init(void) {
     movement_state.settings.bit.led_green_color = MOVEMENT_DEFAULT_GREEN_COLOR;
     movement_state.settings.bit.button_should_sound = true;
     movement_state.settings.bit.le_interval = 1;
-    movement_state.settings.bit.led_duration = 1;
+    movement_state.settings.bit.led_duration = 0;
     movement_state.light_ticks = -1;
     movement_state.alarm_ticks = -1;
     movement_state.next_available_backup_register = 4;

--- a/movement/movement.h
+++ b/movement/movement.h
@@ -50,7 +50,7 @@ typedef union {
         uint8_t to_interval : 2;            // an inactivity interval for asking the active face to resign.
         bool to_always : 1;                 // if true, always time out from the active face to face 0. otherwise only faces that time out will resign (the default).
         uint8_t le_interval : 3;            // 0 to disable low energy mode, or an inactivity interval for going into low energy mode.
-        uint8_t led_duration : 2;           // how many seconds to shine the LED for (x2), or 0 to disable it.
+        uint8_t led_duration : 3;           // how many seconds to shine the LED for (x2), 0 to shine only while the button is depressed, or all bits set to disable the LED altogether.
         uint8_t led_red_color : 4;          // for general purpose illumination, the red LED value (0-15)
         uint8_t led_green_color : 4;        // for general purpose illumination, the green LED value (0-15)
         uint8_t time_zone : 6;              // an integer representing an index in the time zone table.
@@ -62,7 +62,7 @@ typedef union {
         bool clock_mode_24h : 1;            // indicates whether clock should use 12 or 24 hour mode.
         bool use_imperial_units : 1;        // indicates whether to use metric units (the default) or imperial.
         bool alarm_enabled : 1;             // indicates whether there is at least one alarm enabled.
-        uint8_t reserved : 6;               // room for more preferences if needed.
+        uint8_t reserved : 5;               // room for more preferences if needed.
     } bit;
     uint32_t reg;
 } movement_settings_t;

--- a/movement/watch_faces/settings/preferences_face.c
+++ b/movement/watch_faces/settings/preferences_face.c
@@ -84,6 +84,9 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
                     break;
                 case 4:
                     settings->bit.led_duration = settings->bit.led_duration + 1;
+                    if (settings->bit.led_duration > 3) {
+                        settings->bit.led_duration = 0b111;
+                    }
                     break;
                 case 5:
                     settings->bit.led_green_color = settings->bit.led_green_color + 1;
@@ -159,11 +162,13 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
                 }
                 break;
             case 4:
-                if (settings->bit.led_duration) {
+                if (settings->bit.led_duration == 0) {
+                    watch_display_string("instnt", 4);
+                } else if (settings->bit.led_duration == 0b111) {
+                    watch_display_string("no LEd", 4);
+                } else {
                     sprintf(buf, " %1d SeC", settings->bit.led_duration * 2 - 1);
                     watch_display_string(buf, 4);
-                } else {
-                    watch_display_string("no LEd", 4);
                 }
                 break;
             case 5:


### PR DESCRIPTION
This illuminates the LED only for the time that the button is pressed, and turns it off as soon as it's released, which is the behaviour of the original watch.

I chose a led_duration of zero to represent "instant" and all bits set to represent "no LED", which is arbitrary but seemed more sensible to me.

This PR also makes this the default. This is a matter of personal preference, but "instant" is the behaviour of the original watch, and seems like the thing more people would expect. Feel free not to take that commit if you disagree, though.