### PR TITLE
Replace secondary face index with "pages" system.

### DIFF
--- a/movement/movement.c
+++ b/movement/movement.c
@@ -249,13 +249,13 @@ void movement_move_to_face(uint8_t watch_face_index) {
 }
 
 void movement_move_to_next_face(void) {
-    for (uint32_t i = 0; i < MOVEMENT_NUM_PAGES; i++) {
-        if ((movement_state.current_watch_face + 1) % MOVEMENT_NUM_FACES == movement_pages[i]) {
-            movement_move_to_face(0);
-            return;
-        }
+    uint16_t face_max;
+    if (MOVEMENT_HIDDEN_FACES_INDEX) {
+        face_max = (movement_state.current_watch_face < (int16_t)MOVEMENT_HIDDEN_FACES_INDEX) ? MOVEMENT_HIDDEN_FACES_INDEX : MOVEMENT_NUM_FACES;
+    } else {
+        face_max = MOVEMENT_NUM_FACES;
     }
-    movement_move_to_face(movement_state.current_watch_face + 1);
+    movement_move_to_face((movement_state.current_watch_face + 1) % face_max);
 }
 
 void movement_schedule_background_task(watch_date_time date_time) {

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -56,11 +56,6 @@
 
 #include "movement_custom_signal_tunes.h"
 
-// Default to no secondary face behaviour.
-#ifndef MOVEMENT_SECONDARY_FACE_INDEX
-#define MOVEMENT_SECONDARY_FACE_INDEX 0
-#endif
-
 // Set default LED colors if not set
 #ifndef MOVEMENT_DEFAULT_RED_COLOR
 #define MOVEMENT_DEFAULT_RED_COLOR 0x0
@@ -232,11 +227,14 @@ bool movement_default_loop_handler(movement_event_t event, movement_settings_t *
             movement_illuminate_led();
             break;
         case EVENT_MODE_LONG_PRESS:
-            if (MOVEMENT_SECONDARY_FACE_INDEX && movement_state.current_watch_face == 0) {
-                movement_move_to_face(MOVEMENT_SECONDARY_FACE_INDEX);
-            } else {
-                movement_move_to_face(0);
+            for (uint32_t i = 0; i < MOVEMENT_NUM_PAGES; i++) {
+                if (movement_state.current_watch_face == movement_pages[i]) {
+                    movement_move_to_face(movement_pages[(i + 1) % MOVEMENT_NUM_PAGES]);
+                    return true;
+                }
             }
+
+            movement_move_to_face(0);
             break;
         default:
             break;
@@ -251,13 +249,13 @@ void movement_move_to_face(uint8_t watch_face_index) {
 }
 
 void movement_move_to_next_face(void) {
-    uint16_t face_max;
-    if (MOVEMENT_SECONDARY_FACE_INDEX) {
-        face_max = (movement_state.current_watch_face < (int16_t)MOVEMENT_SECONDARY_FACE_INDEX) ? MOVEMENT_SECONDARY_FACE_INDEX : MOVEMENT_NUM_FACES;
-    } else {
-        face_max = MOVEMENT_NUM_FACES;
+    for (uint32_t i = 0; i < MOVEMENT_NUM_PAGES; i++) {
+        if ((movement_state.current_watch_face + 1) % MOVEMENT_NUM_FACES == movement_pages[i]) {
+            movement_move_to_face(0);
+            return;
+        }
     }
-    movement_move_to_face((movement_state.current_watch_face + 1) % face_max);
+    movement_move_to_face(movement_state.current_watch_face + 1);
 }
 
 void movement_schedule_background_task(watch_date_time date_time) {

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -228,9 +228,16 @@ bool movement_default_loop_handler(movement_event_t event, movement_settings_t *
             break;
         case EVENT_MODE_LONG_PRESS:
             for (uint32_t i = 0; i < MOVEMENT_NUM_PAGES; i++) {
-                if (movement_state.current_watch_face == movement_pages[i]) {
-                    movement_move_to_face(movement_pages[(i + 1) % MOVEMENT_NUM_PAGES]);
-                    return true;
+                if (MOVEMENT_MODE_LONGPRESS_ALWAYS_NEXT_PAGE) {
+                    if (movement_state.current_watch_face >= movement_pages[i] && movement_state.current_watch_face < movement_pages[(i + 1) % MOVEMENT_NUM_PAGES]) {
+                        movement_move_to_face(movement_pages[(i + 1) % MOVEMENT_NUM_PAGES]);
+                        return true;
+                    }
+                } else {
+                    if (movement_state.current_watch_face == movement_pages[i]) {
+                        movement_move_to_face(movement_pages[(i + 1) % MOVEMENT_NUM_PAGES]);
+                        return true;
+                    }
                 }
             }
 

--- a/movement/movement_config.h
+++ b/movement/movement_config.h
@@ -62,6 +62,13 @@ const uint8_t movement_pages[] = { 0, MOVEMENT_NUM_FACES - 2 };
 
 #define MOVEMENT_HIDDEN_FACES_INDEX MOVEMENT_NUM_FACES - 2
 
+/* Setting this to true will make a long-press of the mode button always jump
+ * to the next page, instead of the default behaviour, which is only jumping to
+ * the next page if you are on the first face of a page. This is likely most
+ * useful if you have a large number of faces, but it has the downside that it
+ * can make returning to the first face more difficult. */
+#define MOVEMENT_MODE_LONGPRESS_ALWAYS_NEXT_PAGE false
+
 /* Custom hourly chime tune. Check movement_custom_signal_tunes.h for options */
 #define SIGNAL_TUNE_DEFAULT
 

--- a/movement/movement_config.h
+++ b/movement/movement_config.h
@@ -41,13 +41,22 @@ const watch_face_t watch_faces[] = {
 
 #define MOVEMENT_NUM_FACES (sizeof(watch_faces) / sizeof(watch_face_t))
 
-/* Determines what face to go to from the first face on long press of the Mode button.
- * Also excludes these faces from the normal rotation.
- * In the default firmware, this lets you access temperature and battery voltage with a long press of Mode.
- * Some folks also like to use this to hide the preferences and time set faces from the normal rotation.
- * If you don't want any faces to be excluded, set this to 0 and a long Mode press will have no effect.
+/* This allows you to set up multiple "pages" of faces. Pressing the mode
+ * button will move through the faces in the current page, and long-pressing
+ * mode from the first face on a page will jump to the next page. Pressing mode
+ * at the end of a page or long-pressing mode on a face that isn't at the start
+ * of a page will return you to the initial page.
+ *
+ * This allows you to quickly cycle through the faces that are important to
+ * you, while hiding and organizing lesser-used faces behind long-presses of
+ * the mode button.
+ *
+ * By default, temperature and battery voltage are on the second page, but you
+ * can set this to { 0 } if you don't want to hide any faces.
  */
-#define MOVEMENT_SECONDARY_FACE_INDEX (MOVEMENT_NUM_FACES - 2) // or (0)
+const uint8_t movement_pages[] = { 0, MOVEMENT_NUM_FACES - 2 };
+
+#define MOVEMENT_NUM_PAGES (sizeof(movement_pages) / sizeof(*movement_pages))
 
 /* Custom hourly chime tune. Check movement_custom_signal_tunes.h for options */
 #define SIGNAL_TUNE_DEFAULT

--- a/movement/movement_config.h
+++ b/movement/movement_config.h
@@ -51,12 +51,16 @@ const watch_face_t watch_faces[] = {
  * you, while hiding and organizing lesser-used faces behind long-presses of
  * the mode button.
  *
- * By default, temperature and battery voltage are on the second page, but you
- * can set this to { 0 } if you don't want to hide any faces.
+ * By default, the second page of faces (temperature and battery voltage) are
+ * hidden using MOVEMENT_HIDDEN_FACES_INDEX. If you just want a simple list of
+ * faces instead of having some hidden, you can set movement_pages to { 0 } and
+ * MOVEMENT_HIDDEN_FACES_INDEX to 0.
  */
 const uint8_t movement_pages[] = { 0, MOVEMENT_NUM_FACES - 2 };
 
 #define MOVEMENT_NUM_PAGES (sizeof(movement_pages) / sizeof(*movement_pages))
+
+#define MOVEMENT_HIDDEN_FACES_INDEX MOVEMENT_NUM_FACES - 2
 
 /* Custom hourly chime tune. Check movement_custom_signal_tunes.h for options */
 #define SIGNAL_TUNE_DEFAULT


### PR DESCRIPTION
This keeps the exact same behaviour in the default case, but allows for having more than two pages of faces, useful for navigating a large number of faces.

The first commit implements this change.

The second commit adds a variable for configuring which faces are hidden, instead of hiding all but the first page of faces.

The third commit allows more configuration of mode long-press behaviour.

It's very possible that there's a nicer way to expose/configure this, I understand that this might be providing more knobs than people want. I'm happy to try to implement other ideas or write more thorough comments if that would help.