### PR TITLE
WIP switching RTC to count32 (vs clock)

### DIFF
--- a/movement/movement.c
+++ b/movement/movement.c
@@ -391,10 +391,8 @@ void app_setup(void) {
         }
 
         // set up the 1 minute alarm (for background tasks and low power updates)
-        watch_date_time alarm_time;
-        alarm_time.reg = 0;
-        alarm_time.unit.second = 59; // after a match, the alarm fires at the next rising edge of CLK_RTC_CNT, so 59 seconds lets us update at :00
-        watch_rtc_register_alarm_callback(cb_alarm_fired, alarm_time, ALARM_MATCH_SS);
+        // TODO
+        // watch_rtc_register_regular_callback(cb_alarm_fired, alarm_time, ALARM_MATCH_SS);
     }
     if (movement_state.le_mode_ticks != -1) {
         watch_disable_extwake_interrupt(BTN_ALARM);

--- a/movement/watch_faces/clock/simple_clock_face.c
+++ b/movement/watch_faces/clock/simple_clock_face.c
@@ -124,6 +124,9 @@ bool simple_clock_face_loop(movement_event_t event, movement_settings_t *setting
                     sprintf(buf, "%s%2d%2d%02d%02d", watch_utility_get_weekday(date_time), date_time.unit.day, date_time.unit.hour, date_time.unit.minute, date_time.unit.second);
                 }
             }
+            //printf("%d-%d-%2d %2d:%02d:%02d\n", date_time.unit.year, date_time.unit.month, date_time.unit.day, date_time.unit.hour, date_time.unit.minute, date_time.unit.second);
+            //printf("unix time: %lu\n", watch_rtc_get_unix_time());
+            //printf("unix time raw: %llu\n", watch_rtc_get_unix_time_raw());
             watch_display_string(buf, pos);
             // handle alarm indicator
             if (state->alarm_enabled != settings->bit.alarm_enabled) _update_alarm_indicator(settings->bit.alarm_enabled, state);

--- a/movement/watch_faces/settings/set_time_face.c
+++ b/movement/watch_faces/settings/set_time_face.c
@@ -183,5 +183,6 @@ void set_time_face_resign(movement_settings_t *settings, void *context) {
     (void) settings;
     (void) context;
     watch_set_led_off();
+    watch_rtc_set_tz_offset(movement_timezone_offsets[settings->bit.time_zone]);
     watch_store_backup_data(settings->reg, 0);
 }

--- a/watch-library/hardware/watch/watch_rtc.c
+++ b/watch-library/hardware/watch/watch_rtc.c
@@ -22,53 +22,108 @@
  * SOFTWARE.
  */
 
+#include <limits.h>
+
+#include "watch_utility.h"
+#include "watch_deepsleep.h"
 #include "watch_rtc.h"
 
 ext_irq_cb_t tick_callbacks[8];
-ext_irq_cb_t alarm_callback;
 ext_irq_cb_t btn_alarm_callback;
 ext_irq_cb_t a2_callback;
 ext_irq_cb_t a4_callback;
 
+static const int CLK_RTC_OSC_HZ = 1024;
+static const int PRESCALER_SETTING = RTC_MODE2_CTRLA_PRESCALER_DIV4_Val;
+static const int PRESCALER_DIV = 1 << (PRESCALER_SETTING - 1);
+const int CLK_RTC_CNT_HZ = CLK_RTC_OSC_HZ / PRESCALER_DIV;
+
 bool _watch_rtc_is_enabled(void) {
-    return RTC->MODE2.CTRLA.bit.ENABLE;
+    return RTC->MODE0.CTRLA.bit.ENABLE;
 }
 
 static void _sync_rtc(void) {
-    while (RTC->MODE2.SYNCBUSY.reg);
+    while (RTC->MODE0.SYNCBUSY.reg);
 }
 
 void _watch_rtc_init(void) {
     MCLK->APBAMASK.reg |= MCLK_APBAMASK_RTC;
 
-    if (_watch_rtc_is_enabled()) return; // don't reset the RTC if it's already set up.
+    // TODO was this guarding some kind of reboot thing?
+    //if (_watch_rtc_is_enabled()) return; // don't reset the RTC if it's already set up.
 
-    RTC->MODE2.CTRLA.bit.ENABLE = 0;
+    RTC->MODE0.CTRLA.bit.ENABLE = 0;
     _sync_rtc();
 
-    RTC->MODE2.CTRLA.bit.SWRST = 1;
+    RTC->MODE0.CTRLA.bit.SWRST = 1;
     _sync_rtc();
 
-    RTC->MODE2.CTRLA.bit.MODE = RTC_MODE2_CTRLA_MODE_CLOCK_Val;
-    RTC->MODE2.CTRLA.bit.PRESCALER = RTC_MODE2_CTRLA_PRESCALER_DIV1024_Val;
-    RTC->MODE2.CTRLA.bit.CLOCKSYNC = 1;
-    RTC->MODE2.CTRLA.bit.ENABLE = 1;
+    RTC->MODE0.CTRLA.bit.MODE = RTC_MODE0_CTRLA_MODE_COUNT32_Val;
+    RTC->MODE0.CTRLA.bit.PRESCALER = PRESCALER_SETTING;
+    RTC->MODE0.CTRLA.bit.COUNTSYNC = 1;
+    RTC->MODE0.CTRLA.bit.ENABLE = 1;
+    RTC->MODE0.INTENSET.reg = RTC_MODE0_INTENSET_OVF;
     _sync_rtc();
 }
 
+static const int TZ_OFFSET_DIVIDER = 15;  // i.e. the granularity of our TZ_OFFSET is in 15 minute intervals
+// TODO Mark this as used in movement.h description
+static const int TB_BKUP_REG = 7;
+
+union time_backup {
+    struct {
+        int32_t tz_offset : 8;
+        uint32_t offset : 24;
+    } bit;
+
+    uint32_t reg;
+};
+
 void watch_rtc_set_date_time(watch_date_time date_time) {
-    _sync_rtc(); // Double sync as without it at high Hz faces setting time is unrealiable (specifically, set_time_hackwatch)
-    RTC->MODE2.CLOCK.reg = date_time.reg;
+    union time_backup tb;
+    tb.reg = watch_get_backup_data(TB_BKUP_REG);
+    watch_rtc_set_unix_time(watch_utility_date_time_to_unix_time(date_time, tb.bit.tz_offset * TZ_OFFSET_DIVIDER));
+}
+
+void watch_rtc_set_unix_time_raw(uint64_t unix_time_raw) {
+    union time_backup tb;
+    tb.reg = watch_get_backup_data(TB_BKUP_REG);
+    tb.bit.offset = (unix_time_raw >> 8) / CLK_RTC_CNT_HZ;
+    watch_store_backup_data(tb.reg, TB_BKUP_REG);
     _sync_rtc();
+    RTC->MODE0.COUNT.reg = unix_time_raw & ((1 << 8) * CLK_RTC_CNT_HZ - 1);
+}
+
+void watch_rtc_set_unix_time(uint32_t unix_time) {
+    watch_rtc_set_unix_time_raw((uint64_t)unix_time * CLK_RTC_CNT_HZ);
+}
+
+void watch_rtc_set_tz_offset(uint32_t tz_offset) {
+    union time_backup tb;
+    tb.reg = watch_get_backup_data(TB_BKUP_REG);
+    tb.bit.tz_offset = tz_offset / TZ_OFFSET_DIVIDER;
+    watch_store_backup_data(tb.reg, TB_BKUP_REG);
+}
+
+uint32_t watch_rtc_get_unix_time(void) {
+    union time_backup tb;
+    tb.reg = watch_get_backup_data(TB_BKUP_REG);
+    _sync_rtc();
+    return (tb.bit.offset << 8) + RTC->MODE0.COUNT.reg / CLK_RTC_CNT_HZ;
+}
+
+uint64_t watch_rtc_get_unix_time_raw(void) {
+    union time_backup tb;
+    tb.reg = watch_get_backup_data(TB_BKUP_REG);
+    _sync_rtc();
+    return (uint64_t)(tb.bit.offset << 8) * CLK_RTC_CNT_HZ + RTC->MODE0.COUNT.reg;
 }
 
 watch_date_time watch_rtc_get_date_time(void) {
-    watch_date_time retval;
-
+    union time_backup tb;
+    tb.reg = watch_get_backup_data(TB_BKUP_REG);
     _sync_rtc();
-    retval.reg = RTC->MODE2.CLOCK.reg;
-
-    return retval;
+    return watch_utility_date_time_from_unix_time((tb.bit.offset << 8) + RTC->MODE0.COUNT.reg / CLK_RTC_CNT_HZ, tb.bit.tz_offset * TZ_OFFSET_DIVIDER);
 }
 
 void watch_rtc_register_tick_callback(ext_irq_cb_t callback) {
@@ -94,42 +149,28 @@ void watch_rtc_register_periodic_callback(ext_irq_cb_t callback, uint8_t frequen
 
     NVIC_ClearPendingIRQ(RTC_IRQn);
     NVIC_EnableIRQ(RTC_IRQn);
-    RTC->MODE2.INTENSET.reg = 1 << per_n;
+    RTC->MODE0.INTENSET.reg = 1 << per_n;
 }
 
 void watch_rtc_disable_periodic_callback(uint8_t frequency) {
     if (__builtin_popcount(frequency) != 1) return;
     uint8_t per_n = __builtin_clz((frequency & 0xFF) << 24);
-    RTC->MODE2.INTENCLR.reg = 1 << per_n;
+    RTC->MODE0.INTENCLR.reg = 1 << per_n;
 }
 
 void watch_rtc_disable_matching_periodic_callbacks(uint8_t mask) {
-    RTC->MODE2.INTENCLR.reg = mask;
+    RTC->MODE0.INTENCLR.reg = mask;
 }
 
 void watch_rtc_disable_all_periodic_callbacks(void) {
     watch_rtc_disable_matching_periodic_callbacks(0xFF);
 }
 
-void watch_rtc_register_alarm_callback(ext_irq_cb_t callback, watch_date_time alarm_time, watch_rtc_alarm_match mask) {
-    RTC->MODE2.Mode2Alarm[0].ALARM.reg = alarm_time.reg;
-    RTC->MODE2.Mode2Alarm[0].MASK.reg = mask;
-    RTC->MODE2.INTENSET.reg = RTC_MODE2_INTENSET_ALARM0;
-    alarm_callback = callback;
-    NVIC_ClearPendingIRQ(RTC_IRQn);
-    NVIC_EnableIRQ(RTC_IRQn);
-    RTC->MODE2.INTENSET.reg = RTC_MODE2_INTENSET_ALARM0;
-}
-
-void watch_rtc_disable_alarm_callback(void) {
-    RTC->MODE2.INTENCLR.reg = RTC_MODE2_INTENCLR_ALARM0;
-}
-
 void RTC_Handler(void) {
-    uint16_t interrupt_status = RTC->MODE2.INTFLAG.reg;
-    uint16_t interrupt_enabled = RTC->MODE2.INTENSET.reg;
+    uint16_t interrupt_status = RTC->MODE0.INTFLAG.reg;
+    uint16_t interrupt_enabled = RTC->MODE0.INTENSET.reg;
 
-    if ((interrupt_status & interrupt_enabled) & RTC_MODE2_INTFLAG_PER_Msk) {
+    if ((interrupt_status & interrupt_enabled) & RTC_MODE0_INTFLAG_PER_Msk) {
         // handle the tick callback first, it's what we do the most.
         // start from PER7, the 1 Hz tick.
         for(int8_t i = 7; i >= 0; i--) {
@@ -137,13 +178,13 @@ void RTC_Handler(void) {
                 if (tick_callbacks[i] != NULL) {
                     tick_callbacks[i]();
                 }
-                RTC->MODE2.INTFLAG.reg = 1 << i;
+                RTC->MODE0.INTFLAG.reg = 1 << i;
 //                break; Uncertain if this fix is requried. We were discussing in discord. Might slightly increase power consumption. 
             }
         }
-    } else if ((interrupt_status & interrupt_enabled) & RTC_MODE2_INTFLAG_TAMPER) {
+    } else if ((interrupt_status & interrupt_enabled) & RTC_MODE0_INTFLAG_TAMPER) {
         // handle the extwake interrupts next.
-        uint8_t reason = RTC->MODE2.TAMPID.reg;
+        uint8_t reason = RTC->MODE0.TAMPID.reg;
         if (reason & RTC_TAMPID_TAMPID2) {
             if (btn_alarm_callback != NULL) btn_alarm_callback();
         } else if (reason & RTC_TAMPID_TAMPID1) {
@@ -151,14 +192,16 @@ void RTC_Handler(void) {
         } else if (reason & RTC_TAMPID_TAMPID0) {
             if (a4_callback != NULL) a4_callback();
         }
-        RTC->MODE2.TAMPID.reg = reason;
-        RTC->MODE2.INTFLAG.reg = RTC_MODE2_INTFLAG_TAMPER;
-    } else if ((interrupt_status & interrupt_enabled) & RTC_MODE2_INTFLAG_ALARM0) {
-        // finally handle the alarm.
-        if (alarm_callback != NULL) {
-            alarm_callback();
-        }
-        RTC->MODE2.INTFLAG.reg = RTC_MODE2_INTFLAG_ALARM0;
+        RTC->MODE0.TAMPID.reg = reason;
+        RTC->MODE0.INTFLAG.reg = RTC_MODE0_INTFLAG_TAMPER;
+    } else if ((interrupt_status & interrupt_enabled) & RTC_MODE0_INTFLAG_OVF) {
+        // Why is this 'else if'? Is it impossible for two interrupts to trigger
+        // at the same time?
+        union time_backup tb;
+        tb.reg = watch_get_backup_data(TB_BKUP_REG);
+        tb.bit.offset += (UINT_MAX >> 8) / CLK_RTC_CNT_HZ + 1;
+        watch_store_backup_data(tb.reg, TB_BKUP_REG);
+        RTC->MODE0.INTFLAG.reg = RTC_MODE0_INTFLAG_OVF;
     }
 }
 
@@ -166,11 +209,11 @@ void watch_rtc_enable(bool en)
 {
     // Writing it twice - as it's quite dangerous operation.
     // If write fails - we might hang with RTC off, which means no recovery possible
-    while (RTC->MODE2.SYNCBUSY.reg);
-    RTC->MODE2.CTRLA.bit.ENABLE = en ? 1 : 0;
-    while (RTC->MODE2.SYNCBUSY.reg);
-    RTC->MODE2.CTRLA.bit.ENABLE = en ? 1 : 0;
-    while (RTC->MODE2.SYNCBUSY.reg);
+    while (RTC->MODE0.SYNCBUSY.reg);
+    RTC->MODE0.CTRLA.bit.ENABLE = en ? 1 : 0;
+    while (RTC->MODE0.SYNCBUSY.reg);
+    RTC->MODE0.CTRLA.bit.ENABLE = en ? 1 : 0;
+    while (RTC->MODE0.SYNCBUSY.reg);
 }
 
 void watch_rtc_freqcorr_write(int16_t value, int16_t sign)
@@ -180,7 +223,7 @@ void watch_rtc_freqcorr_write(int16_t value, int16_t sign)
     data.bit.VALUE = value;
     data.bit.SIGN = sign;
 
-    RTC->MODE2.FREQCORR.reg = data.reg; // Setting correction in single write operation
+    RTC->MODE0.FREQCORR.reg = data.reg; // Setting correction in single write operation
 
     // We do not sycnronize. We are not in a hurry
 }

--- a/watch-library/shared/watch/watch_rtc.h
+++ b/watch-library/shared/watch/watch_rtc.h
@@ -21,16 +21,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 #ifndef _WATCH_RTC_H_INCLUDED
 #define _WATCH_RTC_H_INCLUDED
-////< @file watch_rtc.h
 
 #include "watch.h"
 #include "hpl_calendar.h"
 
 /** @addtogroup rtc Real-Time Clock
   * @brief This section covers functions related to the SAM L22's real-time clock peripheral, including
-  *        date, time and alarm functions.
+  *        date and time functions.
   * @details The real-time clock is the only peripheral that main.c enables for you. It is the cornerstone
   *          of low power operation on the watch, and it is required for several key functions that we
   *          assume will be available, namely the wake from BACKUP mode and the callback on the ALARM button.
@@ -40,6 +40,8 @@
 /// @{
 
 #define WATCH_RTC_REFERENCE_YEAR (2020)
+
+extern const int CLK_RTC_CNT_HZ;
 
 typedef union {
     struct {
@@ -52,13 +54,6 @@ typedef union {
     } unit;
     uint32_t reg;               // the bit-packed value as expected by the RTC peripheral's CLOCK register.
 } watch_date_time;
-
-typedef enum watch_rtc_alarm_match {
-    ALARM_MATCH_DISABLED = 0,
-    ALARM_MATCH_SS,
-    ALARM_MATCH_MMSS,
-    ALARM_MATCH_HHMMSS,
-} watch_rtc_alarm_match;
 
 /** @brief Called by main.c to check if the RTC is enabled.
   * You may call this function, but outside of app_init, it should always return true.
@@ -81,26 +76,12 @@ void watch_rtc_set_date_time(watch_date_time date_time);
   */
 watch_date_time watch_rtc_get_date_time(void);
 
-/** @brief Registers an alarm callback that will be called when the RTC time matches the target time, as masked
-  *        by the provided mask.
-  * @param callback The function you wish to have called when the alarm fires. If this value is NULL, the alarm
-  *                 interrupt will still be enabled, but no callback function will be called.
-  * @param alarm_time The time that you wish to match. The date is currently ignored.
-  * @param mask One of the values in watch_rtc_alarm_match indicating which values to check.
-  * @details The alarm interrupt is a versatile tool for scheduling events in the future, especially since it can
-  *          wake the device from all sleep modes. The key to its versatility is the mask parameter.
-  *          Suppose we set an alarm for midnight, 00:00:00.
-  *           * if mask is ALARM_MATCH_SS, the alarm will fire every minute when the clock ticks to seconds == 0.
-  *           * with ALARM_MATCH_MMSS, the alarm will once an hour, at the top of each hour.
-  *           * with ALARM_MATCH_HHMMSS, the alarm will fire at midnight every day.
-  *          In theory the SAM L22's alarm function can match on days, months and even years, but I have not had
-  *          success with this yet; as such, I am omitting these options for now.
-  */
-void watch_rtc_register_alarm_callback(ext_irq_cb_t callback, watch_date_time alarm_time, watch_rtc_alarm_match mask);
-
-/** @brief Disables the alarm callback.
-  */
-void watch_rtc_disable_alarm_callback(void);
+//TODO
+uint32_t watch_rtc_get_unix_time(void);
+uint64_t watch_rtc_get_unix_time_raw(void);
+void watch_rtc_set_unix_time(uint32_t);
+void watch_rtc_set_unix_time_raw(uint64_t);
+void watch_rtc_set_tz_offset(uint32_t tz_offset);
 
 /** @brief Registers a "tick" callback that will be called once per second.
   * @param callback The function you wish to have called when the clock ticks. If you pass in NULL, the tick


### PR DESCRIPTION
The RTC has three modes, COUNT16, COUNT32 and CLOCK.

CLOCK is nice, in that it:
- gives us year/month/day/hours/mins/secs straight up
- allows one to set a number of alarms

However, it doesn't support more than 1 sec granularity. This makes things like a stopwatch (or time systems that don't use seconds) annoying, and also makes it harder for us to set it appropriately (see hackwatch).

If we use COUNT32 instead, we get up to 1024Hz granularity (with the 1024Hz oscillator configured). This commit has it set to 256Hz.

Downsides:
- extra code complexity
- we have to maintain an offset (and know about the TZ at a lower level if we want compatibility)
- we lose the in-built periodic alarms. At the moment, we're only using these for the 1minute wake from sleep operation, which could be replaced by a COMP check (TODO!)
- potentially, power consumption (I suspect not, since the internals have to deal with the 1024Hz oscillator and the events based on this anyway, but ...)

TODO:
- simulator support
- comments on new public functions
- public function to get just the sub-second count (maybe?) or create a non-compatible watch_get_date_time function which returns all the relevant info (and the real year?)
- add COMP check to replicate wake from sleep behaviour
- power consumption implications (if none, switch to 1024Hz counter?)