### PR TITLE
template: fix compiler warning on watch_face_index as mentioned in PR269

### DIFF
--- a/movement/template/template.c
+++ b/movement/template/template.c
@@ -28,6 +28,7 @@
 
 void <#watch_face_name#>_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {
     (void) settings;
+    (void) watch_face_index;
     if (*context_ptr == NULL) {
         *context_ptr = malloc(sizeof(<#watch_face_name#>_state_t));
         memset(*context_ptr, 0, sizeof(<#watch_face_name#>_state_t));


### PR DESCRIPTION
Addresses a compiler warning of unused watch_face_index, as @WesleyAC mentioned in [a comment](https://github.com/joeycastillo/Sensor-Watch/pull/269#discussion_r1398458836) on Pull Request #269.
Putting the fix right at the root of where it came from - in the template.