### PR TITLE
Change 24 h with alarm

### DIFF
--- a/movement/movement.c
+++ b/movement/movement.c
@@ -377,7 +377,11 @@ void app_init(void) {
 
     memset(&movement_state, 0, sizeof(movement_state));
 
+#ifdef CLOCK_FACE_24H_ONLY
+    movement_state.settings.bit.clock_mode_24h = true;
+#else
     movement_state.settings.bit.clock_mode_24h = MOVEMENT_DEFAULT_24H_MODE;
+#endif
     movement_state.settings.bit.led_red_color = MOVEMENT_DEFAULT_RED_COLOR;
     movement_state.settings.bit.led_green_color = MOVEMENT_DEFAULT_GREEN_COLOR;
     movement_state.settings.bit.button_should_sound = MOVEMENT_DEFAULT_BUTTON_SOUND;

--- a/movement/watch_faces/clock/simple_clock_face.c
+++ b/movement/watch_faces/clock/simple_clock_face.c
@@ -51,7 +51,9 @@ void simple_clock_face_activate(movement_settings_t *settings, void *context) {
 
     if (watch_tick_animation_is_running()) watch_stop_tick_animation();
 
+#ifndef CLOCK_FACE_24H_ONLY
     if (settings->bit.clock_mode_24h) watch_set_indicator(WATCH_INDICATOR_24H);
+#endif
 
     // handle chime indicator
     if (state->signal_enabled) watch_set_indicator(WATCH_INDICATOR_BELL);
@@ -106,6 +108,7 @@ bool simple_clock_face_loop(movement_event_t event, movement_settings_t *setting
                 sprintf(buf, "%02d%02d", date_time.unit.minute, date_time.unit.second);
             } else {
                 // other stuff changed; let's do it all.
+#ifndef CLOCK_FACE_24H_ONLY
                 if (!settings->bit.clock_mode_24h) {
                     // if we are in 12 hour mode, do some cleanup.
                     if (date_time.unit.hour < 12) {
@@ -116,6 +119,7 @@ bool simple_clock_face_loop(movement_event_t event, movement_settings_t *setting
                     date_time.unit.hour %= 12;
                     if (date_time.unit.hour == 0) date_time.unit.hour = 12;
                 }
+#endif
                 pos = 0;
                 if (event.event_type == EVENT_LOW_ENERGY_UPDATE) {
                     if (!watch_tick_animation_is_running()) watch_start_tick_animation(500);

--- a/movement/watch_faces/clock/simple_clock_face.c
+++ b/movement/watch_faces/clock/simple_clock_face.c
@@ -134,6 +134,7 @@ bool simple_clock_face_loop(movement_event_t event, movement_settings_t *setting
             else watch_clear_indicator(WATCH_INDICATOR_BELL);
             break;
         case EVENT_ALARM_BUTTON_UP:
+#ifndef CLOCK_FACE_24H_ONLY
             settings->bit.clock_mode_24h = !settings->bit.clock_mode_24h;
             date_time = watch_rtc_get_date_time();
             if (settings->bit.clock_mode_24h) {
@@ -148,6 +149,7 @@ bool simple_clock_face_loop(movement_event_t event, movement_settings_t *setting
             } 
             sprintf(buf, "%2d", date_time.unit.hour);
             watch_display_string(buf, 4);
+#endif
             break;
         case EVENT_BACKGROUND_TASK:
             // uncomment this line to snap back to the clock face when the hour signal sounds:

--- a/movement/watch_faces/clock/simple_clock_face.c
+++ b/movement/watch_faces/clock/simple_clock_face.c
@@ -133,6 +133,22 @@ bool simple_clock_face_loop(movement_event_t event, movement_settings_t *setting
             if (state->signal_enabled) watch_set_indicator(WATCH_INDICATOR_BELL);
             else watch_clear_indicator(WATCH_INDICATOR_BELL);
             break;
+        case EVENT_ALARM_BUTTON_UP:
+            settings->bit.clock_mode_24h = !settings->bit.clock_mode_24h;
+            date_time = watch_rtc_get_date_time();
+            if (settings->bit.clock_mode_24h) {
+                watch_set_indicator(WATCH_INDICATOR_24H);
+                watch_clear_indicator(WATCH_INDICATOR_PM);
+            }
+            else {
+                watch_clear_indicator(WATCH_INDICATOR_24H);
+                if (date_time.unit.hour >= 12) watch_set_indicator(WATCH_INDICATOR_PM);
+                date_time.unit.hour %= 12;
+                if (date_time.unit.hour == 0) date_time.unit.hour = 12;
+            } 
+            sprintf(buf, "%2d", date_time.unit.hour);
+            watch_display_string(buf, 4);
+            break;
         case EVENT_BACKGROUND_TASK:
             // uncomment this line to snap back to the clock face when the hour signal sounds:
             // movement_move_to_face(state->watch_face_index);

--- a/movement/watch_faces/settings/preferences_face.c
+++ b/movement/watch_faces/settings/preferences_face.c
@@ -26,8 +26,8 @@
 #include "preferences_face.h"
 #include "watch.h"
 
-#define PREFERENCES_FACE_NUM_PREFEFENCES (7)
-const char preferences_face_titles[PREFERENCES_FACE_NUM_PREFEFENCES][11] = {
+#define PREFERENCES_FACE_NUM_PREFERENCES (7)
+const char preferences_face_titles[PREFERENCES_FACE_NUM_PREFERENCES][11] = {
     "CL        ",   // Clock: 12 or 24 hour
     "BT  Beep  ",   // Buttons: should they beep?
     "TO        ",   // Timeout: how long before we snap back to the clock face?
@@ -65,7 +65,7 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
             movement_move_to_next_face();
             return false;
         case EVENT_LIGHT_BUTTON_DOWN:
-            current_page = (current_page + 1) % PREFERENCES_FACE_NUM_PREFEFENCES;
+            current_page = (current_page + 1) % PREFERENCES_FACE_NUM_PREFERENCES;
             *((uint8_t *)context) = current_page;
             break;
         case EVENT_ALARM_BUTTON_UP:
@@ -99,7 +99,9 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
         default:
             return movement_default_loop_handler(event, settings);
     }
-
+#ifdef CLOCK_FACE_24H_ONLY
+    if (current_page == 0) current_page++;  // Skip past the 24H/12H setting if we want to always use 24H mode
+#endif
     watch_display_string((char *)preferences_face_titles[current_page], 0);
 
     // blink active setting on even-numbered quarter-seconds


### PR DESCRIPTION
The original Casio F-91W swaps between 24H mode by pressing the `ALARM` button.  
This PR does the same both on the `simple_clock_face` and the `clock_face`.  

`clock_face` will ignore this if `CLOCK_FACE_24H_ONLY` is set on make.


![24h](https://github.com/joeycastillo/Sensor-Watch/assets/36523934/2145deee-cb9b-43da-88ed-212a8934c66d)
