### PR TITLE
Support leading zero representation for 24h clock

### DIFF
--- a/movement/movement.h
+++ b/movement/movement.h
@@ -60,9 +60,10 @@ typedef union {
         // time-oriented complication like a sunrise/sunset timer, and a simple locale preference could tell an
         // altimeter to display feet or meters as easily as it tells a thermometer to display degrees in F or C.
         bool clock_mode_24h : 1;            // indicates whether clock should use 12 or 24 hour mode.
+        bool clock_24h_leading_zero : 1;    // indicates whether clock should leading zero to indicate 24 hour mode.
         bool use_imperial_units : 1;        // indicates whether to use metric units (the default) or imperial.
         bool alarm_enabled : 1;             // indicates whether there is at least one alarm enabled.
-        uint8_t reserved : 6;               // room for more preferences if needed.
+        uint8_t reserved : 5;               // room for more preferences if needed.
     } bit;
     uint32_t reg;
 } movement_settings_t;

--- a/movement/watch_faces/clock/simple_clock_bin_led_face.c
+++ b/movement/watch_faces/clock/simple_clock_bin_led_face.c
@@ -60,7 +60,7 @@ void simple_clock_bin_led_face_activate(movement_settings_t *settings, void *con
 
     if (watch_tick_animation_is_running()) watch_stop_tick_animation();
 
-    if (settings->bit.clock_mode_24h) watch_set_indicator(WATCH_INDICATOR_24H);
+    if (settings->bit.clock_mode_24h && !settings->bit.clock_24h_leading_zero) watch_set_indicator(WATCH_INDICATOR_24H);
 
     // handle chime indicator
     if (state->signal_enabled) watch_set_indicator(WATCH_INDICATOR_BELL);
@@ -138,6 +138,7 @@ bool simple_clock_bin_led_face_loop(movement_event_t event, movement_settings_t 
                 // ...and set the LAP indicator if low.
                 if (state->battery_low) watch_set_indicator(WATCH_INDICATOR_LAP);
 
+                bool set_leading_zero = false;
                 if ((date_time.reg >> 6) == (previous_date_time >> 6) && event.event_type != EVENT_LOW_ENERGY_UPDATE) {
                     // everything before seconds is the same, don't waste cycles setting those segments.
                     watch_display_character_lp_seconds('0' + date_time.unit.second / 10, 8);
@@ -158,6 +159,8 @@ bool simple_clock_bin_led_face_loop(movement_event_t event, movement_settings_t 
                         }
                         date_time.unit.hour %= 12;
                         if (date_time.unit.hour == 0) date_time.unit.hour = 12;
+                    } else if (settings->bit.clock_24h_leading_zero && date_time.unit.hour < 10) {
+                        set_leading_zero = true;
                     }
                     pos = 0;
                     if (event.event_type == EVENT_LOW_ENERGY_UPDATE) {
@@ -168,6 +171,8 @@ bool simple_clock_bin_led_face_loop(movement_event_t event, movement_settings_t 
                     }
                 }
                 watch_display_string(buf, pos);
+                if (set_leading_zero)
+                    watch_display_string("0", 4);
                 // handle alarm indicator
                 if (state->alarm_enabled != settings->bit.alarm_enabled) _update_alarm_indicator(settings->bit.alarm_enabled, state);
             }

--- a/movement/watch_faces/clock/simple_clock_face.c
+++ b/movement/watch_faces/clock/simple_clock_face.c
@@ -51,7 +51,7 @@ void simple_clock_face_activate(movement_settings_t *settings, void *context) {
 
     if (watch_tick_animation_is_running()) watch_stop_tick_animation();
 
-    if (settings->bit.clock_mode_24h) watch_set_indicator(WATCH_INDICATOR_24H);
+    if (settings->bit.clock_mode_24h && !settings->bit.clock_24h_leading_zero) watch_set_indicator(WATCH_INDICATOR_24H);
 
     // handle chime indicator
     if (state->signal_enabled) watch_set_indicator(WATCH_INDICATOR_BELL);
@@ -95,6 +95,7 @@ bool simple_clock_face_loop(movement_event_t event, movement_settings_t *setting
             // ...and set the LAP indicator if low.
             if (state->battery_low) watch_set_indicator(WATCH_INDICATOR_LAP);
 
+            bool set_leading_zero = false;
             if ((date_time.reg >> 6) == (previous_date_time >> 6) && event.event_type != EVENT_LOW_ENERGY_UPDATE) {
                 // everything before seconds is the same, don't waste cycles setting those segments.
                 watch_display_character_lp_seconds('0' + date_time.unit.second / 10, 8);
@@ -115,6 +116,8 @@ bool simple_clock_face_loop(movement_event_t event, movement_settings_t *setting
                     }
                     date_time.unit.hour %= 12;
                     if (date_time.unit.hour == 0) date_time.unit.hour = 12;
+                } else if (settings->bit.clock_24h_leading_zero && date_time.unit.hour < 10) {
+                    set_leading_zero = true;
                 }
                 pos = 0;
                 if (event.event_type == EVENT_LOW_ENERGY_UPDATE) {
@@ -125,6 +128,8 @@ bool simple_clock_face_loop(movement_event_t event, movement_settings_t *setting
                 }
             }
             watch_display_string(buf, pos);
+            if (set_leading_zero)
+                watch_display_string("0", 4);
             // handle alarm indicator
             if (state->alarm_enabled != settings->bit.alarm_enabled) _update_alarm_indicator(settings->bit.alarm_enabled, state);
             break;

--- a/movement/watch_faces/clock/weeknumber_clock_face.c
+++ b/movement/watch_faces/clock/weeknumber_clock_face.c
@@ -50,7 +50,7 @@ void weeknumber_clock_face_activate(movement_settings_t *settings, void *context
 
     if (watch_tick_animation_is_running()) watch_stop_tick_animation();
 
-    if (settings->bit.clock_mode_24h) watch_set_indicator(WATCH_INDICATOR_24H);
+    if (settings->bit.clock_mode_24h && !settings->bit.clock_24h_leading_zero) watch_set_indicator(WATCH_INDICATOR_24H);
 
     // handle chime indicator
     if (state->signal_enabled) watch_set_indicator(WATCH_INDICATOR_BELL);
@@ -94,6 +94,7 @@ bool weeknumber_clock_face_loop(movement_event_t event, movement_settings_t *set
             // ...and set the LAP indicator if low.
             if (state->battery_low) watch_set_indicator(WATCH_INDICATOR_LAP);
 
+            bool set_leading_zero = false;
             if ((date_time.reg >> 12) == (previous_date_time >> 12) && event.event_type != EVENT_LOW_ENERGY_UPDATE) {
                 // everything before minutes is the same.
                 pos = 6;
@@ -109,6 +110,8 @@ bool weeknumber_clock_face_loop(movement_event_t event, movement_settings_t *set
                     }
                     date_time.unit.hour %= 12;
                     if (date_time.unit.hour == 0) date_time.unit.hour = 12;
+                } else if (settings->bit.clock_24h_leading_zero && date_time.unit.hour < 10) {
+                    set_leading_zero = true;
                 }
                 pos = 0;
                 if (event.event_type == EVENT_LOW_ENERGY_UPDATE) {
@@ -119,6 +122,8 @@ bool weeknumber_clock_face_loop(movement_event_t event, movement_settings_t *set
                 }
             }
             watch_display_string(buf, pos);
+            if (set_leading_zero)
+                watch_display_string("0", 4);
             // handle alarm indicator
             if (state->alarm_enabled != settings->bit.alarm_enabled) _update_alarm_indicator(settings->bit.alarm_enabled, state);
             break;

--- a/movement/watch_faces/complication/activity_face.c
+++ b/movement/watch_faces/complication/activity_face.c
@@ -293,6 +293,7 @@ static void _activity_update_logging_screen(movement_settings_t *settings, activ
     }
     // Briefly, show time without seconds
     else {
+        bool set_leading_zero = false;
         watch_clear_indicator(WATCH_INDICATOR_LAP);
         watch_date_time now = watch_rtc_get_date_time();
         uint8_t hour = now.unit.hour;
@@ -304,14 +305,18 @@ static void _activity_update_logging_screen(movement_settings_t *settings, activ
                 watch_set_indicator(WATCH_INDICATOR_PM);
             hour %= 12;
             if (hour == 0) hour = 12;
-        }
-        else {
-            watch_set_indicator(WATCH_INDICATOR_24H);
+        } else {
             watch_clear_indicator(WATCH_INDICATOR_PM);
+            if (!settings->bit.clock_24h_leading_zero)
+                watch_set_indicator(WATCH_INDICATOR_24H);
+            else if (hour < 10)
+                set_leading_zero = true;
         }
         sprintf(activity_buf, "%2d%02d  ", hour, now.unit.minute);
         watch_set_colon();
         watch_display_string(activity_buf, 4);
+        if (set_leading_zero)
+            watch_display_string("0", 4);
     }
 }
 

--- a/movement/watch_faces/complication/alarm_face.c
+++ b/movement/watch_faces/complication/alarm_face.c
@@ -99,6 +99,7 @@ static void _alarm_face_draw(movement_settings_t *settings, alarm_state_t *state
         i = state->alarm[state->alarm_idx].day + 1;
     }
     //handle am/pm for hour display
+    bool set_leading_zero = false;
     uint8_t h = state->alarm[state->alarm_idx].hour;
     if (!settings->bit.clock_mode_24h) {
         if (h >= 12) {
@@ -108,6 +109,10 @@ static void _alarm_face_draw(movement_settings_t *settings, alarm_state_t *state
             watch_clear_indicator(WATCH_INDICATOR_PM);
         }
         if (h == 0) h = 12;
+    } else if (!settings->bit.clock_24h_leading_zero) {
+        watch_set_indicator(WATCH_INDICATOR_24H);
+    } else if (h < 10) {
+        set_leading_zero = true;
     }
     sprintf(buf, "%c%c%2d%2d%02d  ",
         _dow_strings[i][0], _dow_strings[i][1],
@@ -119,6 +124,8 @@ static void _alarm_face_draw(movement_settings_t *settings, alarm_state_t *state
         buf[_blink_idx[state->setting_state]] = buf[_blink_idx2[state->setting_state]] = ' ';
     }
     watch_display_string(buf, 0);
+    if (set_leading_zero)
+        watch_display_string("0", 4);
     
     if (state->is_setting) {
     // draw pitch level indicator

--- a/movement/watch_faces/complication/planetary_hours_face.c
+++ b/movement/watch_faces/complication/planetary_hours_face.c
@@ -228,6 +228,7 @@ static void _planetary_hours(movement_settings_t *settings, planetary_hours_stat
     uint8_t weekday, planet, planetary_hour;
     uint32_t current_hour_epoch;
     watch_date_time scratch_time;
+    bool set_leading_zero = false;
 
     // check if we have a location. If not, display error
     if ( state->no_location ) {
@@ -253,7 +254,7 @@ static void _planetary_hours(movement_settings_t *settings, planetary_hours_stat
         return;
     }
 
-    if (settings->bit.clock_mode_24h) watch_set_indicator(WATCH_INDICATOR_24H);
+    if (settings->bit.clock_mode_24h && !settings->bit.clock_24h_leading_zero) watch_set_indicator(WATCH_INDICATOR_24H);
 
     // roll over hour iterator
     if ( state->hour < 0 ) state->hour = 23;
@@ -313,6 +314,8 @@ static void _planetary_hours(movement_settings_t *settings, planetary_hours_stat
         }
         scratch_time.unit.hour %= 12;
         if (scratch_time.unit.hour == 0) scratch_time.unit.hour = 12;
+    } else if (settings->bit.clock_24h_leading_zero && scratch_time.unit.hour < 10) {
+        set_leading_zero = true;
     }
     
     // planetary ruler of the hour
@@ -328,6 +331,8 @@ static void _planetary_hours(movement_settings_t *settings, planetary_hours_stat
 
     watch_set_colon();
     watch_display_string(buf, 0);
+    if (set_leading_zero)
+        watch_display_string("0", 4);
 
     if ( state->ruler == 2 ) _planetary_icon(planet);
 }

--- a/movement/watch_faces/complication/planetary_time_face.c
+++ b/movement/watch_faces/complication/planetary_time_face.c
@@ -206,6 +206,7 @@ static void _planetary_time(movement_event_t event, movement_settings_t *setting
     double night_hour_count = 0.0;
     uint8_t weekday, planet, planetary_hour;
     double hour_duration, current_hour, current_minute, current_second;
+    bool set_leading_zero = false;
 
         watch_set_colon();
 
@@ -218,7 +219,7 @@ static void _planetary_time(movement_event_t event, movement_settings_t *setting
         return;
     }
 
-    if (settings->bit.clock_mode_24h) watch_set_indicator(WATCH_INDICATOR_24H);
+    if (settings->bit.clock_mode_24h && !settings->bit.clock_24h_leading_zero) watch_set_indicator(WATCH_INDICATOR_24H);
 
     // PM for night hours, otherwise the night hours are counted from 13
     if ( state->night ) {
@@ -246,6 +247,9 @@ static void _planetary_time(movement_event_t event, movement_settings_t *setting
     state->scratch.unit.minute = floor(current_minute);
     state->scratch.unit.second = (uint8_t)floor(current_second) % 60;
 
+    if (settings->bit.clock_mode_24h && settings->bit.clock_24h_leading_zero && state->scratch.unit.hour < 10)
+        set_leading_zero = true;
+
     // what weekday is it (0 - 6)
     weekday = watch_utility_get_iso8601_weekday_number(state->scratch.unit.year, state->scratch.unit.month, state->scratch.unit.day) - 1;
 
@@ -263,6 +267,8 @@ static void _planetary_time(movement_event_t event, movement_settings_t *setting
     else sprintf(buf, "%s h%2d%02d%02d", ruler, state->scratch.unit.hour, state->scratch.unit.minute, state->scratch.unit.second);
     
     watch_display_string(buf, 0);
+    if (set_leading_zero)
+        watch_display_string("0", 4);
 
     if ( state->ruler == 2 ) _planetary_icon(planet);
 

--- a/movement/watch_faces/complication/sunrise_sunset_face.c
+++ b/movement/watch_faces/complication/sunrise_sunset_face.c
@@ -85,7 +85,7 @@ static void _sunrise_sunset_face_update(movement_settings_t *settings, sunrise_s
         }
 
         watch_set_colon();
-        if (settings->bit.clock_mode_24h) watch_set_indicator(WATCH_INDICATOR_24H);
+        if (settings->bit.clock_mode_24h && !settings->bit.clock_24h_leading_zero) watch_set_indicator(WATCH_INDICATOR_24H);
 
         rise += hours_from_utc;
         set += hours_from_utc;
@@ -105,12 +105,17 @@ static void _sunrise_sunset_face_update(movement_settings_t *settings, sunrise_s
 
         if (date_time.reg < scratch_time.reg || show_next_match) {
             if (state->rise_index == 0 || show_next_match) {
+                bool set_leading_zero = false;
                 if (!settings->bit.clock_mode_24h) {
                     if (watch_utility_convert_to_12_hour(&scratch_time)) watch_set_indicator(WATCH_INDICATOR_PM);
                     else watch_clear_indicator(WATCH_INDICATOR_PM);
+                } else if (settings->bit.clock_24h_leading_zero && scratch_time.unit.hour < 10) {
+                    set_leading_zero = true;
                 }
                 sprintf(buf, "rI%2d%2d%02d  ", scratch_time.unit.day, scratch_time.unit.hour, scratch_time.unit.minute);
                 watch_display_string(buf, 0);
+                if (set_leading_zero)
+                    watch_display_string("0", 4);
                 return;
             } else {
                 show_next_match = true;
@@ -132,12 +137,17 @@ static void _sunrise_sunset_face_update(movement_settings_t *settings, sunrise_s
 
         if (date_time.reg < scratch_time.reg || show_next_match) {
             if (state->rise_index == 0 || show_next_match) {
+                bool set_leading_zero = false;
                 if (!settings->bit.clock_mode_24h) {
                     if (watch_utility_convert_to_12_hour(&scratch_time)) watch_set_indicator(WATCH_INDICATOR_PM);
                     else watch_clear_indicator(WATCH_INDICATOR_PM);
+                } else if (settings->bit.clock_24h_leading_zero && scratch_time.unit.hour < 10) {
+                    set_leading_zero = true;
                 }
                 sprintf(buf, "SE%2d%2d%02d  ", scratch_time.unit.day, scratch_time.unit.hour, scratch_time.unit.minute);
                 watch_display_string(buf, 0);
+                if (set_leading_zero)
+                    watch_display_string("0", 4);
                 return;
             } else {
                 show_next_match = true;

--- a/movement/watch_faces/complication/wake_face.c
+++ b/movement/watch_faces/complication/wake_face.c
@@ -50,12 +50,15 @@ void _wake_face_update_display(movement_settings_t *settings, wake_face_state_t 
     uint8_t hour = state->hour;
 
     watch_clear_display();
-    if ( settings->bit.clock_mode_24h )
-        watch_set_indicator(WATCH_INDICATOR_24H);
-    else {
+    bool set_leading_zero = false;
+    if ( !settings->bit.clock_mode_24h ) {
         if ( hour >= 12 )
             watch_set_indicator(WATCH_INDICATOR_PM);
         hour = hour % 12 ? hour % 12 : 12;
+    } else if ( !settings->bit.clock_24h_leading_zero ) {
+        watch_set_indicator(WATCH_INDICATOR_24H);
+    } else if ( hour < 10 ) {
+        set_leading_zero = true;
     }
 
     if ( state->mode )
@@ -66,6 +69,8 @@ void _wake_face_update_display(movement_settings_t *settings, wake_face_state_t 
 
     watch_set_colon();
     watch_display_string(lcdbuf, 0);
+    if ( set_leading_zero )
+        watch_display_string("0", 4);
 }
 
 //

--- a/movement/watch_faces/sensor/thermistor_logging_face.c
+++ b/movement/watch_faces/sensor/thermistor_logging_face.c
@@ -40,9 +40,10 @@ static void _thermistor_logging_face_log_data(thermistor_logger_state_t *logger_
     thermistor_driver_disable();
 }
 
-static void _thermistor_logging_face_update_display(thermistor_logger_state_t *logger_state, bool in_fahrenheit, bool clock_mode_24h) {
+static void _thermistor_logging_face_update_display(thermistor_logger_state_t *logger_state, bool in_fahrenheit, bool clock_mode_24h, bool clock_24h_leading_zero) {
     int8_t pos = (logger_state->data_points - 1 - logger_state->display_index) % THERMISTOR_LOGGING_NUM_DATA_POINTS;
     char buf[14];
+    bool set_leading_zero = false;
 
     watch_clear_indicator(WATCH_INDICATOR_24H);
     watch_clear_indicator(WATCH_INDICATOR_PM);
@@ -53,12 +54,14 @@ static void _thermistor_logging_face_update_display(thermistor_logger_state_t *l
     } else if (logger_state->ts_ticks) {
         watch_date_time date_time = logger_state->data[pos].timestamp;
         watch_set_colon();
-        if (clock_mode_24h) {
-            watch_set_indicator(WATCH_INDICATOR_24H);
-        } else {
+        if (!clock_mode_24h) {
             if (date_time.unit.hour > 11) watch_set_indicator(WATCH_INDICATOR_PM);
             date_time.unit.hour %= 12;
             if (date_time.unit.hour == 0) date_time.unit.hour = 12;
+        } else if (!clock_24h_leading_zero) {
+            watch_set_indicator(WATCH_INDICATOR_24H);
+        } else if (date_time.unit.hour < 10) {
+            set_leading_zero = true;
         }
         sprintf(buf, "AT%2d%2d%02d%02d", date_time.unit.day, date_time.unit.hour, date_time.unit.minute, date_time.unit.second);
     } else {
@@ -70,6 +73,8 @@ static void _thermistor_logging_face_update_display(thermistor_logger_state_t *l
     }
 
     watch_display_string(buf, 0);
+    if (set_leading_zero)
+        watch_display_string("0", 4);
 }
 
 void thermistor_logging_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {
@@ -100,18 +105,18 @@ bool thermistor_logging_face_loop(movement_event_t event, movement_settings_t *s
             break;
         case EVENT_LIGHT_BUTTON_DOWN:
             logger_state->ts_ticks = 2;
-            _thermistor_logging_face_update_display(logger_state, settings->bit.use_imperial_units, settings->bit.clock_mode_24h);
+            _thermistor_logging_face_update_display(logger_state, settings->bit.use_imperial_units, settings->bit.clock_mode_24h, settings->bit.clock_24h_leading_zero);
             break;
         case EVENT_ALARM_BUTTON_DOWN:
             logger_state->display_index = (logger_state->display_index + 1) % THERMISTOR_LOGGING_NUM_DATA_POINTS;
             logger_state->ts_ticks = 0;
             // fall through
         case EVENT_ACTIVATE:
-            _thermistor_logging_face_update_display(logger_state, settings->bit.use_imperial_units, settings->bit.clock_mode_24h);
+            _thermistor_logging_face_update_display(logger_state, settings->bit.use_imperial_units, settings->bit.clock_mode_24h, settings->bit.clock_24h_leading_zero);
             break;
         case EVENT_TICK:
             if (logger_state->ts_ticks && --logger_state->ts_ticks == 0) {
-                _thermistor_logging_face_update_display(logger_state, settings->bit.use_imperial_units, settings->bit.clock_mode_24h);
+                _thermistor_logging_face_update_display(logger_state, settings->bit.use_imperial_units, settings->bit.clock_mode_24h, settings->bit.clock_24h_leading_zero);
             }
             break;
         case EVENT_BACKGROUND_TASK:

--- a/movement/watch_faces/settings/preferences_face.c
+++ b/movement/watch_faces/settings/preferences_face.c
@@ -93,6 +93,14 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
                     break;
             }
             break;
+        case EVENT_ALARM_LONG_PRESS:
+            switch (current_page) {
+                case 0:
+                    if (settings->bit.clock_mode_24h)
+                        settings->bit.clock_24h_leading_zero = !(settings->bit.clock_24h_leading_zero);
+                    break;
+            }
+            break;
         case EVENT_TIMEOUT:
             movement_move_to_face(0);
             break;
@@ -107,8 +115,10 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
         char buf[8];
         switch (current_page) {
             case 0:
-                if (settings->bit.clock_mode_24h) watch_display_string("24h", 4);
-                else watch_display_string("12h", 4);
+                if (settings->bit.clock_mode_24h) {
+                    if (settings->bit.clock_24h_leading_zero) watch_display_string("024h", 4);
+                    else watch_display_string("24h", 4);
+                } else watch_display_string("12h", 4);
                 break;
             case 1:
                 if (settings->bit.button_should_sound) watch_display_string("y", 9);

--- a/movement/watch_faces/settings/set_time_face.c
+++ b/movement/watch_faces/settings/set_time_face.c
@@ -131,10 +131,14 @@ bool set_time_face_loop(movement_event_t event, movement_settings_t *settings, v
     }
 
     char buf[11];
+    bool set_leading_zero = false;
     if (current_page < 3) {
         watch_set_colon();
         if (settings->bit.clock_mode_24h) {
-            watch_set_indicator(WATCH_INDICATOR_24H);
+            if (!settings->bit.clock_24h_leading_zero)
+                watch_set_indicator(WATCH_INDICATOR_24H);
+            else if (date_time.unit.hour < 10)
+                set_leading_zero = true;
             sprintf(buf, "%s  %2d%02d%02d", set_time_face_titles[current_page], date_time.unit.hour, date_time.unit.minute, date_time.unit.second);
         } else {
             sprintf(buf, "%s  %2d%02d%02d", set_time_face_titles[current_page], (date_time.unit.hour % 12) ? (date_time.unit.hour % 12) : 12, date_time.unit.minute, date_time.unit.second);
@@ -175,6 +179,8 @@ bool set_time_face_loop(movement_event_t event, movement_settings_t *settings, v
     }
 
     watch_display_string(buf, 0);
+    if (set_leading_zero)
+        watch_display_string("0", 4);
 
     return true;
 }

--- a/movement/watch_faces/settings/set_time_hackwatch_face.c
+++ b/movement/watch_faces/settings/set_time_hackwatch_face.c
@@ -209,10 +209,14 @@ bool set_time_hackwatch_face_loop(movement_event_t event, movement_settings_t *s
     }
 
     char buf[11];
+    bool set_leading_zero = false;
     if (current_page < 3) {
         watch_set_colon();
         if (settings->bit.clock_mode_24h) {
-            watch_set_indicator(WATCH_INDICATOR_24H);
+            if (!settings->bit.clock_24h_leading_zero)
+                watch_set_indicator(WATCH_INDICATOR_24H);
+            else if (date_time_settings.unit.hour < 10)
+                set_leading_zero = true;
             sprintf(buf,
                     "%s  %2d%02d%02d",
                     set_time_hackwatch_face_titles[current_page],
@@ -278,6 +282,8 @@ bool set_time_hackwatch_face_loop(movement_event_t event, movement_settings_t *s
     }
 
     watch_display_string(buf, 0);
+    if (set_leading_zero)
+        watch_display_string("0", 4);
 
     return true;
 }


### PR DESCRIPTION
This adds a mode to display 24h clock with leading zero rather than with the 24h indicator. For instance, "6:00 24h" appears as "06:00" with this mode enabled. (Finally! After all these years, I no longer need to squint to check if my watch says "24h" or if I accidentally bumped the alarm button and it says "PM"!)

The new mode is "hidden" behind the existing 24h option. Switch between leading-zero mode and the default with long-press of alarm button when viewing the screen with 24h setting. With leading-zero mode enabled, the options screen displays "024h". Otherwise, the existing 24h option works as before, so the change should not be disruptive to existing users.

This change occupies an additional global preferences bit, but I'm hoping this feature is popular enough to justify the cost. (If some day it does not fit in the BKUP register and needs to be stored elsewhere, I don't mind.)

Impact to performance should be minimal, as the bit only needs to be checked once every hour.

The only thing I'm not super happy about is all of the additional format strings. If there's a way to manually force the display to show a leading zero without using a format string, please let me know and I will rewrite this patch.