### PR TITLE
Added ability to add presets to the sunrise and sunset face

### DIFF
--- a/movement/watch_faces/complication/sunrise_sunset_face.c
+++ b/movement/watch_faces/complication/sunrise_sunset_face.c
@@ -399,7 +399,7 @@ bool sunrise_sunset_face_loop(movement_event_t event, movement_settings_t *setti
                 movement_request_tick_frequency(4);
                 _sunrise_sunset_face_update_settings_display(event, context);
             }
-            else{
+            else {
                 state->active_digit = 0;
                 state->page = 0;
                 _sunrise_sunset_face_update_location_register(state);

--- a/movement/watch_faces/complication/sunrise_sunset_face.c
+++ b/movement/watch_faces/complication/sunrise_sunset_face.c
@@ -372,7 +372,7 @@ bool sunrise_sunset_face_loop(movement_event_t event, movement_settings_t *setti
             else if (!state->page) movement_illuminate_led();
             break;
         case EVENT_LIGHT_BUTTON_UP:
-            if (state->page == 0) {
+            if (state->page == 0 && _location_count > 1) {
                 state->longLatToUse = (state->longLatToUse + 1) % _location_count;
                 _sunrise_sunset_face_update(settings, state);
             }
@@ -387,7 +387,12 @@ bool sunrise_sunset_face_loop(movement_event_t event, movement_settings_t *setti
             }
             break;
         case EVENT_ALARM_LONG_PRESS:
-            if (state->page == 0 && state->longLatToUse == 0) {
+            if (state->page == 0) {
+            if (state->longLatToUse != 0) {
+                state->longLatToUse = 0;
+                _sunrise_sunset_face_update(settings, state);
+                break;
+            }
                 state->page++;
                 state->active_digit = 0;
                 watch_clear_display();

--- a/movement/watch_faces/complication/sunrise_sunset_face.c
+++ b/movement/watch_faces/complication/sunrise_sunset_face.c
@@ -37,6 +37,8 @@
 #include <emscripten.h>
 #endif
 
+static const uint8_t _location_count = sizeof(longLatPresets) / sizeof(long_lat_presets_t);
+
 static void _sunrise_sunset_set_expiration(sunrise_sunset_state_t *state, watch_date_time next_rise_set) {
     uint32_t timestamp = watch_utility_date_time_to_unix_time(next_rise_set, 0);
     state->rise_set_expires = watch_utility_date_time_from_unix_time(timestamp + 60, 0);
@@ -46,7 +48,13 @@ static void _sunrise_sunset_face_update(movement_settings_t *settings, sunrise_s
     char buf[14];
     double rise, set, minutes, seconds;
     bool show_next_match = false;
-    movement_location_t movement_location = (movement_location_t) watch_get_backup_data(1);
+    movement_location_t movement_location;
+    if (state->longLatToUse == 0)
+        movement_location = (movement_location_t) watch_get_backup_data(1);
+    else{
+        movement_location.bit.latitude = longLatPresets[state->longLatToUse].latitude;
+        movement_location.bit.longitude = longLatPresets[state->longLatToUse].longitude;
+    }
 
     if (movement_location.reg == 0) {
         watch_display_string("RI  no Loc", 0);
@@ -109,7 +117,7 @@ static void _sunrise_sunset_face_update(movement_settings_t *settings, sunrise_s
                     if (watch_utility_convert_to_12_hour(&scratch_time)) watch_set_indicator(WATCH_INDICATOR_PM);
                     else watch_clear_indicator(WATCH_INDICATOR_PM);
                 }
-                sprintf(buf, "rI%2d%2d%02d  ", scratch_time.unit.day, scratch_time.unit.hour, scratch_time.unit.minute);
+                sprintf(buf, "rI%2d%2d%02d%s", scratch_time.unit.day, scratch_time.unit.hour, scratch_time.unit.minute,longLatPresets[state->longLatToUse].name);
                 watch_display_string(buf, 0);
                 return;
             } else {
@@ -136,7 +144,7 @@ static void _sunrise_sunset_face_update(movement_settings_t *settings, sunrise_s
                     if (watch_utility_convert_to_12_hour(&scratch_time)) watch_set_indicator(WATCH_INDICATOR_PM);
                     else watch_clear_indicator(WATCH_INDICATOR_PM);
                 }
-                sprintf(buf, "SE%2d%2d%02d  ", scratch_time.unit.day, scratch_time.unit.hour, scratch_time.unit.minute);
+                sprintf(buf, "SE%2d%2d%02d%s", scratch_time.unit.day, scratch_time.unit.hour, scratch_time.unit.minute, longLatPresets[state->longLatToUse].name);
                 watch_display_string(buf, 0);
                 return;
             } else {
@@ -351,11 +359,21 @@ bool sunrise_sunset_face_loop(movement_event_t event, movement_settings_t *setti
                     _sunrise_sunset_face_update_location_register(state);
                 }
                 _sunrise_sunset_face_update_settings_display(event, context);
-            } else {
+            } else if (_location_count == 1) {
                 movement_illuminate_led();
             }
             if (state->page == 0) {
                 movement_request_tick_frequency(1);
+                _sunrise_sunset_face_update(settings, state);
+            }
+            break;
+        case EVENT_LIGHT_LONG_PRESS:
+            if (_location_count == 1) break;
+            else if (!state->page) movement_illuminate_led();
+            break;
+        case EVENT_LIGHT_BUTTON_UP:
+            if (state->page == 0) {
+                state->longLatToUse = (state->longLatToUse + 1) % _location_count;
                 _sunrise_sunset_face_update(settings, state);
             }
             break;
@@ -369,12 +387,18 @@ bool sunrise_sunset_face_loop(movement_event_t event, movement_settings_t *setti
             }
             break;
         case EVENT_ALARM_LONG_PRESS:
-            if (state->page == 0) {
+            if (state->page == 0 && state->longLatToUse == 0) {
                 state->page++;
                 state->active_digit = 0;
                 watch_clear_display();
                 movement_request_tick_frequency(4);
                 _sunrise_sunset_face_update_settings_display(event, context);
+            }
+            else{
+                state->active_digit = 0;
+                state->page = 0;
+                _sunrise_sunset_face_update_location_register(state);
+                _sunrise_sunset_face_update(settings, state);
             }
             break;
         case EVENT_TIMEOUT:

--- a/movement/watch_faces/complication/sunrise_sunset_face.h
+++ b/movement/watch_faces/complication/sunrise_sunset_face.h
@@ -53,9 +53,9 @@ typedef struct {
     uint8_t active_digit;
     bool location_changed;
     watch_date_time rise_set_expires;
-    uint8_t longLatToUse;
     sunrise_sunset_lat_lon_settings_t working_latitude;
     sunrise_sunset_lat_lon_settings_t working_longitude;
+    uint8_t longLatToUse;
 } sunrise_sunset_state_t;
 
 void sunrise_sunset_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr);

--- a/movement/watch_faces/complication/sunrise_sunset_face.h
+++ b/movement/watch_faces/complication/sunrise_sunset_face.h
@@ -53,6 +53,7 @@ typedef struct {
     uint8_t active_digit;
     bool location_changed;
     watch_date_time rise_set_expires;
+    uint8_t longLatToUse;
     sunrise_sunset_lat_lon_settings_t working_latitude;
     sunrise_sunset_lat_lon_settings_t working_longitude;
 } sunrise_sunset_state_t;
@@ -69,5 +70,19 @@ void sunrise_sunset_face_resign(movement_settings_t *settings, void *context);
     sunrise_sunset_face_resign, \
     NULL, \
 })
+
+typedef struct {
+    char name[2];
+    int16_t latitude;
+    int16_t longitude;
+} long_lat_presets_t;
+
+static const long_lat_presets_t longLatPresets[] =
+{
+    { .name = "  "},  // Default, the long and lat get replaced by what's set in the watch
+//    { .name = "Ny", .latitude = 4072, .longitude = -7401 },  // New York City, NY
+//    { .name = "LA", .latitude = 3405, .longitude = -11824 },  // New York City, NY
+//    { .name = "dE", .latitude = 4221, .longitude = -8305 },  // Detroit, MI
+};
 
 #endif // SUNRISE_SUNSET_FACE_H_

--- a/movement/watch_faces/complication/sunrise_sunset_face.h
+++ b/movement/watch_faces/complication/sunrise_sunset_face.h
@@ -81,7 +81,7 @@ static const long_lat_presets_t longLatPresets[] =
 {
     { .name = "  "},  // Default, the long and lat get replaced by what's set in the watch
 //    { .name = "Ny", .latitude = 4072, .longitude = -7401 },  // New York City, NY
-//    { .name = "LA", .latitude = 3405, .longitude = -11824 },  // New York City, NY
+//    { .name = "LA", .latitude = 3405, .longitude = -11824 },  // Los Angeles, CA
 //    { .name = "dE", .latitude = 4221, .longitude = -8305 },  // Detroit, MI
 };
 


### PR DESCRIPTION
I made it easy to cycle through other hardcoded coordinates in the sunrise senset face by pressing the `light` button.
If no presets are added except for the default, then it behaves exactly the same as it already does.
Adding more presets only will change the LED functionality, where a long-press causes the LED to start and clicking the LED button cycles. Holding the Alarm button when on a preset will default back to the default coordinates screen.

Example of adding other coordinates in my 'sunrise_sunset.h' file:
```
static const long_lat_presets_t longLatPresets[] =
{
    { .name = "  "},  // Default, the long and lat get replaced by what's set in the watch
//    { .name = "Ny", .latitude = 4072, .longitude = -7401 },  // New York City, NY
//    { .name = "LA", .latitude = 3405, .longitude = -11824 },  // Los Angeles, CA
//    { .name = "dE", .latitude = 4221, .longitude = -8305 },  // Detroit, MI
};
```

https://github.com/user-attachments/assets/6673804f-f45a-4989-8bc3-a085ed98d219


