### PR TITLE
Sunrise sunset presets 

### DIFF
--- a/movement/watch_faces/complication/sunrise_sunset_face.c
+++ b/movement/watch_faces/complication/sunrise_sunset_face.c
@@ -49,7 +49,7 @@ static void _sunrise_sunset_face_update(movement_settings_t *settings, sunrise_s
     double rise, set, minutes, seconds;
     bool show_next_match = false;
     movement_location_t movement_location;
-    if (state->longLatToUse == 0)
+    if (state->longLatToUse == 0 || _location_count <= 1)
         movement_location = (movement_location_t) watch_get_backup_data(1);
     else{
         movement_location.bit.latitude = longLatPresets[state->longLatToUse].latitude;

--- a/movement/watch_faces/complication/sunrise_sunset_face.c
+++ b/movement/watch_faces/complication/sunrise_sunset_face.c
@@ -359,7 +359,7 @@ bool sunrise_sunset_face_loop(movement_event_t event, movement_settings_t *setti
                     _sunrise_sunset_face_update_location_register(state);
                 }
                 _sunrise_sunset_face_update_settings_display(event, context);
-            } else if (_location_count == 1) {
+            } else if (_location_count <= 1) {
                 movement_illuminate_led();
             }
             if (state->page == 0) {
@@ -368,7 +368,7 @@ bool sunrise_sunset_face_loop(movement_event_t event, movement_settings_t *setti
             }
             break;
         case EVENT_LIGHT_LONG_PRESS:
-            if (_location_count == 1) break;
+            if (_location_count <= 1) break;
             else if (!state->page) movement_illuminate_led();
             break;
         case EVENT_LIGHT_BUTTON_UP:


### PR DESCRIPTION
This is in response to my PR of  https://github.com/joeycastillo/Sensor-Watch/pull/420.
That PR is fine, but has a warning when building because there's an if/else statement that the compiler doesn't know will never run one of the statements, so it's been made more explicit.

Before the fix:
```
CC build/totp_face.o
CC build/totp_face_lfs.o
CC build/sunrise_sunset_face.o
CC build/countdown_face.o
CC build/sailing_face.o
../watch_faces/complication/pulsometer_face.c: In function 'pulsometer_display_title':
../watch_faces/complication/pulsometer_face.c:61:58: warning: unused parameter 'pulsometer' [-Wunused-parameter]
CC build/counter_face.o
CC build/blinky_face.o
CC build/moon_phase_face.o
CC build/accelerometer_data_acquisition_face.o
CC build/mars_time_face.o
CC build/orrery_face.o
CC build/astronomy_face.o
CC build/tomato_face.o
CC build/probability_face.o
CC build/wake_face.o
../watch_faces/complication/totp_face.c: In function 'totp_face_loop':
../watch_faces/complication/totp_face.c:208:47: warning: comparison of integer expressions of different signedness: 'int' and 'size_t' {aka 'unsigned int'} [-Wsign-compare]
CC build/frequency_correction_face.o
CC build/alarm_face.o
../watch_faces/complication/sunrise_sunset_face.c: In function '_sunrise_sunset_face_update':
../watch_faces/complication/sunrise_sunset_face.c:55:56: warning: array subscript 1 is above array bounds of 'const long_lat_presets_t[1]' {aka 'const struct <anonymous>[1]'} [-Warray-bounds]
In file included from ../watch_faces/complication/sunrise_sunset_face.c:31:
../watch_faces/complication/sunrise_sunset_face.h:80:33: note: while referencing 'longLatPresets'
CC build/ratemeter_face.o
CC build/interval_face.o
```

After the fix:
```
CC build/totp_face.o
CC build/totp_face_lfs.o
CC build/sunrise_sunset_face.o
CC build/countdown_face.o
CC build/sailing_face.o
CC build/counter_face.o
CC build/blinky_face.o
CC build/moon_phase_face.o
CC build/accelerometer_data_acquisition_face.o
CC build/mars_time_face.o
CC build/orrery_face.o
../watch_faces/complication/pulsometer_face.c: In function 'pulsometer_display_title':
../watch_faces/complication/pulsometer_face.c:61:58: warning: unused parameter 'pulsometer' [-Wunused-parameter]
CC build/astronomy_face.o
CC build/tomato_face.o
CC build/probability_face.o
../watch_faces/complication/totp_face.c: In function 'totp_face_loop':
../watch_faces/complication/totp_face.c:208:47: warning: comparison of integer expressions of different signedness: 'int' and 'size_t' {aka 'unsigned int'} [-Wsign-compare]
CC build/wake_face.o
CC build/frequency_correction_face.o
CC build/alarm_face.o
CC build/ratemeter_face.o
CC build/interval_face.o
```