### PR TITLE
Keep light on if interacting

### DIFF
--- a/movement/movement.c
+++ b/movement/movement.c
@@ -543,6 +543,17 @@ bool app_loop(void) {
         event.subsecond = movement_state.subsecond;
         // the first trip through the loop overrides the can_sleep state
         can_sleep = wf->loop(event, &movement_state.settings, watch_face_contexts[movement_state.current_face_idx]);
+
+        // Keep light on if user is still interacting with the watch.
+        if (movement_state.light_ticks > 0) {
+            switch (event.event_type) {
+                case EVENT_LIGHT_BUTTON_DOWN:
+                case EVENT_MODE_BUTTON_DOWN:
+                case EVENT_ALARM_BUTTON_DOWN:
+                    movement_illuminate_led();
+            }
+        }
+
         event.event_type = EVENT_NONE;
     }
 

--- a/watch-library/simulator/main.c
+++ b/watch-library/simulator/main.c
@@ -89,6 +89,7 @@ void main_loop_sleep(uint32_t ms) {
     main_loop_set_sleeping(true);
     emscripten_sleep(ms);
     main_loop_set_sleeping(false);
+    animation_frame_id = ANIMATION_FRAME_ID_INVALID;
 }
 
 bool main_loop_is_sleeping(void) {


### PR DESCRIPTION
This makes it possible to do a bunch of things without having to keep touching the light button.

I don't really see any downside with this. If you want the light to go off, just stop touching buttons.

WARNING: haven't yet tested on real hardware. Includes a minor patch to fix what I think is a bug in the simulator (without this, the watch will freeze up on transition as the buzzer causes the simulator to sleep in a state where the last animation frame was valid if the light was on).