### PR TITLE
Balanced nonary clock face

### DIFF
--- a/movement/make/Makefile
+++ b/movement/make/Makefile
@@ -122,6 +122,7 @@ SRCS += \
   ../watch_faces/clock/minute_repeater_decimal_face.c \
   ../watch_faces/complication/tuning_tones_face.c \
   ../watch_faces/complication/kitchen_conversions_face.c \
+  ../watch_faces/clock/nonary_clock_face.c \
 # New watch faces go above this line.
 
 # Leave this line at the bottom of the file; it has all the targets for making your project.

--- a/movement/movement_faces.h
+++ b/movement/movement_faces.h
@@ -99,6 +99,7 @@
 #include "minute_repeater_decimal_face.h"
 #include "tuning_tones_face.h"
 #include "kitchen_conversions_face.h"
+#include "nonary_clock_face.h"
 // New includes go above this line.
 
 #endif // MOVEMENT_FACES_H_

--- a/movement/watch_faces/clock/minute_repeater_decimal_face.c
+++ b/movement/watch_faces/clock/minute_repeater_decimal_face.c
@@ -129,8 +129,8 @@ bool minute_repeater_decimal_face_loop(movement_event_t event, movement_settings
 
             if ((date_time.reg >> 6) == (previous_date_time >> 6) && event.event_type != EVENT_LOW_ENERGY_UPDATE) {
                 // everything before seconds is the same, don't waste cycles setting those segments.
-                watch_display_character_lp_seconds('0' + date_time.unit.second / 10, 8);
-                watch_display_character_lp_seconds('0' + date_time.unit.second % 10, 9);
+                watch_display_character_lp('0' + date_time.unit.second / 10, 8);
+                watch_display_character_lp('0' + date_time.unit.second % 10, 9);
                 break;
             } else if ((date_time.reg >> 12) == (previous_date_time >> 12) && event.event_type != EVENT_LOW_ENERGY_UPDATE) {
                 // everything before minutes is the same.

--- a/movement/watch_faces/clock/nonary_clock_face.c
+++ b/movement/watch_faces/clock/nonary_clock_face.c
@@ -1,0 +1,235 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 James Haggerty <james@gruemail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "nonary_clock_face.h"
+#include "watch.h"
+#include "watch_utility.h"
+#include "watch_private_display.h"
+
+static const int TICK_FREQUENCY = 8;
+
+static void _update_alarm_indicator(bool settings_alarm_enabled, nonary_clock_state_t *state) {
+    state->alarm_enabled = settings_alarm_enabled;
+    if (state->alarm_enabled) watch_set_indicator(WATCH_INDICATOR_SIGNAL);
+    else watch_clear_indicator(WATCH_INDICATOR_SIGNAL);
+}
+
+void nonary_clock_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {
+    (void) settings;
+    (void) watch_face_index;
+
+    if (*context_ptr == NULL) {
+        *context_ptr = malloc(sizeof(nonary_clock_state_t));
+        nonary_clock_state_t *state = (nonary_clock_state_t *)*context_ptr;
+        state->signal_enabled = false;
+        state->watch_face_index = watch_face_index;
+    }
+}
+
+static const int32_t NONARY_SECS_IN_HOUR = 9 * 9 * 9 * 9;
+
+/*
+ * Bit position -> segment mapping.
+ *  --0--
+ * |     |
+ * 5     1
+ * |     |
+ *  --6--
+ * |     |
+ * 4     2
+ * |     |
+ *  --3--
+ *
+ * Digits (-4,-3,-2-1,0,1,2,3,4)
+ *     __   __  __  __  __
+ *     __   __         |  |       __   __   __|
+ *    |__|, __|,__|,__,|__|,   |,   |,|  |,|  |
+ */
+uint8_t nonary_digit_map[] = {
+    0b01011101, // -4
+    0b01001101, // -3
+    0b00001101, // -2
+    0b00001001, // -1
+    0b00111111, // 0
+    0b00000100, // 1
+    0b01000100, // 2
+    0b01010100, // 3
+    0b01010110, // 4
+};
+
+static uint8_t previous_display[4];
+
+static void display_nonary(int32_t val, int pos, int max_len) {
+    int sign = val >= 0 ? 1 : -1;
+    val = abs(val);
+    for (int i = 0; i < max_len && pos >= 0; ++i) {
+        int digit = val % 9;
+        val /= 9;
+        if (digit >= 5) {
+            digit -= 9;
+            val += 1;
+        }
+        uint8_t c = nonary_digit_map[digit * sign + 4];
+        if (previous_display[pos] != c) {
+            watch_display_segdata(c, pos--);
+        }
+    }
+}
+
+static int32_t find_nonary_secs_from_hour(watch_date_time date_time, int ticks) {
+    int32_t nonary_secs_past_hour = ((date_time.unit.minute * 60 + date_time.unit.second) * TICK_FREQUENCY + ticks) * NONARY_SECS_IN_HOUR / TICK_FREQUENCY / 3600;
+
+    return nonary_secs_past_hour <= NONARY_SECS_IN_HOUR / 2 ? nonary_secs_past_hour : (nonary_secs_past_hour - NONARY_SECS_IN_HOUR);
+}
+
+void nonary_clock_face_activate(movement_settings_t *settings, void *context) {
+    nonary_clock_state_t *state = (nonary_clock_state_t *)context;
+
+    if (watch_tick_animation_is_running()) watch_stop_tick_animation();
+
+    if (settings->bit.clock_mode_24h) watch_set_indicator(WATCH_INDICATOR_24H);
+
+    // handle chime indicator
+    if (state->signal_enabled) watch_set_indicator(WATCH_INDICATOR_BELL);
+    else watch_clear_indicator(WATCH_INDICATOR_BELL);
+
+    // show alarm indicator if there is an active alarm
+    _update_alarm_indicator(settings->bit.alarm_enabled, state);
+
+    watch_set_colon();
+
+    // this ensures that none of the timestamp fields will match, so we can re-render them all.
+    state->previous_date_time = 0xFFFFFFFF;
+
+    // Since our seconds aren't really seconds, we need a higher tick frequency
+    // to avoid skips and jerky time changes.
+    movement_request_tick_frequency(TICK_FREQUENCY);
+
+    memset(previous_display, ' ', sizeof(previous_display));
+}
+
+bool nonary_clock_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
+    static uint8_t ticks = 0;
+    static int32_t previous_nonary_secs_from_hour = 0;
+    nonary_clock_state_t *state = (nonary_clock_state_t *)context;
+
+    watch_date_time date_time;
+    uint32_t previous_date_time;
+    switch (event.event_type) {
+        case EVENT_TICK:
+        case EVENT_ACTIVATE:
+        case EVENT_LOW_ENERGY_UPDATE:
+            date_time = watch_rtc_get_date_time();
+            previous_date_time = state->previous_date_time;
+            state->previous_date_time = date_time.reg;
+
+            if (event.event_type == EVENT_TICK) {
+                if (previous_date_time == date_time.reg) {
+                    ++ticks;
+                } else {
+                    ticks = 0;
+                }
+            }
+
+            // check the battery voltage once a day...
+            if (date_time.unit.day != state->last_battery_check) {
+                state->last_battery_check = date_time.unit.day;
+                watch_enable_adc();
+                uint16_t voltage = watch_get_vcc_voltage();
+                watch_disable_adc();
+                // 2.2 volts will happen when the battery has maybe 5-10% remaining?
+                // we can refine this later.
+                state->battery_low = (voltage < 2200);
+            }
+
+            // ...and set the LAP indicator if low.
+            if (state->battery_low) watch_set_indicator(WATCH_INDICATOR_LAP);
+
+            // handle alarm indicator
+            if (state->alarm_enabled != settings->bit.alarm_enabled) _update_alarm_indicator(settings->bit.alarm_enabled, state);
+
+            int32_t nonary_secs_from_hour = find_nonary_secs_from_hour(date_time, ticks);
+            if (previous_nonary_secs_from_hour != nonary_secs_from_hour) {
+                display_nonary(nonary_secs_from_hour, 9, 4);
+                previous_nonary_secs_from_hour = nonary_secs_from_hour;
+            }
+
+            if ((date_time.reg >> 12) == (previous_date_time >> 12) && event.event_type != EVENT_LOW_ENERGY_UPDATE) {
+                break;
+            }
+
+            int32_t nonary_hour = (int32_t)date_time.unit.hour - 12 + (nonary_secs_from_hour < 0);
+            display_nonary(nonary_hour, 5, 2);
+            char buf[5];
+            sprintf(buf, "%s%2d", watch_utility_get_weekday(date_time), date_time.unit.day);
+            watch_display_string(buf, 0);
+
+            if (event.event_type == EVENT_LOW_ENERGY_UPDATE) {
+                watch_display_character_lp(' ', 8);
+                watch_display_character_lp(' ', 9);
+                if (!watch_tick_animation_is_running()) watch_start_tick_animation(500);
+            }
+            break;
+        case EVENT_ALARM_LONG_PRESS:
+            state->signal_enabled = !state->signal_enabled;
+            if (state->signal_enabled) watch_set_indicator(WATCH_INDICATOR_BELL);
+            else watch_clear_indicator(WATCH_INDICATOR_BELL);
+            break;
+        case EVENT_BACKGROUND_TASK:
+            // uncomment this line to snap back to the clock face when the hour signal sounds:
+            // movement_move_to_face(state->watch_face_index);
+            #ifdef SIGNAL_TUNE_DEFAULT
+            movement_play_signal();
+            #else
+            //movement_play_tune();
+            #endif
+            break;
+        default:
+            return movement_default_loop_handler(event, settings);
+    }
+
+    return true;
+}
+
+void nonary_clock_face_resign(movement_settings_t *settings, void *context) {
+    (void) settings;
+    (void) context;
+
+    movement_request_tick_frequency(1);
+}
+
+bool nonary_clock_face_wants_background_task(movement_settings_t *settings, void *context) {
+    (void) settings;
+    nonary_clock_state_t *state = (nonary_clock_state_t *)context;
+    if (!state->signal_enabled) return false;
+
+    watch_date_time date_time = watch_rtc_get_date_time();
+
+    // TODO to make this work better, we need to have the CLOCK->COUNT32 change
+    // (so we can set COMP to an appropriate interval).
+    // At the moment, this will not fire at appropriate times.
+    return date_time.unit.minute == 0;
+}

--- a/movement/watch_faces/clock/nonary_clock_face.h
+++ b/movement/watch_faces/clock/nonary_clock_face.h
@@ -1,0 +1,101 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 James Haggerty <james@gruemail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef NONARY_CLOCK_FACE_H_
+#define NONARY_CLOCK_FACE_H_
+
+/*
+ * Balanced Nonary Clock Face
+ *
+ * Like simple clock face, but... confusing?
+ *
+ * What's the point of having a customisable wrist watch unless you have bizarre timing schemes?
+ * This maintains the normal concept of hours, but divides each hour into
+ * 9*9*9*9 seconds, so that we can display the time in nonary.
+ *
+ * But not just any nonary, this is _balanced_ nonary, such that our digit
+ * values are -4, -3, -2, -1, 0, 1, 2, 3, 4
+ *
+ * Midday is therefore 00:00:00. An example of counting before midday
+ * and after:
+ *
+ *  00:00:0(-4)
+ *  00:00:0(-3)
+ *  00:00:0(-2)
+ *  00:00:0(-1)
+ *  00:00:00
+ *  00:00:01
+ *  00:00:02
+ *  00:00:03
+ *  00:00:04
+ *  00:00:1(-4)
+ *  00:00:1(-3)
+ *  00:00:1(-2)
+ *  00:00:1(-1)
+ *  00:00:10
+ *  00:00:11
+ *  etc.
+ *
+ *  This has the advantage that you can always see what hour/minute you're closer to.
+ *
+ *  But wait - how can we display the negative digits? Well, to do this
+ *  we use the top 'bar' in a digit as the negative sign, and for those
+ *  numbers compress them into the bottom 4 segments, and then simply use
+ *  the number of other segments filled as the digit. So, counting
+ *  from -4 to 4:
+ *         __   __  __  __  __
+ *         __   __         |  |       __   __   __|
+ *        |__|, __|,__|,__,|__|,   |,   |,|  |,|  |
+ *
+ * Sadly, because the top and the bottom segments are tied, we can't
+ * easily use the same digit for positive and negative values without
+ * running into 'normal' numbers in confusing ways.
+ */
+
+#include "movement.h"
+
+typedef struct {
+    uint32_t previous_date_time;
+    uint8_t last_battery_check;
+    uint8_t watch_face_index;
+    bool signal_enabled;
+    bool battery_low;
+    bool alarm_enabled;
+} nonary_clock_state_t;
+
+void nonary_clock_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr);
+void nonary_clock_face_activate(movement_settings_t *settings, void *context);
+bool nonary_clock_face_loop(movement_event_t event, movement_settings_t *settings, void *context);
+void nonary_clock_face_resign(movement_settings_t *settings, void *context);
+bool nonary_clock_face_wants_background_task(movement_settings_t *settings, void *context);
+
+#define nonary_clock_face ((const watch_face_t){ \
+    nonary_clock_face_setup, \
+    nonary_clock_face_activate, \
+    nonary_clock_face_loop, \
+    nonary_clock_face_resign, \
+    nonary_clock_face_wants_background_task, \
+})
+
+#endif

--- a/movement/watch_faces/clock/repetition_minute_face.c
+++ b/movement/watch_faces/clock/repetition_minute_face.c
@@ -114,8 +114,8 @@ bool repetition_minute_face_loop(movement_event_t event, movement_settings_t *se
 
             if ((date_time.reg >> 6) == (previous_date_time >> 6) && event.event_type != EVENT_LOW_ENERGY_UPDATE) {
                 // everything before seconds is the same, don't waste cycles setting those segments.
-                watch_display_character_lp_seconds('0' + date_time.unit.second / 10, 8);
-                watch_display_character_lp_seconds('0' + date_time.unit.second % 10, 9);
+                watch_display_character_lp('0' + date_time.unit.second / 10, 8);
+                watch_display_character_lp('0' + date_time.unit.second % 10, 9);
                 break;
             } else if ((date_time.reg >> 12) == (previous_date_time >> 12) && event.event_type != EVENT_LOW_ENERGY_UPDATE) {
                 // everything before minutes is the same.

--- a/movement/watch_faces/clock/simple_clock_bin_led_face.c
+++ b/movement/watch_faces/clock/simple_clock_bin_led_face.c
@@ -140,8 +140,8 @@ bool simple_clock_bin_led_face_loop(movement_event_t event, movement_settings_t 
 
                 if ((date_time.reg >> 6) == (previous_date_time >> 6) && event.event_type != EVENT_LOW_ENERGY_UPDATE) {
                     // everything before seconds is the same, don't waste cycles setting those segments.
-                    watch_display_character_lp_seconds('0' + date_time.unit.second / 10, 8);
-                    watch_display_character_lp_seconds('0' + date_time.unit.second % 10, 9);
+                    watch_display_character_lp('0' + date_time.unit.second / 10, 8);
+                    watch_display_character_lp('0' + date_time.unit.second % 10, 9);
                     break;
                 } else if ((date_time.reg >> 12) == (previous_date_time >> 12) && event.event_type != EVENT_LOW_ENERGY_UPDATE) {
                     // everything before minutes is the same.

--- a/movement/watch_faces/clock/simple_clock_face.c
+++ b/movement/watch_faces/clock/simple_clock_face.c
@@ -97,8 +97,8 @@ bool simple_clock_face_loop(movement_event_t event, movement_settings_t *setting
 
             if ((date_time.reg >> 6) == (previous_date_time >> 6) && event.event_type != EVENT_LOW_ENERGY_UPDATE) {
                 // everything before seconds is the same, don't waste cycles setting those segments.
-                watch_display_character_lp_seconds('0' + date_time.unit.second / 10, 8);
-                watch_display_character_lp_seconds('0' + date_time.unit.second % 10, 9);
+                watch_display_character_lp('0' + date_time.unit.second / 10, 8);
+                watch_display_character_lp('0' + date_time.unit.second % 10, 9);
                 break;
             } else if ((date_time.reg >> 12) == (previous_date_time >> 12) && event.event_type != EVENT_LOW_ENERGY_UPDATE) {
                 // everything before minutes is the same.

--- a/watch-library/shared/watch/watch_private_display.h
+++ b/watch-library/shared/watch/watch_private_display.h
@@ -27,6 +27,20 @@
 #include "hpl_slcd_config.h"
 #include "driver_init.h"
 
+// Bit position -> segment mapping for Character_Set.
+//  --0--
+// |     |
+// 5     1
+// |     |
+//  --6--
+// |     |
+// 4     2
+// |     |
+//  --3--
+//
+// 7 is the middle divider (i.e. only position 0).
+
+
 static const uint8_t Character_Set[] =
 {
     0b00000000, //  
@@ -140,9 +154,5 @@ static const uint64_t Segment_Map[] = {
 };
 
 static const uint8_t Num_Chars = 10;
-
-void watch_display_character(uint8_t character, uint8_t position);
-void watch_display_character_lp_seconds(uint8_t character, uint8_t position);
-
 
 #endif

--- a/watch-library/shared/watch/watch_slcd.h
+++ b/watch-library/shared/watch/watch_slcd.h
@@ -74,7 +74,7 @@ void watch_clear_pixel(uint8_t com, uint8_t seg);
 void watch_clear_display(void);
 
 /** @brief Displays a string at the given position, starting from the top left. There are ten digits.
-           A space in any position will clear that digit.
+  *        A space in any position will clear that digit.
   * @param string A null-terminated string.
   * @param position The position where you wish to start displaying the string. The day of week digits
   *                 are positions 0 and 1; the day of month digits are positions 2 and 3, and the main
@@ -83,6 +83,79 @@ void watch_clear_display(void);
           position 0, positions 2-9 will retain whatever state they were previously displaying.
   */
 void watch_display_string(char *string, uint8_t position);
+
+/** @brief Displays a character at the given position, starting from the top left. There are ten digits.
+  *        A space in any position will clear that digit.
+  * @param character A single character to display.
+  * @param position The position where you wish to display the character. The day of week digits
+  *                 are positions 0 and 1; the day of month digits are positions 2 and 3, and the main
+  *                 clock line occupies positions 4-9.
+  */
+void watch_display_character(uint8_t character, uint8_t position);
+
+/** @brief Displays a character at the given position, starting from the top left. There are ten digits.
+  *        lp refers to 'low-power', as this does _not_ do any special casing to try to handle the pecularities of each position,
+  *        This means it's best used to display numbers in the expected form.
+  * @param character A single character to display.
+  * @param position The position where you wish to display the character. The day of week digits
+  *                 are positions 0 and 1; the day of month digits are positions 2 and 3, and the main
+  *                 clock line occupies positions 4-9.
+  */
+void watch_display_character_lp(uint8_t character, uint8_t position);
+
+/** @brief Attempt to invert the display (i.e. rotate all characters 180 degrees).
+ *         As with watch_display_character_lp, due to the limitations of the display this works best
+ *         with numbers. This affects all subsequent calls to watch_display_string/character.
+ *  @param inv whether to invert (true) or not invert (false).
+ */
+void watch_display_invert(bool inv);
+
+/** @brief Display arbitrary segment data at a particular position.
+ *         cf watch_display_character.
+ *  @param segdata Raw bits which are mapped to the position. See below.
+ *  @param position The position where you wish to display the character. The day of week digits
+ *                  are positions 0 and 1; the day of month digits are positions 2 and 3, and the main
+ *                  clock line occupies positions 4-9.
+ *  @note The bits are mapped as follows:
+ *
+ *  --0-- 
+ * |     |
+ * 5     1
+ * |     |
+ *  --6--
+ * |     |
+ * 4     2
+ * |     |
+ *  --3--
+ *
+ * 7 is the middle divider. i.e. only position 0.
+ *
+ * If you want to display/clear an individual segment, use watch_display_segment.
+ */
+void watch_display_segdata(uint8_t segdata, uint8_t position);
+
+/** @brief Generate segdata for a position that could be used as input to watch_display_segdata.
+ *  @param character A single character to convert.
+ *  @param position The position to generate the character for.
+ *  @note You might wonder why the position is necessary for this function even though
+ *        we don't actually display the character here. This is because we generate different segment
+ *        data depending on the characte to handle the limitiations of the position.
+ */
+uint8_t watch_convert_char_to_segdata(uint8_t character, uint8_t position);
+
+/** @brief Generate segdata for a position that could be used as input to watch_display_segdata (lp).
+ *         This is analagous to watch_display_character_lp.
+ *  @param character A single character to convert.
+ */
+uint8_t watch_convert_char_to_segdata_lp(uint8_t character);
+
+/** @brief Map an individual segment to a particular position. See watch_display_segdata for segment info.
+ *         This is similar to watch_set_pixel, but maps the segments for an arbitrary spot on the display.
+ *  @param bit_pos Bit position (0 to 7).
+ *  @param position Character position.
+ *  @param on Whether to set or clear at that position.
+ */
+void watch_display_segment(uint8_t bit_pos, uint8_t position, bool on);
 
 /** @brief Turns the colon segment on.
   */
@@ -147,5 +220,6 @@ bool watch_tick_animation_is_running(void);
   * @details This will stop the animation and clear all segments in position 8.
   */
 void watch_stop_tick_animation(void);
+
 /// @}
 #endif


### PR DESCRIPTION
WARNING: this includes a commit from https://github.com/joeycastillo/Sensor-Watch/pull/346, so, err, ignore any watch_private_display.* things. The actual changes are all in nonary_clock_face.*

What's the point of having a customisable wrist watch unless you have bizarre timing schemes?

This maintains the normal concept of hours, but divides each hour into
9*9*9*9 seconds, so that we can display the time in nonary.

But not just nonary, this is _balanced_ nonary, such that our digit
values are -4, -3, -2, -1, 0, 1, 2, 3, 4

Midday is therefore 00:00:00. An example of counting before midday
and after:

00:00:0(-4)
00:00:0(-3)
00:00:0(-2)
00:00:0(-1)
00:00:00
00:00:01
00:00:02
00:00:03
00:00:04
00:00:1(-4)
00:00:1(-3)
00:00:1(-2)
00:00:1(-1)
00:00:10
00:00:11
etc.

This has the advantage that you can always see what hour/minute you're closer to.

But wait - how can we display the negative digits? Well, to do this
we use the top 'bar' in a digit as the negative sign, and for those
numbers compress them into the bottom 4 segments, and then simply use
the number of other segments filled as the digit. So, counting
from -4 to 4:

```
 __   __  __  __  __
 __   __         |  |       __   __   __|
|__|, __|,__|,__,|__|,   |,   |,|  |,|  |
```

Sadly, because the top and the bottom segments are tied, we can't
easily use the same digit for positive and negative values without
running into 'normal' numbers in confusing ways.