### PR TITLE
totp_face_lfs - reduce memory usage and add secmod

### DIFF
--- a/movement/lib/TOTP/TOTP.h
+++ b/movement/lib/TOTP/TOTP.h
@@ -4,7 +4,7 @@
 #include <inttypes.h>
 #include "time.h"
 
-typedef enum {
+typedef enum __attribute__ ((__packed__)) {
     SHA1,
     SHA224,
     SHA256,

--- a/movement/watch_faces/complication/totp_face_lfs.c
+++ b/movement/watch_faces/complication/totp_face_lfs.c
@@ -35,29 +35,47 @@
 
 #include "totp_face_lfs.h"
 
-#define MAX_TOTP_RECORDS 20
-#define MAX_TOTP_SECRET_SIZE 48
+#define MAX_TOTP_RECORDS 30
+#define MAX_TOTP_SECRET_SIZE 128
 #define TOTP_FILE "totp_uris.txt"
 
 const char* TOTP_URI_START = "otpauth://totp/";
 
+/* The totp_record struct has two modes of operation:
+ *  - secmod = false: read from lfs (in which file_secret_offset
+ *    points to an offset in totp_uris.txt)
+ *  - secmod = true: read from memory
+ *    (in which case secret contains the decoded secret)
+ */
 struct totp_record {
-    uint8_t *secret;
-    size_t secret_size;
     char label[2];
-    uint32_t period;
     hmac_alg algorithm;
+    uint8_t period;
+    uint8_t secret_size;
+
+    union {
+        uint8_t *secret;
+        struct {
+            uint16_t file_secret_offset;
+            uint16_t file_secret_length;
+        };
+    };
 };
 
+/* This is used if we're not storing all the secrets but instead
+ * calculating them on demand. Avoids malloc in normal operation.
+ */
+static uint8_t current_secret[MAX_TOTP_SECRET_SIZE];
+
 static struct totp_record totp_records[MAX_TOTP_RECORDS];
-static int num_totp_records = 0;
+static uint8_t num_totp_records = 0;
 
 static void init_totp_record(struct totp_record *totp_record) {
-    totp_record->secret_size = 0;
     totp_record->label[0] = 'A';
     totp_record->label[1] = 'A';
-    totp_record->period = 30;
     totp_record->algorithm = SHA1;
+    totp_record->period = 30;
+    totp_record->secret_size = 0;
 }
 
 static bool totp_face_lfs_read_param(struct totp_record *totp_record, char *param, char *value) {
@@ -69,14 +87,13 @@ static bool totp_face_lfs_read_param(struct totp_record *totp_record, char *para
         totp_record->label[0] = value[0];
         totp_record->label[1] = value[1];
     } else if (!strcmp(param, "secret")) {
-        if (UNBASE32_LEN(strlen(value)) > MAX_TOTP_SECRET_SIZE) {
+        totp_record->file_secret_length = strlen(value);
+        if (UNBASE32_LEN(totp_record->file_secret_length) > MAX_TOTP_SECRET_SIZE) {
             printf("TOTP secret too long: %s\n", value);
             return false;
         }
-        totp_record->secret = malloc(UNBASE32_LEN(strlen(value)));
-        totp_record->secret_size = base32_decode((unsigned char *)value, totp_record->secret);
+        totp_record->secret_size = base32_decode((unsigned char *)value, current_secret);
         if (totp_record->secret_size == 0) {
-            free(totp_record->secret);
             printf("TOTP can't decode secret: %s\n", value);
             return false;
         }
@@ -126,8 +143,8 @@ static void totp_face_lfs_read_file(char *filename) {
     }
 
     char line[256];
-    int32_t offset = 0;
-    while (filesystem_read_line(filename, line, &offset, 255) && strlen(line)) {
+    int32_t offset = 0, old_offset = 0;
+    while (old_offset = offset, filesystem_read_line(filename, line, &offset, 255) && strlen(line)) {
         if (num_totp_records == MAX_TOTP_RECORDS) {
             printf("TOTP max records: %d\n", MAX_TOTP_RECORDS);
             break;
@@ -155,7 +172,13 @@ static void totp_face_lfs_read_file(char *filename) {
         do {
             char *param_middle = strchr(param, '=');
             *param_middle = '\0';
-            error = error || !totp_face_lfs_read_param(&totp_records[num_totp_records], param, param_middle + 1);
+            if (totp_face_lfs_read_param(&totp_records[num_totp_records], param, param_middle + 1)) {
+                if (!strcmp(param, "secret")) {
+                    totp_records[num_totp_records].file_secret_offset = old_offset + (param_middle + 1 - line);
+                }
+            } else {
+                error = true;
+            }
         } while ((param = strtok_r(NULL, "&", &param_saveptr)));
 
         if (error) {
@@ -186,15 +209,42 @@ void totp_face_lfs_setup(movement_settings_t *settings, uint8_t watch_face_index
 #endif
 }
 
+static uint8_t *totp_face_lfs_get_file_secret(struct totp_record *record) {
+    char buffer[BASE32_LEN(MAX_TOTP_SECRET_SIZE) + 1];
+    int32_t file_secret_offset = record->file_secret_offset;
+
+    /* TODO filesystem_read_line is quite inefficient. Consider writing a new function,
+     * and keeping the file open?
+     */
+    if (!filesystem_read_line(TOTP_FILE, buffer, &file_secret_offset, record->file_secret_length + 1)) {
+        /* Shouldn't happen at this point. Return current_secret, which is misleading but will not cause a crash. */
+        printf("TOTP can't read expected secret from totp_uris.txt (failed readline)\n");
+        return current_secret;
+    }
+    if (base32_decode((unsigned char *)buffer, current_secret) != record->secret_size) {
+        printf("TOTP can't properly decode secret from totp_uris.txt; failed at offset %d; read to %d\n", buffer, record->file_secret_offset, file_secret_offset);
+    }
+    return current_secret;
+}
+
 static void totp_face_set_record(totp_lfs_state_t *totp_state, int i) {
+    struct totp_record *record;
+
     if (num_totp_records == 0 && i >= num_totp_records) {
         return;
     }
 
     totp_state->current_index = i;
-    TOTP(totp_records[i].secret, totp_records[i].secret_size, totp_records[i].period, totp_records[i].algorithm);
+    record = &totp_records[i];
+
+    TOTP(
+        (totp_state->secmod ? record->secret : totp_face_lfs_get_file_secret(record)),
+        record->secret_size,
+        record->period,
+        record->algorithm
+    );
     totp_state->current_code = getCodeFromTimestamp(totp_state->timestamp);
-    totp_state->steps = totp_state->timestamp / totp_records[i].period;
+    totp_state->steps = totp_state->timestamp / record->period;
 }
 
 void totp_face_lfs_activate(movement_settings_t *settings, void *context) {
@@ -210,6 +260,7 @@ void totp_face_lfs_activate(movement_settings_t *settings, void *context) {
     }
 #endif
 
+    totp_state->secmod_request = false;
     totp_state->timestamp = watch_utility_date_time_to_unix_time(watch_rtc_get_date_time(), movement_timezone_offsets[settings->bit.time_zone] * 60);
     totp_face_set_record(totp_state, 0);
 }
@@ -235,6 +286,26 @@ static void totp_face_display(totp_lfs_state_t *totp_state) {
     watch_display_string(buf, 0);
 }
 
+static void totp_face_lfs_switch_to_secmod(totp_lfs_state_t *totp_state) {
+    int i;
+
+    for (i = 0; i < num_totp_records; ++i) {
+        totp_face_lfs_get_file_secret(&totp_records[i]);
+        totp_records[i].secret = malloc(totp_records[i].secret_size);
+        if (totp_records[i].secret == NULL) {
+            num_totp_records = i - 1;
+            // We can't easily undo at this point, because we destroyed
+            // the offset info (secret is in a union). So let's just junk
+            // the remaining records.
+            break;
+        }
+        memcpy(totp_records[i].secret, current_secret, totp_records[i].secret_size);
+    }
+
+    filesystem_rm(TOTP_FILE);
+    totp_state->secmod = true;
+}
+
 bool totp_face_lfs_loop(movement_event_t event, movement_settings_t *settings, void *context) {
     (void) settings;
 
@@ -242,8 +313,10 @@ bool totp_face_lfs_loop(movement_event_t event, movement_settings_t *settings, v
 
     switch (event.event_type) {
         case EVENT_TICK:
-            totp_state->timestamp++;
-            totp_face_display(totp_state);
+            if (!totp_state->secmod_request) {
+                totp_state->timestamp++;
+                totp_face_display(totp_state);
+            }
             break;
         case EVENT_ACTIVATE:
             totp_face_display(totp_state);
@@ -252,24 +325,40 @@ bool totp_face_lfs_loop(movement_event_t event, movement_settings_t *settings, v
             movement_move_to_face(0);
             break;
         case EVENT_ALARM_BUTTON_UP:
+            totp_state->secmod_request = false;
             totp_face_set_record(totp_state, (totp_state->current_index + 1) % num_totp_records);
             totp_face_display(totp_state);
             break;
         case EVENT_LIGHT_BUTTON_UP:
-            if (totp_state->current_index - 1 >= 0) {
-                totp_face_set_record(totp_state, totp_state->current_index - 1);
-            } else {
-                // Wrap around to the last record.
-                totp_face_set_record(totp_state, num_totp_records - 1);
-            }
+            totp_state->secmod_request = false;
+            totp_face_set_record(totp_state, (totp_state->current_index + num_totp_records - 1) % num_totp_records);
             totp_face_display(totp_state);
             break;
-        case EVENT_ALARM_BUTTON_DOWN:
         case EVENT_ALARM_LONG_PRESS:
+            if (totp_state->secmod || num_totp_records < 1) {
+                break;
+            }
+
+            /* now long press 'Light' if you want secmod */
+            totp_state->secmod_request = true;
+            watch_display_string("LIIFSecmod", 0);
+            break;
+        case EVENT_ALARM_BUTTON_DOWN:
         case EVENT_LIGHT_BUTTON_DOWN:
             break;
         case EVENT_LIGHT_LONG_PRESS:
-            movement_illuminate_led();
+            if (totp_state->secmod_request) {
+                totp_face_lfs_switch_to_secmod(totp_state);
+                totp_face_set_record(totp_state, 0);
+                totp_face_display(totp_state);
+            } else {
+                movement_illuminate_led();
+            }
+            totp_state->secmod_request = false;
+            break;
+        case EVENT_MODE_BUTTON_UP:
+            totp_state->secmod_request = false;
+            movement_default_loop_handler(event, settings);
             break;
         default:
             movement_default_loop_handler(event, settings);

--- a/movement/watch_faces/complication/totp_face_lfs.h
+++ b/movement/watch_faces/complication/totp_face_lfs.h
@@ -35,7 +35,8 @@
  *   otpauth://totp/ACME%20Co:john.doe@email.com?secret=HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ&issuer=ACME%20Co&algorithm=SHA1&digits=6&period=30
  *
  * This is also the same as what Aegis exports in plain-text format.
- * This face performs minimal sanitisation of input, however.
+ * This face performs minimal sanitisation of input, however, and you
+ * will only see errors if you use the simulator or view the serial console.
  *
  * At the moment, to get the records onto the filesystem, start a serial connection and do:
  *   echo otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example > totp_uris.txt
@@ -49,6 +50,16 @@
  * If you have more than one secret key, press ALARM to cycle through them.
  * Press LIGHT to cycle in the other direction or keep it pressed longer to
  * activate the light.
+ *
+ * Finally, if you're especially paranoid, doing a long-hold of ALARM will bring
+ * up the option to move to 'secure mode' (LI IF SECMOD). To enable secure
+ * mode, do a long press of the LIGHT button. Secure mode removes totp_uris.txt
+ * from the filesystem, which means the codes will disappear when your
+ * watch loses power (i.e. when the battery runs out or you next disassemble it).
+ * HOWEVER, it will also use more memory. If you have a large number of TOTP
+ * codes, or many other faces loaded which allocate memory, this will drop any
+ * codes it can't allocate space for, and potentially cause other failures
+ * if other code requires memory.
  */
 
 #include "movement.h"
@@ -58,6 +69,8 @@ typedef struct {
     uint8_t steps;
     uint32_t current_code;
     uint8_t current_index;
+    bool secmod;
+    bool secmod_request;
 } totp_lfs_state_t;
 
 void totp_face_lfs_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr);


### PR DESCRIPTION
This should fix #392 

I've refactored this so it doesn't allocate the secrets on startup, but instead reads them from lfs each time. Not a fan of the filesystem API here... (would be so much more efficient if I had easy access to the underlying seek/read and could just leave the file open, but putting all that in this PR seemed like overkill).

I've also added a 'secure mode' which lets you remove from the secrets from the flash (see doco in header).

@madhogs - I haven't tried this on a real watch yet, so if you want to be a guinea pig that would be awesome :)