### PR TITLE
Update comments for correct LE timeout values

### DIFF
--- a/movement/movement_config.h
+++ b/movement/movement_config.h
@@ -76,12 +76,12 @@ const watch_face_t watch_faces[] = {
 /* Set the timeout before switching to low energy mode
  * Valid values are:
  * 0: Never
- * 1: 1 hour
- * 2: 2 hours
- * 3: 6 hours
- * 4: 12 hours
- * 5: 1 day
- * 6: 2 days
+ * 1: 10 minutes
+ * 2: 1 hour
+ * 3: 2 hours
+ * 4: 6 hours
+ * 5: 12 hours
+ * 6: 1 day
  * 7: 7 days
  */
 #define MOVEMENT_DEFAULT_LOW_ENERGY_INTERVAL 1


### PR DESCRIPTION
The comments showed incorrect (probably outdated) values for `MOVEMENT_DEFAULT_LOW_ENERGY_INTERVAL`. I updated these values [according to the source code](https://github.com/joeycastillo/Sensor-Watch/blob/d2b5ed7155419d8528be9f52bf76754bdfbbf44c/movement/watch_faces/settings/preferences_face.c#L134).

