### PR TITLE
Add minute repeater decimal face

### DIFF
--- a/movement/make/Makefile
+++ b/movement/make/Makefile
@@ -118,6 +118,7 @@ SRCS += \
   ../watch_faces/complication/flashlight_face.c \
   ../watch_faces/clock/decimal_time_face.c \
   ../watch_faces/clock/wyoscan_face.c \
+  ../watch_faces/clock/minute_repeater_decimal_face.c \
 # New watch faces go above this line.
 
 # Leave this line at the bottom of the file; it has all the targets for making your project.

--- a/movement/movement_faces.h
+++ b/movement/movement_faces.h
@@ -95,6 +95,7 @@
 #include "flashlight_face.h"
 #include "decimal_time_face.h"
 #include "wyoscan_face.h"
+#include "minute_repeater_decimal_face.h"
 // New includes go above this line.
 
 #endif // MOVEMENT_FACES_H_

--- a/movement/watch_faces/clock/minute_repeater_decimal_face.c
+++ b/movement/watch_faces/clock/minute_repeater_decimal_face.c
@@ -1,0 +1,238 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Jonas Termeau - original repetition_minute_face
+ * Copyright (c) 2023 Brian Blakley - modified minute_repeater_decimal_face
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * This face, minute_repeater_decimal_face, is a modification of the original 
+ * repetition_minute_face by Jonas Termeau.
+ * 
+ * This version was created by BrianBinFL to use a decimal minute repeater pattern 
+ * (hours, tens, and minutes) instead of the traditional pattern (hours, quarters, 
+ * minutes).
+ *
+ * Also 500ms delays were added after the hours segment and after the tens segment
+ * to make it easier for the user to realize that the counting for the current 
+ * segment has ended.
+ *
+ */
+ 
+#include <stdlib.h>
+#include "minute_repeater_decimal_face.h"
+#include "watch.h"
+#include "watch_utility.h"
+#include "watch_private_display.h"
+
+void mrd_play_hour_chime(void) {
+        watch_buzzer_play_note(BUZZER_NOTE_C6, 75);
+        watch_buzzer_play_note(BUZZER_NOTE_REST, 500);
+}
+
+void mrd_play_tens_chime(void) {
+        watch_buzzer_play_note(BUZZER_NOTE_E6, 75);
+        watch_buzzer_play_note(BUZZER_NOTE_REST, 150);
+        watch_buzzer_play_note(BUZZER_NOTE_C6, 75);
+        watch_buzzer_play_note(BUZZER_NOTE_REST, 750);
+}
+
+void mrd_play_minute_chime(void) {
+        watch_buzzer_play_note(BUZZER_NOTE_E6, 75);
+        watch_buzzer_play_note(BUZZER_NOTE_REST, 500);
+}
+
+static void _update_alarm_indicator(bool settings_alarm_enabled, minute_repeater_decimal_state_t *state) {
+    state->alarm_enabled = settings_alarm_enabled;
+    if (state->alarm_enabled) watch_set_indicator(WATCH_INDICATOR_SIGNAL);
+    else watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
+}
+
+void minute_repeater_decimal_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {
+    (void) settings;
+    (void) watch_face_index;
+
+    if (*context_ptr == NULL) {
+        *context_ptr = malloc(sizeof(minute_repeater_decimal_state_t));
+        minute_repeater_decimal_state_t *state = (minute_repeater_decimal_state_t *)*context_ptr;
+        state->signal_enabled = false;
+        state->watch_face_index = watch_face_index;
+    }
+}
+
+void minute_repeater_decimal_face_activate(movement_settings_t *settings, void *context) {
+    minute_repeater_decimal_state_t *state = (minute_repeater_decimal_state_t *)context;
+
+    if (watch_tick_animation_is_running()) watch_stop_tick_animation();
+
+    if (settings->bit.clock_mode_24h) watch_set_indicator(WATCH_INDICATOR_24H);
+
+    // handle chime indicator
+    if (state->signal_enabled) watch_set_indicator(WATCH_INDICATOR_BELL);
+    else watch_clear_indicator(WATCH_INDICATOR_BELL);
+
+    // show alarm indicator if there is an active alarm
+    _update_alarm_indicator(settings->bit.alarm_enabled, state);
+
+    watch_set_colon();
+
+    // this ensures that none of the timestamp fields will match, so we can re-render them all.
+    state->previous_date_time = 0xFFFFFFFF;
+}
+
+bool minute_repeater_decimal_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
+    minute_repeater_decimal_state_t *state = (minute_repeater_decimal_state_t *)context;
+    char buf[11];
+    uint8_t pos;
+
+    watch_date_time date_time;
+    uint32_t previous_date_time;
+    switch (event.event_type) {
+        case EVENT_ACTIVATE:
+        case EVENT_TICK:
+        case EVENT_LOW_ENERGY_UPDATE:
+            date_time = watch_rtc_get_date_time();
+            previous_date_time = state->previous_date_time;
+            state->previous_date_time = date_time.reg;
+
+            // check the battery voltage once a day...
+            if (date_time.unit.day != state->last_battery_check) {
+                state->last_battery_check = date_time.unit.day;
+                watch_enable_adc();
+                uint16_t voltage = watch_get_vcc_voltage();
+                watch_disable_adc();
+                // 2.2 volts will happen when the battery has maybe 5-10% remaining?
+                // we can refine this later.
+                state->battery_low = (voltage < 2200);
+            }
+
+            // ...and set the LAP indicator if low.
+            if (state->battery_low) watch_set_indicator(WATCH_INDICATOR_LAP);
+
+            if ((date_time.reg >> 6) == (previous_date_time >> 6) && event.event_type != EVENT_LOW_ENERGY_UPDATE) {
+                // everything before seconds is the same, don't waste cycles setting those segments.
+                watch_display_character_lp_seconds('0' + date_time.unit.second / 10, 8);
+                watch_display_character_lp_seconds('0' + date_time.unit.second % 10, 9);
+                break;
+            } else if ((date_time.reg >> 12) == (previous_date_time >> 12) && event.event_type != EVENT_LOW_ENERGY_UPDATE) {
+                // everything before minutes is the same.
+                pos = 6;
+                sprintf(buf, "%02d%02d", date_time.unit.minute, date_time.unit.second);
+            } else {
+                // other stuff changed; let's do it all.
+                if (!settings->bit.clock_mode_24h) {
+                    // if we are in 12 hour mode, do some cleanup.
+                    if (date_time.unit.hour < 12) {
+                        watch_clear_indicator(WATCH_INDICATOR_PM);
+                    } else {
+                        watch_set_indicator(WATCH_INDICATOR_PM);
+                    }
+                    date_time.unit.hour %= 12;
+                    if (date_time.unit.hour == 0) date_time.unit.hour = 12;
+                }
+                pos = 0;
+                if (event.event_type == EVENT_LOW_ENERGY_UPDATE) {
+                    if (!watch_tick_animation_is_running()) watch_start_tick_animation(500);
+                    sprintf(buf, "%s%2d%2d%02d  ", watch_utility_get_weekday(date_time), date_time.unit.day, date_time.unit.hour, date_time.unit.minute);
+                } else {
+                    sprintf(buf, "%s%2d%2d%02d%02d", watch_utility_get_weekday(date_time), date_time.unit.day, date_time.unit.hour, date_time.unit.minute, date_time.unit.second);
+                }
+            }
+            watch_display_string(buf, pos);
+            // handle alarm indicator
+            if (state->alarm_enabled != settings->bit.alarm_enabled) _update_alarm_indicator(settings->bit.alarm_enabled, state);
+            break;
+        case EVENT_ALARM_LONG_PRESS:
+            state->signal_enabled = !state->signal_enabled;
+            if (state->signal_enabled) watch_set_indicator(WATCH_INDICATOR_BELL);
+            else watch_clear_indicator(WATCH_INDICATOR_BELL);
+            break;
+        case EVENT_BACKGROUND_TASK:
+            movement_play_signal();
+            break;
+        case EVENT_LIGHT_LONG_UP:
+            /*
+             * Howdy neighbors, this is the actual complication. Like an actual
+             * (very expensive) watch with a repetition minute complication it's
+             * boring at 00:00 or 1:00 and very quite musical at 23:59 or 12:59.
+             */
+
+            date_time = watch_rtc_get_date_time();
+            
+            
+            int hours = date_time.unit.hour;
+            int tens = date_time.unit.minute / 10;
+            int minutes = date_time.unit.minute % 10;
+
+            // chiming hours
+            if (!settings->bit.clock_mode_24h) {
+                hours = date_time.unit.hour % 12;                
+                if (hours == 0) hours = 12;
+            }
+            if (hours > 0) {
+                int count = 0;
+                for(count = hours; count > 0; --count) {          
+                    mrd_play_hour_chime();
+                }
+                // do a little pause before proceeding to tens
+                watch_buzzer_play_note(BUZZER_NOTE_REST, 500);
+            }
+
+            // chiming tens (if needed)
+            if (tens > 0) {
+                int count = 0;
+                for(count = tens; count > 0; --count) {          
+                    mrd_play_tens_chime();
+                }
+                // do a little pause before proceeding to minutes
+                watch_buzzer_play_note(BUZZER_NOTE_REST, 500);
+            }
+
+            // chiming minutes (if needed)
+            if (minutes > 0) {
+                int count = 0;
+                for(count = minutes; count > 0; --count) {          
+                    mrd_play_minute_chime();
+                }
+            }
+           
+            break; 
+        default:
+            return movement_default_loop_handler(event, settings);
+    }
+
+    return true;
+}
+
+void minute_repeater_decimal_face_resign(movement_settings_t *settings, void *context) {
+    (void) settings;
+    (void) context;
+}
+
+bool minute_repeater_decimal_face_wants_background_task(movement_settings_t *settings, void *context) {
+    (void) settings;
+    minute_repeater_decimal_state_t *state = (minute_repeater_decimal_state_t *)context;
+    if (!state->signal_enabled) return false;
+
+    watch_date_time date_time = watch_rtc_get_date_time();
+
+    return date_time.unit.minute == 0;
+}

--- a/movement/watch_faces/clock/minute_repeater_decimal_face.h
+++ b/movement/watch_faces/clock/minute_repeater_decimal_face.h
@@ -1,0 +1,84 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Jonas Termeau - original repetition_minute_face
+ * Copyright (c) 2023 Brian Blakley - modified minute_repeater_decimal_face
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef MINUTE_REPEATER_DECIMAL_FACE_H_
+#define MINUTE_REPEATER_DECIMAL_FACE_H_
+
+#include "movement.h"
+
+/*
+ * A hopefully useful complication for friendly neighbors in the dark
+ *
+ * Originating from 1676 from reverend and mechanician Edward Barlow, and
+ * perfected in 1820 by neighbor Abraham Breguet, a minute repeater or 
+ * "repetition minute" is a complication in a mechanical watch or clock that
+ * chimes the hours and often minutes at the press of a button. There are many
+ * types of repeater, from the simple repeater which merely strikes the number
+ * of hours, to the minute repeater which chimes the time down to the minute,
+ * using separate tones for hours, decimal hours, and minutes. They originated
+ * before widespread artificial illumination, to allow the time to be determined
+ * in the dark, and were also used by the visually impaired. 
+ *
+ *
+ * How to use it :
+ * 
+ * Long press the light button to get an auditive reading of the time like so :
+ * 0..23 (1..12 if 24-hours format isn't enabled) low beep(s) for the hours
+ * 0..9 low-high couple pitched beeps for the tens of minutes
+ * 0..9 high pitched beep(s) for the remaining minutes (ones of minutes)
+ *
+ * Prerequisite : a watch with a working buzzer
+ * 
+ * ~ Only in the darkness can you see the stars. - Martin Luther King ~
+ *
+ */
+
+typedef struct {
+    uint32_t previous_date_time;
+    uint8_t last_battery_check;
+    uint8_t watch_face_index;
+    bool signal_enabled;
+    bool battery_low;
+    bool alarm_enabled;
+} minute_repeater_decimal_state_t;
+
+void mrd_play_hour_chime(void);
+void mrd_play_tens_chime(void);
+void mrd_play_minute_chime(void);
+void minute_repeater_decimal_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr);
+void minute_repeater_decimal_face_activate(movement_settings_t *settings, void *context);
+bool minute_repeater_decimal_face_loop(movement_event_t event, movement_settings_t *settings, void *context);
+void minute_repeater_decimal_face_resign(movement_settings_t *settings, void *context);
+bool minute_repeater_decimal_face_wants_background_task(movement_settings_t *settings, void *context);
+
+#define minute_repeater_decimal_face ((const watch_face_t){ \
+    minute_repeater_decimal_face_setup, \
+    minute_repeater_decimal_face_activate, \
+    minute_repeater_decimal_face_loop, \
+    minute_repeater_decimal_face_resign, \
+    minute_repeater_decimal_face_wants_background_task, \
+})
+
+#endif // MINUTE_REPEATER_DECIMAL_FACE_H_


### PR DESCRIPTION
This new minute_repeater_decimal_face is a copy of repetition_minute_face, but with changes to make it a decimal minute repeater (hours, tens, and ones) instead of the more traditional, but more difficult to understand hours, quarter hours, and remainder minutes.

The new decimal minute repeater chimes 5:23 as:
ding,ding,ding,ding,ding (5) -- 5 hours
ding-dong,ding-dong (2) -- 20 minutes
dong,dong,dong (3) -- 3 minutes added to the 20 minutes (23 total)

The original repetition minute chimes 5:23 as:
ding,ding,ding,ding,ding (5) -- 5 hours
ding-dong (1) -- 1 quarter hour
dong,dong,dong,dong,dong,dong,dong,dong (8) -- 8 minutes added to the quarter hour (23 total)

With the decimal minute repeater there really is no math - the chimes tell you each digit of the time. You appreciate this if you've woken in the middle of the night and hit the button to chime the time, and aren't ready for even simple math.