### PR TITLE
Forced 24h display build option

### DIFF
--- a/make.mk
+++ b/make.mk
@@ -229,3 +229,7 @@ endif
 ifeq ($(BOARD), OSO-FEAL-A1-00)
 CFLAGS += -DCRYSTALLESS
 endif
+
+ifdef FORCE_24H
+CFLAGS += -DMOVEMENT_FORCE_24H
+endif

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -1,7 +1,23 @@
+/* SPDX-License-Identifier: MIT */
+
 /*
  * MIT License
  *
- * Copyright (c) 2022 Joey Castillo
+ * Copyright © 2021-2023 Joey Castillo <jose.castillo@gmail.com> <joeycastillo@utexas.edu>
+ * Copyright © 2022-2023 TheOnePerson <a.nebinger@web.de>
+ * Copyright © 2022 Alexsander Akers <me@a2.io>
+ * Copyright © 2022 James Haggerty <james@gruemail.com>
+ * Copyright © 2022 Niclas Hoyer <info@niclashoyer.de>
+ * Copyright © 2022 Wesley Ellis <tahnok@gmail.com>
+ * Copyright © 2023 Wesley Aptekar-Cassels <me@wesleyac.com>
+ * Copyright © 2023 Alex Maestas <git@se30.xyz>
+ * Copyright © 2023 Jeremy O'Brien <neutral@fastmail.com>
+ * Copyright © 2023 Mikhail Svarichevsky <3@14.by>
+ * Copyright © 2024 Alex Maestas <git@se30.xyz>
+ * Copyright © 2024 Christian Buschau <cbuschau@d00t.de>
+ * Copyright © 2024 Max Zettlmeißl <max@zettlmeissl.de>
+ * Copyright © 2024 Wesley Aptekar-Cassels <me@wesleyac.com>
+ * Copyright © 2024 Matheus Afonso Martins Moreira <matheus.a.m.moreira@gmail.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -384,13 +384,17 @@ void app_init(void) {
         }
     }
 #endif
+
+    _movement_force_24h_if_configured();
 }
 
 void app_wake_from_backup(void) {
     movement_state.settings.reg = watch_get_backup_data(0);
+    _movement_force_24h_if_configured();
 }
 
 void app_setup(void) {
+    _movement_force_24h_if_configured();
     watch_store_backup_data(movement_state.settings.reg, 0);
 
     static bool is_first_launch = true;

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -135,6 +135,10 @@ void cb_alarm_fired(void);
 void cb_fast_tick(void);
 void cb_tick(void);
 
+static inline void _movement_force_24h(void) {
+    movement_state.settings.bit.clock_mode_24h = true;
+}
+
 static inline void _movement_reset_inactivity_countdown(void) {
     movement_state.le_mode_ticks = movement_le_inactivity_deadlines[movement_state.settings.bit.le_interval];
     movement_state.timeout_ticks = movement_timeout_inactivity_deadlines[movement_state.settings.bit.to_interval];

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -139,6 +139,12 @@ static inline void _movement_force_24h(void) {
     movement_state.settings.bit.clock_mode_24h = true;
 }
 
+static inline void _movement_force_24h_if_configured(void) {
+#if MOVEMENT_FORCE_24H
+    _movement_force_24h();
+#endif
+}
+
 static inline void _movement_reset_inactivity_countdown(void) {
     movement_state.le_mode_ticks = movement_le_inactivity_deadlines[movement_state.settings.bit.le_interval];
     movement_state.timeout_ticks = movement_timeout_inactivity_deadlines[movement_state.settings.bit.to_interval];

--- a/movement/watch_faces/settings/preferences_face.c
+++ b/movement/watch_faces/settings/preferences_face.c
@@ -60,7 +60,9 @@ void preferences_face_setup(movement_settings_t *settings, uint8_t watch_face_in
 
 void preferences_face_activate(movement_settings_t *settings, void *context) {
     (void) settings;
-    *((uint8_t *)context) = 0;
+    uint8_t *current_page = context;
+    *current_page = 0;
+    _preferences_face_skip_CL_page_if_forced_24h(current_page);
     movement_request_tick_frequency(4); // we need to manually blink some pixels
 }
 
@@ -77,6 +79,7 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
             return false;
         case EVENT_LIGHT_BUTTON_DOWN:
             _preferences_face_next_page(&current_page);
+            _preferences_face_skip_CL_page_if_forced_24h(&current_page);
             *((uint8_t *)context) = current_page;
             break;
         case EVENT_ALARM_BUTTON_UP:

--- a/movement/watch_faces/settings/preferences_face.c
+++ b/movement/watch_faces/settings/preferences_face.c
@@ -27,6 +27,7 @@
 #include "watch.h"
 
 #define PREFERENCES_FACE_NUM_PREFEFENCES (7)
+#define PREFERENCES_FACE_PAGE_CL 0
 const char preferences_face_titles[PREFERENCES_FACE_NUM_PREFEFENCES][11] = {
     "CL        ",   // Clock: 12 or 24 hour
     "BT  Beep  ",   // Buttons: should they beep?
@@ -43,6 +44,12 @@ const char preferences_face_titles[PREFERENCES_FACE_NUM_PREFEFENCES][11] = {
 
 static void _preferences_face_next_page(uint8_t *current_page) {
     *current_page = (*current_page + 1) % PREFERENCES_FACE_NUM_PREFEFENCES;
+}
+
+static void _preferences_face_skip_CL_page_if_forced_24h(uint8_t *current_page) {
+#if MOVEMENT_FORCE_24H
+    if (*current_page == PREFERENCES_FACE_PAGE_CL) { _preferences_face_next_page(current_page); }
+#endif
 }
 
 void preferences_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {

--- a/movement/watch_faces/settings/preferences_face.c
+++ b/movement/watch_faces/settings/preferences_face.c
@@ -41,6 +41,10 @@ const char preferences_face_titles[PREFERENCES_FACE_NUM_PREFEFENCES][11] = {
     "LT   red  ",   // Light: red component
 };
 
+static void _preferences_face_next_page(uint8_t *current_page) {
+    *current_page = (*current_page + 1) % PREFERENCES_FACE_NUM_PREFEFENCES;
+}
+
 void preferences_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {
     (void) settings;
     (void) watch_face_index;
@@ -65,7 +69,7 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
             movement_move_to_next_face();
             return false;
         case EVENT_LIGHT_BUTTON_DOWN:
-            current_page = (current_page + 1) % PREFERENCES_FACE_NUM_PREFEFENCES;
+            _preferences_face_next_page(&current_page);
             *((uint8_t *)context) = current_page;
             break;
         case EVENT_ALARM_BUTTON_UP:

--- a/movement/watch_faces/settings/preferences_face.c
+++ b/movement/watch_faces/settings/preferences_face.c
@@ -1,7 +1,11 @@
+/* SPDX-License-Identifier: MIT */
+
 /*
  * MIT License
  *
- * Copyright (c) 2022 Joey Castillo
+ * Copyright © 2021-2023 Joey Castillo <joeycastillo@utexas.edu> <jose.castillo@gmail.com>
+ * Copyright © 2024 Max Zettlmeißl <max@zettlmeissl.de>
+ * Copyright © 2024 Matheus Afonso Martins Moreira <matheus.a.m.moreira@gmail.com> (https://www.matheusmoreira.com/)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/movement/watch_faces/settings/preferences_face.h
+++ b/movement/watch_faces/settings/preferences_face.h
@@ -1,7 +1,11 @@
+/* SPDX-License-Identifier: MIT */
+
 /*
  * MIT License
  *
- * Copyright (c) 2022 Joey Castillo
+ * Copyright © 2021-2022 Joey Castillo <joeycastillo@utexas.edu> <jose.castillo@gmail.com>
+ * Copyright © 2022 Alexsander Akers <me@a2.io>
+ * Copyright © 2023 Alex Utter <ooterness@gmail.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Adds a build time configuration option which causes the entire movement framework to force a 24 hour clock display mode configuration. Applies to all watch faces which use the setting and resists attempts by watch faces to set a different mode. Updates the preferences watch face to hide the clock mode configuration page since there's no point in changing the setting.

All of these changes are conditionally compiled into the movement framework. The compiler is expected to eliminate all the forced 24h logic as dead code when not in this configuration.

It can be used via the build system:

    make FORCE_24H=yes