### PR TITLE
Tally Face Changes

### DIFF
--- a/movement/watch_faces/complication/tally_face.c
+++ b/movement/watch_faces/complication/tally_face.c
@@ -105,10 +105,15 @@ static void tally_face_decrement(tally_state_t *state, bool sound_on) {
         }
 }
 
+static bool tally_face_should_move_back(tally_state_t *state) {
+    if (_tally_default_size <= 1) { return false; }
+    return state->tally_idx == _tally_default[state->tally_default_idx];
+}
+
 bool tally_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
     tally_state_t *state = (tally_state_t *)context;
     static bool using_led = false;
-    
+
     if (using_led) {
         if(!watch_get_pin_level(BTN_MODE) && !watch_get_pin_level(BTN_LIGHT) && !watch_get_pin_level(BTN_ALARM))
             using_led = false;
@@ -118,7 +123,7 @@ bool tally_face_loop(movement_event_t event, movement_settings_t *settings, void
             return true;
         }
     }
-    
+
     switch (event.event_type) {
         case EVENT_TICK:
             if (_quick_ticks_running) {
@@ -138,7 +143,7 @@ bool tally_face_loop(movement_event_t event, movement_settings_t *settings, void
             start_quick_cyc();
             break;
         case EVENT_MODE_LONG_PRESS:
-            if (state->tally_idx == _tally_default[state->tally_default_idx]) {
+            if (tally_face_should_move_back(state)) {
                 _init_val = true;
                 movement_move_to_face(0);
             }

--- a/movement/watch_faces/complication/tally_face.c
+++ b/movement/watch_faces/complication/tally_face.c
@@ -48,7 +48,7 @@ static const int16_t _tally_default[] = {
 
 };
 
-static const uint8_t _tally_default_size = sizeof(_tally_default) / sizeof(int16_t);
+#define TALLY_FACE_PRESETS_SIZE() (sizeof(_tally_default) / sizeof(int16_t))
 
 void tally_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {
     (void) settings;
@@ -106,7 +106,7 @@ static void tally_face_decrement(tally_state_t *state, bool sound_on) {
 }
 
 static bool tally_face_should_move_back(tally_state_t *state) {
-    if (_tally_default_size <= 1) { return false; }
+    if (TALLY_FACE_PRESETS_SIZE() <= 1) { return false; }
     return state->tally_idx == _tally_default[state->tally_default_idx];
 }
 
@@ -169,7 +169,7 @@ bool tally_face_loop(movement_event_t event, movement_settings_t *settings, void
             break;
         case EVENT_LIGHT_LONG_PRESS:
             if (_init_val){
-                state->tally_default_idx = (state->tally_default_idx + 1) % _tally_default_size;
+                state->tally_default_idx = (state->tally_default_idx + 1) % TALLY_FACE_PRESETS_SIZE();
                 state->tally_idx = _tally_default[state->tally_default_idx];
                 if (settings->bit.button_should_sound) watch_buzzer_play_note(BUZZER_NOTE_E6, 30);
                 if (settings->bit.button_should_sound) watch_buzzer_play_note(BUZZER_NOTE_REST, 30);

--- a/movement/watch_faces/complication/tally_face.c
+++ b/movement/watch_faces/complication/tally_face.c
@@ -27,44 +27,148 @@
 #include "tally_face.h"
 #include "watch.h"
 
+#define TALLY_FACE_MAX 9999
+#define TALLY_FACE_MIN -99
+
+static bool _init_val;
+static bool _quick_ticks_running;
+static const int16_t _tally_default[] = {0, 40, 20};
+static const uint8_t _tally_default_size = sizeof(_tally_default) / sizeof(int16_t);
+
 void tally_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {
     (void) settings;
     (void) watch_face_index;
     if (*context_ptr == NULL) {
         *context_ptr = malloc(sizeof(tally_state_t));
         memset(*context_ptr, 0, sizeof(tally_state_t));
+        tally_state_t *state = (tally_state_t *)*context_ptr;
+        state->tally_default_idx = 0;
+        state->soundOff = true;
+        state->tally_idx = _tally_default[state->tally_default_idx];
+        _init_val = true;
     }
 }
 
 void tally_face_activate(movement_settings_t *settings, void *context) {
     (void) settings;
     (void) context;
+    _quick_ticks_running = false;
+}
+
+static void start_quick_cyc(void){
+    _quick_ticks_running = true;
+    movement_request_tick_frequency(8);
+}
+
+static void stop_quick_cyc(void){
+    _quick_ticks_running = false;
+    movement_request_tick_frequency(1);
+}
+
+static void tally_face_increment(tally_state_t *state) {
+        bool soundOn = !_quick_ticks_running && !state->soundOff;
+        _init_val = false;
+        if (state->tally_idx >= TALLY_FACE_MAX){
+            if (soundOn) watch_buzzer_play_note(BUZZER_NOTE_E7, 30);
+        }
+        else {
+            state->tally_idx++;
+            print_tally(state);
+            if (soundOn) watch_buzzer_play_note(BUZZER_NOTE_E6, 30);
+        }
+}
+
+static void tally_face_decrement(tally_state_t *state) {
+        bool soundOn = !_quick_ticks_running && !state->soundOff;
+        _init_val = false;
+        if (state->tally_idx <= TALLY_FACE_MIN){
+            if (soundOn) watch_buzzer_play_note(BUZZER_NOTE_C5SHARP_D5FLAT, 30);
+        }
+        else {
+            state->tally_idx--;
+            print_tally(state);
+            if (soundOn) watch_buzzer_play_note(BUZZER_NOTE_C6SHARP_D6FLAT, 30);
+        }
 }
 
 bool tally_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
     (void) settings;
     tally_state_t *state = (tally_state_t *)context;
+    static bool using_led = false;
+    
+    if (using_led) {
+        if(!watch_get_pin_level(BTN_MODE) && !watch_get_pin_level(BTN_LIGHT) && !watch_get_pin_level(BTN_ALARM))
+            using_led = false;
+        else {
+            if (event.event_type == EVENT_LIGHT_BUTTON_DOWN || event.event_type == EVENT_ALARM_BUTTON_DOWN)
+                movement_illuminate_led();
+            return true;
+        }
+    }
     
     switch (event.event_type) {
-        case EVENT_ALARM_BUTTON_UP:
-            // increment tally index
-            state->tally_idx++;
-            if (state->tally_idx > 999999) { //0-999,999
-                //reset tally index and play a reset tune
-                state->tally_idx = 0;
-                watch_buzzer_play_note(BUZZER_NOTE_G6, 30);
-                watch_buzzer_play_note(BUZZER_NOTE_REST, 30);
+        case EVENT_TICK:
+            if (_quick_ticks_running) {
+                bool light_pressed = watch_get_pin_level(BTN_LIGHT);
+                bool alarm_pressed = watch_get_pin_level(BTN_ALARM);
+                if (light_pressed && alarm_pressed) stop_quick_cyc();
+                else if (light_pressed) tally_face_increment(state);
+                else if (alarm_pressed) tally_face_decrement(state);
+                else stop_quick_cyc();
             }
-            print_tally(state);
-            watch_buzzer_play_note(BUZZER_NOTE_E6, 30);
+            break;
+        case EVENT_ALARM_BUTTON_UP:
+            tally_face_decrement(state);
             break;
         case EVENT_ALARM_LONG_PRESS:
-            state->tally_idx = 0; // reset tally index
-            //play a reset tune
-            watch_buzzer_play_note(BUZZER_NOTE_G6, 30);
-            watch_buzzer_play_note(BUZZER_NOTE_REST, 30);
-            watch_buzzer_play_note(BUZZER_NOTE_E6, 30);
-            print_tally(state);
+            if (_init_val) {
+                state->soundOff = !state->soundOff;
+                if (!state->soundOff) watch_buzzer_play_note(BUZZER_NOTE_E6, 30);
+                print_tally(state);
+            }
+            else{
+                tally_face_decrement(state);
+                start_quick_cyc();
+            }
+            break;
+        case EVENT_MODE_LONG_PRESS:
+            if (state->tally_idx == _tally_default[state->tally_default_idx]) {
+                _init_val = true;
+                movement_move_to_face(0);
+            }
+            else {
+                state->tally_idx = _tally_default[state->tally_default_idx]; // reset tally index
+                _init_val = true;
+                //play a reset tune
+                if (!state->soundOff) watch_buzzer_play_note(BUZZER_NOTE_G6, 30);
+                if (!state->soundOff) watch_buzzer_play_note(BUZZER_NOTE_REST, 30);
+                if (!state->soundOff) watch_buzzer_play_note(BUZZER_NOTE_E6, 30);
+                print_tally(state);
+            }
+            break;
+        case EVENT_LIGHT_BUTTON_UP:
+            tally_face_increment(state);
+            break;
+        case EVENT_LIGHT_BUTTON_DOWN:
+        case EVENT_ALARM_BUTTON_DOWN:
+            if (watch_get_pin_level(BTN_MODE)) {
+                movement_illuminate_led();
+                using_led = true;
+            }
+            break;
+        case EVENT_LIGHT_LONG_PRESS:
+            if (_init_val){
+                state->tally_default_idx = (state->tally_default_idx + 1) % _tally_default_size;
+                state->tally_idx = _tally_default[state->tally_default_idx];
+                if (!state->soundOff) watch_buzzer_play_note(BUZZER_NOTE_E6, 30);
+                if (!state->soundOff) watch_buzzer_play_note(BUZZER_NOTE_REST, 30);
+                if (!state->soundOff) watch_buzzer_play_note(BUZZER_NOTE_G6, 30);
+                print_tally(state);
+            }
+            else{
+                tally_face_increment(state);
+                start_quick_cyc();
+            }
             break;
         case EVENT_ACTIVATE:
             print_tally(state);
@@ -83,7 +187,14 @@ bool tally_face_loop(movement_event_t event, movement_settings_t *settings, void
 // print tally index at the center of display.
 void print_tally(tally_state_t *state) {
     char buf[14];
-    sprintf(buf, "TA  %06d", (int)(state->tally_idx)); // center of LCD display
+    if (!state->soundOff)
+        watch_set_indicator(WATCH_INDICATOR_BELL);
+    else
+        watch_clear_indicator(WATCH_INDICATOR_BELL);
+    if (state->tally_idx >= 0)
+        sprintf(buf, "TA  %4d  ", (int)(state->tally_idx)); // center of LCD display
+    else
+        sprintf(buf, "TA     %-3d", (int)(state->tally_idx)); // center of LCD display
     watch_display_string(buf, 0);
 }
 

--- a/movement/watch_faces/complication/tally_face.c
+++ b/movement/watch_faces/complication/tally_face.c
@@ -168,7 +168,7 @@ bool tally_face_loop(movement_event_t event, movement_settings_t *settings, void
             }
             break;
         case EVENT_LIGHT_LONG_PRESS:
-            if (_init_val){
+            if (TALLY_FACE_PRESETS_SIZE() > 1 && _init_val){
                 state->tally_default_idx = (state->tally_default_idx + 1) % TALLY_FACE_PRESETS_SIZE();
                 state->tally_idx = _tally_default[state->tally_default_idx];
                 if (settings->bit.button_should_sound) watch_buzzer_play_note(BUZZER_NOTE_E6, 30);

--- a/movement/watch_faces/complication/tally_face.c
+++ b/movement/watch_faces/complication/tally_face.c
@@ -41,6 +41,11 @@ static const int16_t _tally_default[] = {
     40,
 #endif /* TALLY_FACE_PRESETS_MTG */
 
+#ifdef TALLY_FACE_PRESETS_YUGIOH
+    4000,
+    8000,
+#endif /* TALLY_FACE_PRESETS_YUGIOH */
+
 };
 
 static const uint8_t _tally_default_size = sizeof(_tally_default) / sizeof(int16_t);

--- a/movement/watch_faces/complication/tally_face.c
+++ b/movement/watch_faces/complication/tally_face.c
@@ -32,7 +32,7 @@
 
 static bool _init_val;
 static bool _quick_ticks_running;
-static const int16_t _tally_default[] = {0, 40, 20};
+static const int16_t _tally_default[] = {0, 100, 40, 20, 10};
 static const uint8_t _tally_default_size = sizeof(_tally_default) / sizeof(int16_t);
 
 void tally_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {

--- a/movement/watch_faces/complication/tally_face.c
+++ b/movement/watch_faces/complication/tally_face.c
@@ -32,7 +32,17 @@
 
 static bool _init_val;
 static bool _quick_ticks_running;
-static const int16_t _tally_default[] = {0, 100, 40, 20, 10};
+
+static const int16_t _tally_default[] = {
+    0,
+
+#ifdef TALLY_FACE_PRESETS_MTG
+    20,
+    40,
+#endif /* TALLY_FACE_PRESETS_MTG */
+
+};
+
 static const uint8_t _tally_default_size = sizeof(_tally_default) / sizeof(int16_t);
 
 void tally_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {

--- a/movement/watch_faces/complication/tally_face.h
+++ b/movement/watch_faces/complication/tally_face.h
@@ -29,16 +29,29 @@
  * TALLY face
  *
  * Tally face is designed to act as a tally counter.
- * Based on the counter_face watch face by Shogo Okamoto.
  *
- * To advance the counter, press the ALARM button.
- * To reset, long press the ALARM button.
+ * Alarm
+ *    Press: Decrement
+ *    Hold : On initial value: Toggle Sound
+ *                       Else: Fast Decrement
+ *
+ * Light
+ *    Press: Increment
+ *    Hold : On initial value: Cycles through other initial values.
+ *                       Else: Fast Increment
+ *
+ * Mode
+ *    Press: Next face
+ *    Hold : On initial value: Go to first face.
+ *                       Else: Resets counter
  */
 
 #include "movement.h"
 
 typedef struct {
-    uint32_t tally_idx;
+    int16_t tally_idx;
+    uint8_t tally_default_idx : 7;
+    bool soundOff;
 } tally_state_t;
 
 

--- a/movement/watch_faces/complication/tally_face.h
+++ b/movement/watch_faces/complication/tally_face.h
@@ -32,8 +32,7 @@
  *
  * Alarm
  *    Press: Decrement
- *    Hold : On initial value: Toggle Sound
- *                       Else: Fast Decrement
+ *    Hold : Fast Decrement
  *
  * Light
  *    Press: Increment
@@ -44,14 +43,15 @@
  *    Press: Next face
  *    Hold : On initial value: Go to first face.
  *                       Else: Resets counter
+ * 
+ * Incrementing or Decrementing the tally will beep if Beeping is set in the global Preferences
  */
 
 #include "movement.h"
 
 typedef struct {
     int16_t tally_idx;
-    uint8_t tally_default_idx : 7;
-    bool soundOff;
+    uint8_t tally_default_idx;
 } tally_state_t;
 
 
@@ -60,7 +60,7 @@ void tally_face_activate(movement_settings_t *settings, void *context);
 bool tally_face_loop(movement_event_t event, movement_settings_t *settings, void *context);
 void tally_face_resign(movement_settings_t *settings, void *context);
 
-void print_tally(tally_state_t *state);
+void print_tally(tally_state_t *state, bool sound_on);
 
 #define tally_face ((const watch_face_t){ \
     tally_face_setup, \

--- a/movement/watch_faces/complication/tally_face.h
+++ b/movement/watch_faces/complication/tally_face.h
@@ -54,6 +54,9 @@ typedef struct {
     uint8_t tally_default_idx;
 } tally_state_t;
 
+//#define TALLY_FACE_PRESETS_MTG
+//#define TALLY_FACE_PRESETS_YUGIOH
+
 
 void tally_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr);
 void tally_face_activate(movement_settings_t *settings, void *context);


### PR DESCRIPTION
## Purpose
I play Magic: the Gathering, and being able to use my watch as the life-counter is really convenient. I have modified the default tally face so it can by used nicely as a life-counter. 

## Features Added
* Multiple presets on the starting number that the face resets to.
  * Defaults are 0, 20, and 40, but can easily be changed by modifying `static const int16_t _tally_default`
* Beeping of sound is now linked to the Beep setting in the global prefereneces.
* Ability to display negative numbers.
  * This loses the ability to show numbers above 9,999, but a range of -99 to 9,999 should be good in almost all cases.
* Fast scrolling by holding the increment or decrement button.


## Controls
### Alarm
* **Press:** Decrement
* **Hold :**  Fast Decrement

 ### **Light**
* **Press:** Increment
* **Hold:** 
  * **On initial value:** Cycles through other initial values.
  * **Else:** Fast Increment

### Mode
* **Press:** Next face
* **Hold:** 
  * **On initial value:** Go to first face.
  * **Else:** Resets counter.

## Video
One outdated item in the video is that toggling the sound no longer happens on the watch. It's now linked to the beep in preferences.  

https://github.com/user-attachments/assets/ebe0c72a-4bb3-4848-9c25-152c589a605f

