### PR TITLE
uf2conv: argument to `re.split` should be a rawstring

### DIFF
--- a/utils/uf2conv.py
+++ b/utils/uf2conv.py
@@ -180,7 +180,7 @@ def get_drives():
                                      "get", "DeviceID,", "VolumeName,",
                                      "FileSystem,", "DriveType"])
         for line in to_str(r).split('\n'):
-            words = re.split('\s+', line)
+            words = re.split(r'\s+', line)
             if len(words) >= 3 and words[1] == "2" and words[2] == "FAT":
                 drives.append(words[0])
     else:


### PR DESCRIPTION
this should eliminate the invalid string escape warning seen in newer Pythons.