### PR TITLE
add the ability to set location and birthdate in movement config

### DIFF
--- a/movement/movement.c
+++ b/movement/movement.c
@@ -95,6 +95,31 @@
 #define MOVEMENT_DEFAULT_LED_DURATION 1
 #endif
 
+// Default to no set location latitude
+#ifndef MOVEMENT_DEFAULT_LATITUDE
+#define MOVEMENT_DEFAULT_LATITUDE 0
+#endif
+
+// Default to no set location longitude
+#ifndef MOVEMENT_DEFAULT_LONGITUDE
+#define MOVEMENT_DEFAULT_LONGITUDE 0
+#endif
+
+// Default to no set birthdate year
+#ifndef MOVEMENT_DEFAULT_BIRTHDATE_YEAR
+#define MOVEMENT_DEFAULT_BIRTHDATE_YEAR 0
+#endif
+
+// Default to no set birthdate month
+#ifndef MOVEMENT_DEFAULT_BIRTHDATE_MONTH
+#define MOVEMENT_DEFAULT_BIRTHDATE_MONTH 0
+#endif
+
+// Default to no set birthdate day
+#ifndef MOVEMENT_DEFAULT_BIRTHDATE_DAY
+#define MOVEMENT_DEFAULT_BIRTHDATE_DAY 0
+#endif
+
 #if __EMSCRIPTEN__
 #include <emscripten.h>
 #endif
@@ -384,6 +409,11 @@ void app_init(void) {
     movement_state.settings.bit.to_interval = MOVEMENT_DEFAULT_TIMEOUT_INTERVAL;
     movement_state.settings.bit.le_interval = MOVEMENT_DEFAULT_LOW_ENERGY_INTERVAL;
     movement_state.settings.bit.led_duration = MOVEMENT_DEFAULT_LED_DURATION;
+    movement_state.location.bit.latitude = MOVEMENT_DEFAULT_LATITUDE;
+    movement_state.location.bit.longitude = MOVEMENT_DEFAULT_LONGITUDE;
+    movement_state.birthdate.bit.year = MOVEMENT_DEFAULT_BIRTHDATE_YEAR;
+    movement_state.birthdate.bit.month = MOVEMENT_DEFAULT_BIRTHDATE_MONTH;
+    movement_state.birthdate.bit.day = MOVEMENT_DEFAULT_BIRTHDATE_DAY;
     movement_state.light_ticks = -1;
     movement_state.alarm_ticks = -1;
     movement_state.next_available_backup_register = 4;
@@ -406,10 +436,14 @@ void app_init(void) {
 
 void app_wake_from_backup(void) {
     movement_state.settings.reg = watch_get_backup_data(0);
+    movement_state.location.reg = watch_get_backup_data(1);
+    movement_state.birthdate.reg = watch_get_backup_data(2);
 }
 
 void app_setup(void) {
     watch_store_backup_data(movement_state.settings.reg, 0);
+    watch_store_backup_data(movement_state.location.reg, 1);
+    watch_store_backup_data(movement_state.birthdate.reg, 2);
 
     static bool is_first_launch = true;
 

--- a/movement/movement.h
+++ b/movement/movement.h
@@ -242,6 +242,8 @@ typedef struct {
 typedef struct {
     // properties stored in BACKUP register
     movement_settings_t settings;
+    movement_location_t location;
+    movement_birthdate_t birthdate;
 
     // transient properties
     int16_t current_face_idx;

--- a/movement/movement_config.h
+++ b/movement/movement_config.h
@@ -76,15 +76,15 @@ const watch_face_t watch_faces[] = {
 /* Set the timeout before switching to low energy mode
  * Valid values are:
  * 0: Never
- * 1: 1 hour
- * 2: 2 hours
- * 3: 6 hours
- * 4: 12 hours
- * 5: 1 day
- * 6: 2 days
+ * 1: 10 mins
+ * 2: 1 hour
+ * 3: 2 hours
+ * 4: 6 hours
+ * 5: 12 hours
+ * 6: 1 day
  * 7: 7 days
  */
-#define MOVEMENT_DEFAULT_LOW_ENERGY_INTERVAL 1
+#define MOVEMENT_DEFAULT_LOW_ENERGY_INTERVAL 2
 
 /* Set the led duration
  * Valid values are:
@@ -94,5 +94,21 @@ const watch_face_t watch_faces[] = {
  * 3: 5 seconds
  */
 #define MOVEMENT_DEFAULT_LED_DURATION 1
+
+/* The latitude and longitude used for the wearers location
+ * Set signed values in 1/100ths of a degree
+ */
+#define MOVEMENT_DEFAULT_LATITUDE 0
+#define MOVEMENT_DEFAULT_LONGITUDE 0
+
+/* The wearers birthdate
+ * Valid values:
+ * Year: 1 - 4095
+ * Month: 1 - 12
+ * Day: 1 - 31
+ */
+#define MOVEMENT_DEFAULT_BIRTHDATE_YEAR 0
+#define MOVEMENT_DEFAULT_BIRTHDATE_MONTH 0
+#define MOVEMENT_DEFAULT_BIRTHDATE_DAY 0
 
 #endif // MOVEMENT_CONFIG_H_


### PR DESCRIPTION
Allow for location and birthdate preferences to be specified in the movement config. This means one less thing for the user to set up each time if they wish.
The defaults of 0 respect the current functionality, eg. for location the sunrise_sunset face still says 'no loc' and for birthdate the day_one face still defaults to 1959.
