### PR TITLE
Enable LTO

### DIFF
--- a/make.mk
+++ b/make.mk
@@ -58,6 +58,7 @@ CFLAGS += -fdata-sections -ffunction-sections
 CFLAGS += -funsigned-char -funsigned-bitfields
 CFLAGS += -mcpu=cortex-m0plus -mthumb
 CFLAGS += -MD -MP -MT $(BUILD)/$(*F).o -MF $(BUILD)/$(@F).d
+CFLAGS += -flto=auto
 
 LDFLAGS += -mcpu=cortex-m0plus -mthumb
 LDFLAGS += -Wl,--gc-sections


### PR DESCRIPTION
This reduces the size of the build by ~8% and may improve speed or reduce power usage as well.

Yet to be tested on hardware.