### PR TITLE
make the zero in wyoscan a little more visually appealing

### DIFF
--- a/movement/watch_faces/clock/wyoscan_face.c
+++ b/movement/watch_faces/clock/wyoscan_face.c
@@ -60,7 +60,7 @@ a line you've already drawn. It is vaguely top to bottom and counter,
 clockwise when possible.
 */
 static char *segment_map[] = {
-    "AXFEDCBX",  // 0
+    "AXFBDEXC",  // 0
     "BXXXCXXX",  // 1
     "ABGEXXXD",  // 2
     "ABGXXXCD",  // 3


### PR DESCRIPTION
The Wyoscan app on the iPhone uses an asymmetric decay pattern for 0 instead of the oldest-first pattern that this replica face uses. This new ordering of 0 segments makes the decaying 0 less visually confusable with the decaying 1.