### PR TITLE
Clock face 24h only flag changes

### DIFF
--- a/movement/movement.c
+++ b/movement/movement.c
@@ -377,7 +377,11 @@ void app_init(void) {
 
     memset(&movement_state, 0, sizeof(movement_state));
 
+#ifdef CLOCK_FACE_24H_ONLY
+    movement_state.settings.bit.clock_mode_24h = true;
+#else
     movement_state.settings.bit.clock_mode_24h = MOVEMENT_DEFAULT_24H_MODE;
+#endif
     movement_state.settings.bit.led_red_color = MOVEMENT_DEFAULT_RED_COLOR;
     movement_state.settings.bit.led_green_color = MOVEMENT_DEFAULT_GREEN_COLOR;
     movement_state.settings.bit.button_should_sound = MOVEMENT_DEFAULT_BUTTON_SOUND;

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -328,6 +328,14 @@ static void end_buzzing_and_disable_buzzer(void) {
     watch_disable_buzzer();
 }
 
+static void set_initial_clock_mode(void) {
+#ifdef CLOCK_FACE_24H_ONLY
+    movement_state.settings.bit.clock_mode_24h = true;
+#else
+    movement_state.settings.bit.clock_mode_24h = MOVEMENT_DEFAULT_24H_MODE;
+#endif
+}
+
 void movement_play_signal(void) {
     void *maybe_disable_buzzer = end_buzzing_and_disable_buzzer;
     if (watch_is_buzzer_or_led_enabled()) {
@@ -376,12 +384,7 @@ void app_init(void) {
 #endif
 
     memset(&movement_state, 0, sizeof(movement_state));
-
-#ifdef CLOCK_FACE_24H_ONLY
-    movement_state.settings.bit.clock_mode_24h = true;
-#else
-    movement_state.settings.bit.clock_mode_24h = MOVEMENT_DEFAULT_24H_MODE;
-#endif
+    set_initial_clock_mode();
     movement_state.settings.bit.led_red_color = MOVEMENT_DEFAULT_RED_COLOR;
     movement_state.settings.bit.led_green_color = MOVEMENT_DEFAULT_GREEN_COLOR;
     movement_state.settings.bit.button_should_sound = MOVEMENT_DEFAULT_BUTTON_SOUND;

--- a/movement/watch_faces/clock/clock_face.c
+++ b/movement/watch_faces/clock/clock_face.c
@@ -42,10 +42,6 @@
 #define CLOCK_FACE_LOW_BATTERY_VOLTAGE_THRESHOLD 2200
 #endif
 
-#ifndef CLOCK_FACE_24H_ONLY
-#define CLOCK_FACE_24H_ONLY 0
-#endif
-
 typedef struct {
     struct {
         watch_date_time previous;
@@ -57,7 +53,6 @@ typedef struct {
 } clock_state_t;
 
 static bool clock_is_in_24h_mode(movement_settings_t *settings) {
-    if (CLOCK_FACE_24H_ONLY) { return true; }
     return settings->bit.clock_mode_24h;
 }
 

--- a/movement/watch_faces/clock/clock_face.c
+++ b/movement/watch_faces/clock/clock_face.c
@@ -53,7 +53,11 @@ typedef struct {
 } clock_state_t;
 
 static bool clock_is_in_24h_mode(movement_settings_t *settings) {
+#ifdef CLOCK_FACE_24H_ONLY
+    return true;
+#else
     return settings->bit.clock_mode_24h;
+#endif
 }
 
 static void clock_indicate(WatchIndicatorSegment indicator, bool on) {

--- a/movement/watch_faces/clock/simple_clock_face.c
+++ b/movement/watch_faces/clock/simple_clock_face.c
@@ -51,7 +51,11 @@ void simple_clock_face_activate(movement_settings_t *settings, void *context) {
 
     if (watch_tick_animation_is_running()) watch_stop_tick_animation();
 
+#ifdef CLOCK_FACE_24H_ONLY
+    watch_set_indicator(WATCH_INDICATOR_24H);
+#else
     if (settings->bit.clock_mode_24h) watch_set_indicator(WATCH_INDICATOR_24H);
+#endif
 
     // handle chime indicator
     if (state->signal_enabled) watch_set_indicator(WATCH_INDICATOR_BELL);
@@ -106,6 +110,7 @@ bool simple_clock_face_loop(movement_event_t event, movement_settings_t *setting
                 sprintf(buf, "%02d%02d", date_time.unit.minute, date_time.unit.second);
             } else {
                 // other stuff changed; let's do it all.
+#ifndef CLOCK_FACE_24H_ONLY
                 if (!settings->bit.clock_mode_24h) {
                     // if we are in 12 hour mode, do some cleanup.
                     if (date_time.unit.hour < 12) {
@@ -116,6 +121,7 @@ bool simple_clock_face_loop(movement_event_t event, movement_settings_t *setting
                     date_time.unit.hour %= 12;
                     if (date_time.unit.hour == 0) date_time.unit.hour = 12;
                 }
+#endif
                 pos = 0;
                 if (event.event_type == EVENT_LOW_ENERGY_UPDATE) {
                     if (!watch_tick_animation_is_running()) watch_start_tick_animation(500);

--- a/movement/watch_faces/settings/preferences_face.c
+++ b/movement/watch_faces/settings/preferences_face.c
@@ -26,8 +26,8 @@
 #include "preferences_face.h"
 #include "watch.h"
 
-#define PREFERENCES_FACE_NUM_PREFEFENCES (7)
-const char preferences_face_titles[PREFERENCES_FACE_NUM_PREFEFENCES][11] = {
+#define PREFERENCES_FACE_NUM_PREFERENCES (7)
+const char preferences_face_titles[PREFERENCES_FACE_NUM_PREFERENCES][11] = {
     "CL        ",   // Clock: 12 or 24 hour
     "BT  Beep  ",   // Buttons: should they beep?
     "TO        ",   // Timeout: how long before we snap back to the clock face?
@@ -65,7 +65,7 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
             movement_move_to_next_face();
             return false;
         case EVENT_LIGHT_BUTTON_DOWN:
-            current_page = (current_page + 1) % PREFERENCES_FACE_NUM_PREFEFENCES;
+            current_page = (current_page + 1) % PREFERENCES_FACE_NUM_PREFERENCES;
             *((uint8_t *)context) = current_page;
             break;
         case EVENT_ALARM_BUTTON_UP:

--- a/movement/watch_faces/settings/preferences_face.c
+++ b/movement/watch_faces/settings/preferences_face.c
@@ -99,7 +99,9 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
         default:
             return movement_default_loop_handler(event, settings);
     }
-
+#ifdef CLOCK_FACE_24H_ONLY
+    if (current_page == 0) current_page++;  // Skips past 12/24HR mode
+#endif
     watch_display_string((char *)preferences_face_titles[current_page], 0);
 
     // blink active setting on even-numbered quarter-seconds


### PR DESCRIPTION
* Made the `CLOCK_FACE_24H_ONLY` flag more universal where it sets the `clock_mode_24h` bit on startup and doesn't allow it to be changed or seen in the preferences.
* Fixed typo of `PREFERENCES_FACE_NUM_PREFEFENCES`