### PR TITLE
Swapped the bell and alarm icon on the clock face to match Casio's doc

### DIFF
--- a/movement/watch_faces/clock/clock_face.c
+++ b/movement/watch_faces/clock/clock_face.c
@@ -70,11 +70,11 @@ static void clock_indicate(WatchIndicatorSegment indicator, bool on) {
 }
 
 static void clock_indicate_alarm(movement_settings_t *settings) {
-    clock_indicate(WATCH_INDICATOR_BELL, settings->bit.alarm_enabled);
+    clock_indicate(WATCH_INDICATOR_SIGNAL, settings->bit.alarm_enabled);
 }
 
 static void clock_indicate_time_signal(clock_state_t *clock) {
-    clock_indicate(WATCH_INDICATOR_SIGNAL, clock->time_signal_enabled);
+    clock_indicate(WATCH_INDICATOR_BELL, clock->time_signal_enabled);
 }
 
 static void clock_indicate_24h(movement_settings_t *settings) {


### PR DESCRIPTION
The clock face currently has its indicators mismatch the Casio documentation.
This fixes that.

For ref:
https://github.com/joeycastillo/Sensor-Watch/pull/380#issuecomment-2154175451