### PR TITLE
Structured TOTP watch face

### DIFF
--- a/movement/watch_faces/complication/totp_face.c
+++ b/movement/watch_faces/complication/totp_face.c
@@ -46,7 +46,7 @@ typedef struct {
     unsigned char *key;
 } totp_t;
 
-#define TOTP_INITIALIZER(label, key_array, algo, timestep) \
+#define CREDENTIAL(label, key_array, algo, timestep) \
     (const totp_t) { \
         .key = ((unsigned char *) key_array), \
         .key_length = sizeof(key_array) - 1, \
@@ -59,8 +59,8 @@ typedef struct {
 // Enter your TOTP key data below
 
 static totp_t credentials[] = {
-    TOTP_INITIALIZER(2F, "JBSWY3DPEHPK3PXP", SHA1, 30),
-    TOTP_INITIALIZER(AC, "JBSWY3DPEHPK3PXP", SHA1, 30),
+    CREDENTIAL(2F, "JBSWY3DPEHPK3PXP", SHA1, 30),
+    CREDENTIAL(AC, "JBSWY3DPEHPK3PXP", SHA1, 30),
 };
 
 // END OF KEY DATA.

--- a/movement/watch_faces/complication/totp_face.c
+++ b/movement/watch_faces/complication/totp_face.c
@@ -46,12 +46,12 @@ typedef struct {
     unsigned char *key;
 } totp_t;
 
-#define TOTP_INITIALIZER(label_1, label_2, key_array, algo, timestep) \
+#define TOTP_INITIALIZER(label, key_array, algo, timestep) \
     (const totp_t) { \
         .key = ((unsigned char *) key_array), \
         .key_length = sizeof(key_array) - 1, \
         .period = (timestep), \
-        .labels = { (label_1), (label_2) }, \
+        .labels = (#label), \
         .algorithm = (algo), \
     }
 
@@ -59,8 +59,8 @@ typedef struct {
 // Enter your TOTP key data below
 
 static totp_t credentials[] = {
-    TOTP_INITIALIZER('2', 'F', "JBSWY3DPEHPK3PXP", SHA1, 30),
-    TOTP_INITIALIZER('A', 'C', "JBSWY3DPEHPK3PXP", SHA1, 30),
+    TOTP_INITIALIZER(2F, "JBSWY3DPEHPK3PXP", SHA1, 30),
+    TOTP_INITIALIZER(AC, "JBSWY3DPEHPK3PXP", SHA1, 30),
 };
 
 // END OF KEY DATA.

--- a/movement/watch_faces/complication/totp_face.c
+++ b/movement/watch_faces/complication/totp_face.c
@@ -66,7 +66,7 @@ static totp_t credentials[] = {
 // END OF KEY DATA.
 ////////////////////////////////////////////////////////////////////////////////
 
-static inline totp_t *_totp_current(totp_state_t *totp_state) {
+static inline totp_t *totp_current(totp_state_t *totp_state) {
     return &credentials[totp_state->current_index];
 }
 
@@ -74,11 +74,11 @@ static inline size_t totp_total(void) {
     return sizeof(credentials) / sizeof(*credentials);
 }
 
-static void _update_display(totp_state_t *totp_state) {
+static void totp_display(totp_state_t *totp_state) {
     char buf[14];
     div_t result;
     uint8_t valid_for;
-    totp_t *totp = _totp_current(totp_state);
+    totp_t *totp = totp_current(totp_state);
 
     result = div(totp_state->timestamp, totp->period);
     if (result.quot != totp_state->steps) {
@@ -121,7 +121,7 @@ void totp_face_activate(movement_settings_t *settings, void *context) {
     (void) settings;
     memset(context, 0, sizeof(totp_state_t));
     totp_state_t *totp_state = (totp_state_t *)context;
-    totp_t *totp = _totp_current(totp_state);
+    totp_t *totp = totp_current(totp_state);
     TOTP(totp->key, totp->key_length, totp->period, totp->algorithm);
     totp_state->timestamp = watch_utility_date_time_to_unix_time(watch_rtc_get_date_time(), movement_timezone_offsets[settings->bit.time_zone] * 60);
     totp_state->current_code = getCodeFromTimestamp(totp_state->timestamp);
@@ -136,7 +136,7 @@ bool totp_face_loop(movement_event_t event, movement_settings_t *settings, void 
             totp_state->timestamp++;
             // fall through
         case EVENT_ACTIVATE:
-            _update_display(totp_state);
+            totp_display(totp_state);
             break;
         case EVENT_TIMEOUT:
             movement_move_to_face(0);
@@ -148,9 +148,9 @@ bool totp_face_loop(movement_event_t event, movement_settings_t *settings, void 
                 // wrap around to first key
                 totp_state->current_index = 0;
             }
-            totp_t *totp = _totp_current(totp_state);
+            totp_t *totp = totp_current(totp_state);
             TOTP(totp->key, totp->key_length, totp->period, totp->algorithm);
-            _update_display(totp_state);
+            totp_display(totp_state);
             break;
         case EVENT_ALARM_BUTTON_DOWN:
         case EVENT_ALARM_LONG_PRESS:

--- a/movement/watch_faces/complication/totp_face.c
+++ b/movement/watch_faces/complication/totp_face.c
@@ -65,6 +65,10 @@ static totp_t totp_data[] = {
 // END OF KEY DATA.
 ////////////////////////////////////////////////////////////////////////////////
 
+static inline size_t _totp_num(void) {
+    return sizeof(totp_data) / sizeof(*totp_data);
+}
+
 static void _update_display(totp_state_t *totp_state) {
     char buf[14];
     div_t result;

--- a/movement/watch_faces/complication/totp_face.c
+++ b/movement/watch_faces/complication/totp_face.c
@@ -48,27 +48,20 @@ typedef struct {
 
 ////////////////////////////////////////////////////////////////////////////////
 // Enter your TOTP key data below
-static const uint8_t num_keys = 2;
-static uint8_t keys[] = {
+
+static uint8_t key_1[] = {
     0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x21, 0xde, 0xad, 0xbe, 0xef, // 1 - JBSWY3DPEHPK3PXP
+};
+
+static uint8_t key_2[] = {
     0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x21, 0xde, 0xad, 0xbe, 0xef, // 2 - JBSWY3DPEHPK3PXP
 };
-static const uint8_t key_sizes[] = {
-    10,
-    10,
+
+static totp_t totp_data[] = {
+    TOTP_INITIALIZER('2', 'F', key_1, SHA1, 30),
+    TOTP_INITIALIZER('A', 'C', key_2, SHA1, 30),
 };
-static const uint32_t timesteps[] = {
-    30,
-    30,
-};
-static const char labels[][2] = {
-    { '2', 'F' },
-    { 'A', 'C' },
-};
-static const hmac_alg algorithms[] = {
-    SHA1,
-    SHA1,
-};
+
 // END OF KEY DATA.
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/movement/watch_faces/complication/totp_face.c
+++ b/movement/watch_faces/complication/totp_face.c
@@ -1,7 +1,15 @@
+/* SPDX-License-Identifier: MIT */
+
 /*
  * MIT License
  *
- * Copyright (c) 2022 Wesley Ellis (https://github.com/tahnok)
+ * Copyright © 2021 Wesley Ellis (https://github.com/tahnok)
+ * Copyright © 2021-2023 Joey Castillo <joeycastillo@utexas.edu>
+ * Copyright © 2022 Jack Bond-Preston <jackbondpreston@outlook.com>
+ * Copyright © 2023 Alex Utter <ooterness@gmail.com>
+ * Copyright © 2023 Emilien Court <emilien.court@telecomnancy.net>
+ * Copyright © 2023 Jeremy O'Brien <neutral@fastmail.com>
+ * Copyright © 2024 Matheus Afonso Martins Moreira <matheus.a.m.moreira@gmail.com> (https://www.matheusmoreira.com/)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/movement/watch_faces/complication/totp_face.c
+++ b/movement/watch_faces/complication/totp_face.c
@@ -29,6 +29,14 @@
 #include "watch_utility.h"
 #include "TOTP.h"
 
+typedef struct {
+    unsigned char labels[2];
+    hmac_alg algorithm;
+    uint32_t period;
+    size_t key_length;
+    uint8_t *key;
+} totp_t;
+
 ////////////////////////////////////////////////////////////////////////////////
 // Enter your TOTP key data below
 static const uint8_t num_keys = 2;

--- a/movement/watch_faces/complication/totp_face.c
+++ b/movement/watch_faces/complication/totp_face.c
@@ -65,6 +65,10 @@ static totp_t totp_data[] = {
 // END OF KEY DATA.
 ////////////////////////////////////////////////////////////////////////////////
 
+static inline totp_t *_totp_current(totp_state_t *totp_state) {
+    return &totp_data[totp_state->current_index];
+}
+
 static inline size_t _totp_num(void) {
     return sizeof(totp_data) / sizeof(*totp_data);
 }

--- a/movement/watch_faces/complication/totp_face.c
+++ b/movement/watch_faces/complication/totp_face.c
@@ -37,6 +37,15 @@ typedef struct {
     uint8_t *key;
 } totp_t;
 
+#define TOTP_INITIALIZER(label_1, label_2, key_array, algo, timestep) \
+    (const totp_t) { \
+        .key = (key_array), \
+        .key_length = sizeof(key_array), \
+        .period = (timestep), \
+        .labels = { (label_1), (label_2) }, \
+        .algorithm = (algo), \
+    }
+
 ////////////////////////////////////////////////////////////////////////////////
 // Enter your TOTP key data below
 static const uint8_t num_keys = 2;

--- a/movement/watch_faces/complication/totp_face.h
+++ b/movement/watch_faces/complication/totp_face.h
@@ -1,7 +1,14 @@
+/* SPDX-License-Identifier: MIT */
+
 /*
  * MIT License
  *
- * Copyright (c) 2022 Wesley Ellis (https://github.com/tahnok)
+ * Copyright © 2021 Wesley Ellis (https://github.com/tahnok)
+ * Copyright © 2021-2022 Joey Castillo <joeycastillo@utexas.edu>
+ * Copyright © 2022 Alexsander Akers <me@a2.io>
+ * Copyright © 2022 Jack Bond-Preston <jackbondpreston@outlook.com>
+ * Copyright © 2023 Alex Utter <ooterness@gmail.com>
+ * Copyright © 2024 Matheus Afonso Martins Moreira <matheus.a.m.moreira@gmail.com> (https://www.matheusmoreira.com/)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/movement/watch_faces/complication/totp_face.h
+++ b/movement/watch_faces/complication/totp_face.h
@@ -60,7 +60,6 @@ typedef struct {
     uint8_t steps;
     uint32_t current_code;
     uint8_t current_index;
-    uint8_t current_key_offset;
 } totp_state_t;
 
 void totp_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr);


### PR DESCRIPTION
Improves the standard TOTP watch face by making it easier to define new secrets. Aggregating the TOTP data into a structure allows simple and functional definition of new instances with an initializer generator macro. This also makes the size and offset variables superfluous and so they are removed.