### PR TITLE
fix undefined behavior found by clang's sanitize

### DIFF
--- a/watch-library/hardware/watch/watch_rtc.c
+++ b/watch-library/hardware/watch/watch_rtc.c
@@ -84,7 +84,7 @@ void watch_rtc_register_periodic_callback(ext_irq_cb_t callback, uint8_t frequen
     if (__builtin_popcount(frequency) != 1) return;
 
     // this left-justifies the period in a 32-bit integer.
-    uint32_t tmp = frequency << 24;
+    uint32_t tmp = (frequency & 0xFF) << 24;
     // now we can count the leading zeroes to get the value we need.
     // 0x01 (1 Hz) will have 7 leading zeros for PER7. 0xF0 (128 Hz) will have no leading zeroes for PER0.
     uint8_t per_n = __builtin_clz(tmp);
@@ -99,7 +99,7 @@ void watch_rtc_register_periodic_callback(ext_irq_cb_t callback, uint8_t frequen
 
 void watch_rtc_disable_periodic_callback(uint8_t frequency) {
     if (__builtin_popcount(frequency) != 1) return;
-    uint8_t per_n = __builtin_clz(frequency << 24);
+    uint8_t per_n = __builtin_clz((frequency & 0xFF) << 24);
     RTC->MODE2.INTENCLR.reg = 1 << per_n;
 }
 

--- a/watch-library/simulator/watch/watch_rtc.c
+++ b/watch-library/simulator/watch/watch_rtc.c
@@ -92,7 +92,7 @@ void watch_rtc_register_periodic_callback(ext_irq_cb_t callback, uint8_t frequen
     if (__builtin_popcount(frequency) != 1) return;
 
     // this left-justifies the period in a 32-bit integer.
-    uint32_t tmp = frequency << 24;
+    uint32_t tmp = (frequency & 0xFF) << 24;
     // now we can count the leading zeroes to get the value we need.
     // 0x01 (1 Hz) will have 7 leading zeros for PER7. 0xF0 (128 Hz) will have no leading zeroes for PER0.
     uint8_t per_n = __builtin_clz(tmp);
@@ -105,7 +105,7 @@ void watch_rtc_register_periodic_callback(ext_irq_cb_t callback, uint8_t frequen
 
 void watch_rtc_disable_periodic_callback(uint8_t frequency) {
     if (__builtin_popcount(frequency) != 1) return;
-    uint8_t per_n = __builtin_clz(frequency << 24);
+    uint8_t per_n = __builtin_clz((frequency & 0xFF) << 24);
     if (tick_callbacks[per_n] != -1) {
         emscripten_clear_interval(tick_callbacks[per_n]);
         tick_callbacks[per_n] = -1;


### PR DESCRIPTION
The compiler isn't completely assured of the possible range of this variable. Probably harmless, but it clears up a clang sanitize error.