### PR TITLE
add temp input to simulator

### DIFF
--- a/watch-library/shared/driver/thermistor_driver.c
+++ b/watch-library/shared/driver/thermistor_driver.c
@@ -45,7 +45,15 @@ void thermistor_driver_disable(void) {
     // Disable the enable pin's output circuitry.
     watch_disable_digital_output(THERMISTOR_ENABLE_PIN);
 }
-
+#if __EMSCRIPTEN__
+#include <emscripten.h>
+float thermistor_driver_get_temperature(void)
+{
+    return EM_ASM_DOUBLE({
+        return temp_c || 25.0;
+    });
+}
+#else
 float thermistor_driver_get_temperature(void) {
     // set the enable pin to the level that powers the thermistor circuit.
     watch_set_pin_level(THERMISTOR_ENABLE_PIN, THERMISTOR_ENABLE_VALUE);
@@ -56,3 +64,4 @@ float thermistor_driver_get_temperature(void) {
 
     return watch_utility_thermistor_temperature(value, THERMISTOR_HIGH_SIDE, THERMISTOR_B_COEFFICIENT, THERMISTOR_NOMINAL_TEMPERATURE, THERMISTOR_NOMINAL_RESISTANCE, THERMISTOR_SERIES_RESISTANCE);
 }
+#endif

--- a/watch-library/simulator/shell.html
+++ b/watch-library/simulator/shell.html
@@ -905,6 +905,11 @@
     <div>
       <button onclick="getLocation()">Set register (will prompt for access)</button>
     </div>
+    <h2>Temp.</h2>
+    <div>
+      <input type="number" min="-100" max="120" id="temp-c" />C
+      <button onclick="setTemp()">Set</button>
+    </div>
   </div>
 
   <form onSubmit="sendText(); return false" style="display: flex; flex-direction: column; width: 100%">
@@ -962,6 +967,7 @@
   lat = 0;
   lon = 0;
   tx = "";
+  temp_c = 25.0;
   function updateLocation(location) {
     lat = Math.round(location.coords.latitude * 100);
     lon = Math.round(location.coords.longitude * 100);
@@ -1038,10 +1044,25 @@
     document.getElementById(skin).checked = true;
     setSkin(skin);
   }
+
+  function setTemp() {
+    let tempInput = document.getElementById("temp-c");
+    if (!tempInput) {
+      return console.warn("no input found");
+    }
+    if (tempInput.value == "") {
+      return console.warn("no value in input");
+    }
+    
+    try {
+      temp_c = Number.parseFloat(tempInput.value);
+    } catch (e) {
+      return console.warn("input value is not a valid float:", tempInput.value,  e);
+    }
+  }
   loadPrefs();
 </script>
 {{{ SCRIPT }}}
 
 </body>
 </html>
-


### PR DESCRIPTION
This PR adds a new field to the form below the watch simulator for adjusting the temperature reading. I spent a bit of time trying to get a reverse calculation at the `adc` layer working but unfortunately my math skill is not quite up to the task instead this PR adds an alternative implementation of the watch_driver function `thermistor_driver_get_temperature` that just looks up the value stored in `globalThis.temp_c` and a button on the main html page to trigger the update. 