### PR TITLE
Fix simulator keyboard shortcuts

### DIFF
--- a/watch-library/simulator/shell.html
+++ b/watch-library/simulator/shell.html
@@ -907,13 +907,13 @@
     </div>
   </div>
 
-  <div style="display: flex; flex-direction: column; width: 100%">
+  <form onSubmit="sendText(); return false" style="display: flex; flex-direction: column; width: 100%">
     <textarea id="output" rows="8" style="width: 100%"></textarea>
     <div style="display: flex">
       <input id="input" placeholder="Filesystem command (see filesystem.c)" style="flex-grow: 1"></input>
-      <button id="submit" onclick="sendText()">Send</button>
+      <button type="submit">Send</button>
     </div>
-  </div>
+  </form>
 
   <p>
     <a href="https://github.com/alexisphilip/Casio-F-91W">Original F-91W SVG</a> is &copy; 2020 Alexis Philip, used here

--- a/watch-library/simulator/watch/watch_extint.c
+++ b/watch-library/simulator/watch/watch_extint.c
@@ -28,7 +28,7 @@
 #include <emscripten.h>
 #include <emscripten/html5.h>
 
-static bool output_focused = false;
+static bool debug_console_focused = false;
 static bool external_interrupt_enabled = false;
 static bool button_callbacks_installed = false;
 static ext_irq_cb_t external_interrupt_mode_callback = NULL;
@@ -45,7 +45,7 @@ static const uint8_t BTN_IDS[] = { BTN_ID_ALARM, BTN_ID_LIGHT, BTN_ID_MODE };
 static EM_BOOL watch_invoke_interrupt_callback(const uint8_t button_id, watch_interrupt_trigger trigger);
 
 static EM_BOOL watch_invoke_key_callback(int eventType, const EmscriptenKeyboardEvent *keyEvent, void *userData) {
-    if (output_focused || keyEvent->repeat) return EM_FALSE;
+    if (debug_console_focused || keyEvent->repeat) return EM_FALSE;
 
     const char *key = keyEvent->key;
     if (key[1] != 0) return EM_FALSE;
@@ -86,7 +86,7 @@ static EM_BOOL watch_invoke_touch_callback(int eventType, const EmscriptenTouchE
 }
 
 static EM_BOOL watch_invoke_focus_callback(int eventType, const EmscriptenFocusEvent *focusEvent, void *userData) {
-    output_focused = eventType == EMSCRIPTEN_EVENT_FOCUS;
+    debug_console_focused = eventType == EMSCRIPTEN_EVENT_FOCUS;
     return EM_TRUE;
 }
 
@@ -97,6 +97,10 @@ static void watch_install_button_callbacks(void) {
     const char *target_output = "#output";
     emscripten_set_focus_callback(target_output, NULL, EM_FALSE, watch_invoke_focus_callback);
     emscripten_set_blur_callback(target_output, NULL, EM_FALSE, watch_invoke_focus_callback);
+
+    const char *target_input = "#input";
+    emscripten_set_focus_callback(target_input, NULL, EM_FALSE, watch_invoke_focus_callback);
+    emscripten_set_blur_callback(target_input, NULL, EM_FALSE, watch_invoke_focus_callback);
 
     for (int i = 0, count = sizeof(BTN_IDS) / sizeof(BTN_IDS[0]); i < count; i++) {
         char target[] = "#btn_";


### PR DESCRIPTION
For context, currently in the simulator, A, L and M keys are shortcuts to "press" Alarm, Light and Mode buttons.

There was a few issues with that.

First issue is that these shortcuts prevented typing these letters in the debug console input.

Second thing is more a matter of taste; even though A, L and M are pretty logical, they are unfortunately physically located on a keyboard in the "wrong" places: A is on the left side of the keyboard while on the watch it's on the right, and for L it's the opposite. This made the shortcuts very counter-intuitive to actually use. For this reason, I added the arrow keys as shortcuts. Arrow up is the Light (the button on the top-left of the watch, arrow down (or left) is the Mode (the button on the bottom-left of the watch), and arrow right is the Alarm (button on the bottom-right).

Arrows have the benefit that contrary to any other letter keys, we can expect them to be placed in the correct disposition on all keyboards.