### PR TITLE
International weekday names

### DIFF
--- a/movement/movement.h
+++ b/movement/movement.h
@@ -62,7 +62,8 @@ typedef union {
         bool clock_mode_24h : 1;            // indicates whether clock should use 12 or 24 hour mode.
         bool use_imperial_units : 1;        // indicates whether to use metric units (the default) or imperial.
         bool alarm_enabled : 1;             // indicates whether there is at least one alarm enabled.
-        uint8_t reserved : 6;               // room for more preferences if needed.
+        uint8_t lang_preference : 2 ;       // which language should weekday names be displayed as, see watch_utility_get_weekday(); 2bits == 4 choices
+        uint8_t reserved : 4;               // room for more preferences if needed.
     } bit;
     uint32_t reg;
 } movement_settings_t;

--- a/movement/watch_faces/settings/preferences_face.c
+++ b/movement/watch_faces/settings/preferences_face.c
@@ -24,6 +24,7 @@
 
 #include <stdlib.h>
 #include "preferences_face.h"
+#include "watch_utility.h"
 #include "watch.h"
 
 #define PREFERENCES_FACE_NUM_PREFEFENCES (8)

--- a/movement/watch_faces/settings/preferences_face.c
+++ b/movement/watch_faces/settings/preferences_face.c
@@ -206,7 +206,7 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
     }
 
     // on LED color select screns, preview the color.
-    if (current_page >= 5) {
+    if (current_page == 5 || current_page == 6) {
         watch_set_led_color(settings->bit.led_red_color ? (0xF | settings->bit.led_red_color << 4) : 0,
                             settings->bit.led_green_color ? (0xF | settings->bit.led_green_color << 4) : 0);
         // return false so the watch stays awake (needed for the PWM driver to function).

--- a/movement/watch_faces/settings/preferences_face.c
+++ b/movement/watch_faces/settings/preferences_face.c
@@ -39,6 +39,7 @@ const char preferences_face_titles[PREFERENCES_FACE_NUM_PREFEFENCES][11] = {
     "LT   grn  ",   // Light: green component
 #endif
     "LT   red  ",   // Light: red component
+    "          ",   // Language of weekday names, title changes based on selection
 };
 
 void preferences_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {
@@ -91,6 +92,10 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
                 case 6:
                     settings->bit.led_red_color = settings->bit.led_red_color + 1;
                     break;
+                case 7:
+                    settings->bit.lang_preference = settings->bit.lang_preference + 1;
+                    watch_store_backup_data(settings->reg, 0);
+                    break;
             }
             break;
         case EVENT_TIMEOUT:
@@ -101,6 +106,11 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
     }
 
     watch_display_string((char *)preferences_face_titles[current_page], 0);
+    if (current_page == 7) {    // weekday language selection
+        //date_time = watch_rtc_get_date_time();
+        //watch_display_string( watch_utility_get_weekday(date_time), 0 ); // dynamic changing title, but shouldn't blink
+        watch_display_string( watch_utility_get_weekday(watch_rtc_get_date_time()), 0 ); // dynamic changing title, but shouldn't blink
+    }
 
     // blink active setting on even-numbered quarter-seconds
     if (event.subsecond % 2) {
@@ -173,6 +183,22 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
             case 6:
                 sprintf(buf, "%2d", settings->bit.led_red_color);
                 watch_display_string(buf, 8);
+                break;
+            case 7:
+                switch (settings->bit.lang_preference) {  // order of langs should match weekdays_dict in watch_utility.c
+                    case 0:
+                        watch_display_string(" En ", 4);
+                        break;
+                    case 1:
+                        watch_display_string(" dE ", 4);
+                        break;
+                    case 2:
+                        watch_display_string(" ES ", 4);
+                        break;
+                    case 3:
+                        watch_display_string(" Fr ", 4);
+                        break;
+                }
                 break;
         }
     }

--- a/movement/watch_faces/settings/preferences_face.c
+++ b/movement/watch_faces/settings/preferences_face.c
@@ -26,7 +26,7 @@
 #include "preferences_face.h"
 #include "watch.h"
 
-#define PREFERENCES_FACE_NUM_PREFEFENCES (7)
+#define PREFERENCES_FACE_NUM_PREFEFENCES (8)
 const char preferences_face_titles[PREFERENCES_FACE_NUM_PREFEFENCES][11] = {
     "CL        ",   // Clock: 12 or 24 hour
     "BT  Beep  ",   // Buttons: should they beep?

--- a/movement/watch_faces/settings/preferences_face.c
+++ b/movement/watch_faces/settings/preferences_face.c
@@ -107,9 +107,11 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
 
     watch_display_string((char *)preferences_face_titles[current_page], 0);
     if (current_page == 7) {    // weekday language selection
-        //date_time = watch_rtc_get_date_time();
+        watch_date_time date_time = watch_rtc_get_date_time();
+        char *weekday_to_show = watch_utility_get_weekday(date_time);
+        watch_display_string( weekday_to_show, 0 ); // dynamic changing title, but shouldn't blink
         //watch_display_string( watch_utility_get_weekday(date_time), 0 ); // dynamic changing title, but shouldn't blink
-        watch_display_string( watch_utility_get_weekday(watch_rtc_get_date_time()), 0 ); // dynamic changing title, but shouldn't blink
+        //watch_display_string( watch_utility_get_weekday(watch_rtc_get_date_time()), 0 ); // dynamic changing title, but shouldn't blink
     }
 
     // blink active setting on even-numbered quarter-seconds

--- a/watch-library/shared/watch/watch_utility.c
+++ b/watch-library/shared/watch/watch_utility.c
@@ -40,8 +40,8 @@ const char * watch_utility_get_weekday(watch_date_time date_time) {
     weekday_index = watch_utility_get_iso8601_weekday_number(date_time.unit.year + WATCH_RTC_REFERENCE_YEAR, date_time.unit.month, date_time.unit.day) - 1 ;
 
     //return weekdays[watch_utility_get_iso8601_weekday_number(date_time.unit.year + WATCH_RTC_REFERENCE_YEAR, date_time.unit.month, date_time.unit.day) - 1];
-    //return  *( *(p_dict_row + (uint8_t)movement_settings.bit.lang_preference) + weekday_index );
-    return  *( *(p_dict_row +                                               3) + weekday_index );   // debug
+    return  *( *(p_dict_row + (uint8_t)movement_settings.bit.lang_preference) + weekday_index );
+    //return  *( *(p_dict_row +                                               3) + weekday_index );   // debug
 
 }
 

--- a/watch-library/shared/watch/watch_utility.c
+++ b/watch-library/shared/watch/watch_utility.c
@@ -32,7 +32,7 @@ const char * watch_utility_get_weekday(watch_date_time date_time) {
 
     //static const char weekdays[7][3] = {"MO", "TU", "WE", "TH", "FR", "SA", "SU"};
     static char weekdays_dict[4][7][3] = { {"MO", "TU", "WE", "TH", "FR", "SA", "SU"} ,   // EN
-                                           {"MO", "DI", "MI", "DO", "FR", "SA", "DO"} ,   // DE
+                                           {"MO", "DI", "MI", "DO", "FR", "SA", "SO"} ,   // DE
                                            {"LU", "ME", "MI", "JU", "VI", "SA", "DO"} ,   // ES
                                            {"LU", "MA", "ME", "JE", "VE", "SA", "DI"} };  // FR
     char (*p_dict_row)[7][3] = weekdays_dict;  // point to the first row; default is English, esp. if there's no config face

--- a/watch-library/shared/watch/watch_utility.c
+++ b/watch-library/shared/watch/watch_utility.c
@@ -24,10 +24,25 @@
 
 #include <math.h>
 #include "watch_utility.h"
+#include "movement.h"
 
 const char * watch_utility_get_weekday(watch_date_time date_time) {
-    static const char weekdays[7][3] = {"MO", "TU", "WE", "TH", "FR", "SA", "SU"};
-    return weekdays[watch_utility_get_iso8601_weekday_number(date_time.unit.year + WATCH_RTC_REFERENCE_YEAR, date_time.unit.month, date_time.unit.day) - 1];
+    movement_settings_t movement_settings = (movement_settings_t) watch_get_backup_data(0);
+    uint8_t weekday_index;
+
+    //static const char weekdays[7][3] = {"MO", "TU", "WE", "TH", "FR", "SA", "SU"};
+    static char weekdays_dict[4][7][3] = { {"MO", "TU", "WE", "TH", "FR", "SA", "SU"} ,   // EN
+                                           {"MO", "DI", "MI", "DO", "FR", "SA", "DO"} ,   // DE
+                                           {"LU", "ME", "MI", "JU", "VI", "SA", "DO"} ,   // ES
+                                           {"LU", "MA", "ME", "JE", "VE", "SA", "DI"} };  // FR
+    char (*p_dict_row)[7][3] = weekdays_dict;  // point to the first row; default is English, esp. if there's no config face
+
+    weekday_index = watch_utility_get_iso8601_weekday_number(date_time.unit.year + WATCH_RTC_REFERENCE_YEAR, date_time.unit.month, date_time.unit.day) - 1 ;
+
+    //return weekdays[watch_utility_get_iso8601_weekday_number(date_time.unit.year + WATCH_RTC_REFERENCE_YEAR, date_time.unit.month, date_time.unit.day) - 1];
+    //return  *( *(p_dict_row + (uint8_t)movement_settings.bit.lang_preference) + weekday_index );
+    return  *( *(p_dict_row +                                               3) + weekday_index );   // debug
+
 }
 
 // Per ISO8601 week starts on Monday with index 1

--- a/watch-library/shared/watch/watch_utility.c
+++ b/watch-library/shared/watch/watch_utility.c
@@ -27,15 +27,15 @@
 #include "movement.h"
 
 const char * watch_utility_get_weekday(watch_date_time date_time) {
-    movement_settings_t movement_settings = (movement_settings_t) watch_get_backup_data(0);
+    //movement_settings_t movement_settings = (movement_settings_t) watch_get_backup_data(0);
     uint8_t weekday_index;
 
     //static const char weekdays[7][3] = {"MO", "TU", "WE", "TH", "FR", "SA", "SU"};
-    static char weekdays_dict[4][7][3] = { {"MO", "TU", "WE", "TH", "FR", "SA", "SU"} ,   // EN
-                                           {"MO", "DI", "MI", "DO", "FR", "SA", "SO"} ,   // DE
-                                           {"LU", "ME", "MI", "JU", "VI", "SA", "DO"} ,   // ES
-                                           {"LU", "MA", "ME", "JE", "VE", "SA", "DI"} };  // FR
-    char (*p_dict_row)[7][3] = weekdays_dict;  // point to the first row; default is English, esp. if there's no config face
+    static const char weekdays_dict[4][7][3] = { {"MO", "TU", "WE", "TH", "FR", "SA", "SU"} ,   // EN
+                                                 {"MO", "DI", "MI", "DO", "FR", "SA", "SO"} ,   // DE
+                                                 {"LU", "ME", "MI", "JU", "VI", "SA", "DO"} ,   // ES
+                                                 {"LU", "MA", "ME", "JE", "VE", "SA", "DI"} };  // FR
+    const char (*p_dict_row)[7][3] = weekdays_dict;  // point to the first row; default is English, esp. if there's no config face
 
     weekday_index = watch_utility_get_iso8601_weekday_number(date_time.unit.year + WATCH_RTC_REFERENCE_YEAR, date_time.unit.month, date_time.unit.day) - 1 ;
 

--- a/watch-library/shared/watch/watch_utility.h
+++ b/watch-library/shared/watch/watch_utility.h
@@ -49,7 +49,7 @@ typedef struct {
   *        in positions 0-1 of the watch face
   * @param date_time The watch_date_time whose weekday you want.
   */
-const char * watch_utility_get_weekday(watch_date_time date_time);
+char * watch_utility_get_weekday(watch_date_time date_time);
 
 /** @brief Returns a number between 1-7 representing the weekday according to ISO8601 : week starts on Monday and has index 1, Sunday has index 7
  * @param year The year of the date


### PR DESCRIPTION
WIP: adding internationalized weekday selections in preferences_face

The idea I have about this is that, inside preferences_face, when a user selects current_page == 7, the particular language blinks, indicating that it is changeable, while the weekday name changes, but does not blink, as the user cycles through the different choices.


My C-fu is not that strong, so I welcome feedback. I'm struggling on how to get watch_utility_get_weekday() to see movement_state without it being declared extern. I'm also struggling to get const put in the right places. TIA