### PR TITLE
TOTP hotfix: reduce memory usage

### DIFF
--- a/movement/watch_faces/complication/totp_face.c
+++ b/movement/watch_faces/complication/totp_face.c
@@ -121,10 +121,11 @@ static bool totp_generate(totp_state_t *totp_state) {
 }
 
 static void totp_display_error(totp_state_t *totp_state) {
-    char buf[9 + 1];
+    char buf[10 + 1];
     totp_t *totp = totp_current(totp_state);
 
-    snprintf(buf, sizeof(buf), "%c%c  ERROR", totp->labels[0], totp->labels[1]);
+    snprintf(buf, sizeof(buf), "%c%c  ERROR ", totp->labels[0], totp->labels[1]);
+    watch_display_string(buf, 0);
 }
 
 static void totp_display(totp_state_t *totp_state) {

--- a/movement/watch_faces/complication/totp_face.h
+++ b/movement/watch_faces/complication/totp_face.h
@@ -70,6 +70,8 @@ typedef struct {
     uint8_t steps;
     uint32_t current_code;
     uint8_t current_index;
+    uint8_t *current_decoded_key;
+    size_t current_decoded_key_length;
 } totp_state_t;
 
 void totp_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr);


### PR DESCRIPTION
The TOTP face is working in the simulator but fails on the real hardware when loaded with lots of codes, just like the LFS version. This is likely caused by the recent refactoring of the TOTP face which introduced a declarative credential interface for ease of use. That's accomplished by decoding the secrets at runtime which increases the RAM requirements. Users are likely hitting memory limits.

In order to mitigate this, the algorithm is changed from decoding all of the secrets only once during initialization to on the fly decoding of the secret for the current TOTP credential only. This converts this face's dynamic memory usage from O(N) to O(1) at the cost of memory management when switching faces and credentials which could impact power consumption.

Due to variable key sizes, the memory cannot be statically allocated. Perhaps there's a maximum key size that can serve as worst case?

Also took this opportunity to restructure the code a bit. Also added code to check for memory allocation failure.