### PR TITLE
Add a 10 minute inactivity deadline.

### DIFF
--- a/movement/movement.c
+++ b/movement/movement.c
@@ -76,7 +76,7 @@
 movement_state_t movement_state;
 void * watch_face_contexts[MOVEMENT_NUM_FACES];
 watch_date_time scheduled_tasks[MOVEMENT_NUM_FACES];
-const int32_t movement_le_inactivity_deadlines[8] = {INT_MAX, 3600, 7200, 21600, 43200, 86400, 172800, 604800};
+const int32_t movement_le_inactivity_deadlines[8] = {INT_MAX, 600, 3600, 7200, 21600, 43200, 86400, 604800};
 const int16_t movement_timeout_inactivity_deadlines[4] = {60, 120, 300, 1800};
 movement_event_t event;
 
@@ -354,7 +354,7 @@ void app_init(void) {
     movement_state.settings.bit.led_red_color = MOVEMENT_DEFAULT_RED_COLOR;
     movement_state.settings.bit.led_green_color = MOVEMENT_DEFAULT_GREEN_COLOR;
     movement_state.settings.bit.button_should_sound = true;
-    movement_state.settings.bit.le_interval = 1;
+    movement_state.settings.bit.le_interval = 2;
     movement_state.settings.bit.led_duration = 1;
     movement_state.light_ticks = -1;
     movement_state.alarm_ticks = -1;

--- a/movement/watch_faces/settings/preferences_face.c
+++ b/movement/watch_faces/settings/preferences_face.c
@@ -136,22 +136,22 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
                         watch_display_string(" Never", 4);
                         break;
                     case 1:
-                        watch_display_string("1 hour", 4);
+                        watch_display_string("10n&in", 4);
                         break;
                     case 2:
-                        watch_display_string("2 hour", 4);
+                        watch_display_string("1 hour", 4);
                         break;
                     case 3:
-                        watch_display_string("6 hour", 4);
+                        watch_display_string("2 hour", 4);
                         break;
                     case 4:
-                        watch_display_string("12 hr", 4);
+                        watch_display_string("6 hour", 4);
                         break;
                     case 5:
-                        watch_display_string(" 1 day", 4);
+                        watch_display_string("12 hr", 4);
                         break;
                     case 6:
-                        watch_display_string(" 2 day", 4);
+                        watch_display_string(" 1 day", 4);
                         break;
                     case 7:
                         watch_display_string(" 7 day", 4);


### PR DESCRIPTION
I like to use the 10 minute timeout on my watch and added the 30 minute deadline to have an option for people who want something in-between.
The default setting is still the 1 hour timeout.

The patch was tested on hardware and the watch properly switches into
the low energy mode after the respective deadlines.
