### PR TITLE
Can Set 29 on Feb on Leap Years Across All Set Faces

### DIFF
--- a/apps/beats-time/app.c
+++ b/apps/beats-time/app.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <math.h>
 #include "watch.h"
+#include "watch_utility.h"
 
 const int8_t UTC_OFFSET = 4; // set to your current UTC offset to see correct beats time
 const uint8_t BEAT_REFRESH_FREQUENCY = 8;
@@ -224,13 +225,10 @@ void set_time_mode_handle_secondary_button(void) {
             break;
         case 5: // day
             date_time.unit.day = date_time.unit.day + 1;
-            // can't set to the 29th on a leap year. if it's february 29, set to 11:59 on the 28th.
-            // and it should roll over.
-            if (date_time.unit.day > days_in_month[date_time.unit.month - 1]) {
-                date_time.unit.day = 1;
-            }
             break;
     }
+    if (date_time.unit.day > days_in_month[date_time.unit.month - 1] + (is_leap(date_time.unit.year) && date_time.unit.month == 2))
+        date_time.unit.day = 1;
     watch_rtc_set_date_time(date_time);
 }
 

--- a/apps/beats-time/app.c
+++ b/apps/beats-time/app.c
@@ -204,7 +204,6 @@ void set_time_mode_handle_primary_button(void) {
 
 void set_time_mode_handle_secondary_button(void) {
     watch_date_time date_time = watch_rtc_get_date_time();
-    const uint8_t days_in_month[12] = {31, 28, 31, 30, 31, 30, 30, 31, 30, 31, 30, 31};
 
     switch (application_state.page) {
         case 0: // hour
@@ -227,7 +226,7 @@ void set_time_mode_handle_secondary_button(void) {
             date_time.unit.day = date_time.unit.day + 1;
             break;
     }
-    if (date_time.unit.day > days_in_month[date_time.unit.month - 1] + (is_leap(date_time.unit.year) && date_time.unit.month == 2))
+    if (date_time.unit.day > days_in_month(date_time.unit.month, date_time.unit.year + WATCH_RTC_REFERENCE_YEAR))
         date_time.unit.day = 1;
     watch_rtc_set_date_time(date_time);
 }

--- a/movement/watch_faces/complication/day_one_face.c
+++ b/movement/watch_faces/complication/day_one_face.c
@@ -27,7 +27,7 @@
 #include "day_one_face.h"
 #include "watch.h"
 
-static const uint8_t days_in_month[12] = {31, 29, 31, 30, 31, 30, 30, 31, 30, 31, 30, 31};
+static const uint8_t days_in_month[12] = {31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 
 static uint32_t _day_one_face_juliandaynum(uint16_t year, uint16_t month, uint16_t day) {
     // from here: https://en.wikipedia.org/wiki/Julian_day#Julian_day_number_calculation

--- a/movement/watch_faces/complication/day_one_face.c
+++ b/movement/watch_faces/complication/day_one_face.c
@@ -28,8 +28,6 @@
 #include "watch.h"
 #include "watch_utility.h"
 
-static const uint8_t days_in_month[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
-
 static uint32_t _day_one_face_juliandaynum(uint16_t year, uint16_t month, uint16_t day) {
     // from here: https://en.wikipedia.org/wiki/Julian_day#Julian_day_number_calculation
     return (1461 * (year + 4800 + (month - 14) / 12)) / 4 + (367 * (month - 2 - 12 * ((month - 14) / 12))) / 12 - (3 * ((year + 4900 + (month - 14) / 12) / 100))/4 + day - 32075;
@@ -71,7 +69,7 @@ static void _day_one_face_increment(day_one_state_t *state) {
         default:
             break;
     }
-    if (state->birth_day == 0 || state->birth_day > (days_in_month[state->birth_month - 1] + (is_leap(state->birth_year) && state->birth_month == 2)))
+    if (state->birth_day == 0 || state->birth_day > days_in_month(state->birth_month, state->birth_year))
         state->birth_day = 1;
 }
 

--- a/movement/watch_faces/complication/day_one_face.c
+++ b/movement/watch_faces/complication/day_one_face.c
@@ -26,8 +26,9 @@
 #include <string.h>
 #include "day_one_face.h"
 #include "watch.h"
+#include "watch_utility.h"
 
-static const uint8_t days_in_month[12] = {31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+static const uint8_t days_in_month[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 
 static uint32_t _day_one_face_juliandaynum(uint16_t year, uint16_t month, uint16_t day) {
     // from here: https://en.wikipedia.org/wiki/Julian_day#Julian_day_number_calculation
@@ -66,13 +67,12 @@ static void _day_one_face_increment(day_one_state_t *state) {
             break;
         case PAGE_DAY:
             state->birth_day = state->birth_day + 1;
-            if (state->birth_day == 0 || state->birth_day > days_in_month[state->birth_month - 1]) {
-                state->birth_day = 1;
-            }
             break;
         default:
             break;
     }
+    if (state->birth_day == 0 || state->birth_day > (days_in_month[state->birth_month - 1] + (is_leap(state->birth_year) && state->birth_month == 2)))
+        state->birth_day = 1;
 }
 
 void day_one_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {

--- a/movement/watch_faces/complication/time_left_face.c
+++ b/movement/watch_faces/complication/time_left_face.c
@@ -158,7 +158,7 @@ static void _draw(time_left_state_t *state, uint8_t subsecond) {
 /// @brief handle short or long pressing the alarm button
 static void _handle_alarm_button(time_left_state_t *state) {
     
-    const uint8_t days_in_month[12] = {31, 28, 31, 30, 31, 30, 30, 31, 30, 31, 30, 31};
+    const uint8_t days_in_month[12] = {31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
     uint32_t tmp_day;
     switch (state->current_page) {
         case TIME_LEFT_FACE_SETTINGS_STATE: // birth year

--- a/movement/watch_faces/complication/time_left_face.c
+++ b/movement/watch_faces/complication/time_left_face.c
@@ -27,6 +27,7 @@
 #include "time_left_face.h"
 #include "watch.h"
 #include "watch_private_display.h"
+#include "watch_utility.h"
 
 const char _state_titles[][3] = {{'D', 'L', ' '}, {'D', 'L', ' '}, {'D', 'A', ' '}, {'D', 'A', ' '}, {'Y', 'R', 'b'}, {'M', 'O', 'b'}, {'D', 'A', 'b'},
                                  {'Y', 'R', 'd'}, {'M', 'O', 'd'}, {'D', 'A', 'd'}};
@@ -158,8 +159,7 @@ static void _draw(time_left_state_t *state, uint8_t subsecond) {
 /// @brief handle short or long pressing the alarm button
 static void _handle_alarm_button(time_left_state_t *state) {
     
-    const uint8_t days_in_month[12] = {31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
-    uint32_t tmp_day;
+    const uint8_t days_in_month[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
     switch (state->current_page) {
         case TIME_LEFT_FACE_SETTINGS_STATE: // birth year
             state->birth_date.bit.year++;
@@ -169,14 +169,7 @@ static void _handle_alarm_button(time_left_state_t *state) {
             state->birth_date.bit.month = (state->birth_date.bit.month % 12) + 1;
             break;
         case TIME_LEFT_FACE_SETTINGS_STATE + 2: // birth day
-            tmp_day = state->birth_date.bit.day;   // use a temporary variable to avoid messing up the months
-            tmp_day++;
-            // handle February 29th on a leap year
-            if (((tmp_day > days_in_month[state->birth_date.bit.month - 1]) && (state->birth_date.bit.month != 2 || (state->birth_date.bit.year % 4) != 0))
-                || (state->birth_date.bit.month == 2 && (state->birth_date.bit.year % 4) == 0 && tmp_day > 29)) {
-                tmp_day = 1;
-            }
-            state->birth_date.bit.day = tmp_day;
+            state->birth_date.bit.day++;
             break;
         case TIME_LEFT_FACE_SETTINGS_STATE + 3: // target year
             state->target_date.bit.year++;
@@ -186,16 +179,13 @@ static void _handle_alarm_button(time_left_state_t *state) {
             state->target_date.bit.month = (state->target_date.bit.month % 12) + 1;
             break;
         case TIME_LEFT_FACE_SETTINGS_STATE + 5: // target day
-            tmp_day = state->target_date.bit.day;
-            tmp_day++;
-            // handle February 29th on a leap year
-            if (((tmp_day > days_in_month[state->target_date.bit.month - 1]) && (state->target_date.bit.month != 2 || (state->target_date.bit.year % 4) != 0))
-                || (state->target_date.bit.month == 2 && (state->target_date.bit.year % 4) == 0 && tmp_day > 29)) {
-                tmp_day = 1;
-            }
-            state->target_date.bit.day = tmp_day;
+            state->target_date.bit.day++;
             break;
     }
+    if (state->birth_date.bit.day > (days_in_month[state->birth_date.bit.month - 1] + (is_leap(state->birth_date.bit.year) && state->birth_date.bit.month == 2)))
+        state->birth_date.bit.day = 1;
+    if (state->target_date.bit.day > (days_in_month[state->target_date.bit.month - 1] + (is_leap(state->target_date.bit.year) && state->target_date.bit.month == 2)))
+        state->target_date.bit.day = 1;
 }
 
 static void _initiate_setting(time_left_state_t *state) {

--- a/movement/watch_faces/complication/time_left_face.c
+++ b/movement/watch_faces/complication/time_left_face.c
@@ -159,7 +159,6 @@ static void _draw(time_left_state_t *state, uint8_t subsecond) {
 /// @brief handle short or long pressing the alarm button
 static void _handle_alarm_button(time_left_state_t *state) {
     
-    const uint8_t days_in_month[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
     switch (state->current_page) {
         case TIME_LEFT_FACE_SETTINGS_STATE: // birth year
             state->birth_date.bit.year++;
@@ -182,9 +181,9 @@ static void _handle_alarm_button(time_left_state_t *state) {
             state->target_date.bit.day++;
             break;
     }
-    if (state->birth_date.bit.day > (days_in_month[state->birth_date.bit.month - 1] + (is_leap(state->birth_date.bit.year) && state->birth_date.bit.month == 2)))
+    if (state->birth_date.bit.day > days_in_month(state->birth_date.bit.month, state->birth_date.bit.year))
         state->birth_date.bit.day = 1;
-    if (state->target_date.bit.day > (days_in_month[state->target_date.bit.month - 1] + (is_leap(state->target_date.bit.year) && state->target_date.bit.month == 2)))
+    if (state->target_date.bit.day > days_in_month(state->target_date.bit.month, state->birth_date.bit.year))
         state->target_date.bit.day = 1;
 }
 

--- a/movement/watch_faces/settings/set_time_face.c
+++ b/movement/watch_faces/settings/set_time_face.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include "set_time_face.h"
 #include "watch.h"
+#include "watch_utility.h"
 
 #define SET_TIME_FACE_NUM_SETTINGS (7)
 const char set_time_face_titles[SET_TIME_FACE_NUM_SETTINGS][3] = {"HR", "M1", "SE", "YR", "MO", "DA", "ZO"};
@@ -33,7 +34,7 @@ static bool _quick_ticks_running;
 
 static void _handle_alarm_button(movement_settings_t *settings, watch_date_time date_time, uint8_t current_page) {
     // handles short or long pressing of the alarm button
-    const uint8_t days_in_month[12] = {31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    const uint8_t days_in_month[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 
     switch (current_page) {
         case 0: // hour
@@ -52,14 +53,7 @@ static void _handle_alarm_button(movement_settings_t *settings, watch_date_time 
             date_time.unit.month = (date_time.unit.month % 12) + 1;
             break;
         case 5: { // day
-            uint32_t tmp_day = date_time.unit.day;   // use a temporary variable to avoid messing up the months
-            tmp_day = tmp_day + 1;
-            // handle February 29th on a leap year
-            if (((tmp_day > days_in_month[date_time.unit.month - 1]) && (date_time.unit.month != 2 || (date_time.unit.year % 4) != 0))
-                || (date_time.unit.month == 2 && (date_time.unit.year % 4) == 0 && tmp_day > 29)) {
-                tmp_day = 1;
-            }
-            date_time.unit.day = tmp_day;
+            date_time.unit.day = date_time.unit.day + 1;
             break;
         }
         case 6: // time zone
@@ -67,6 +61,8 @@ static void _handle_alarm_button(movement_settings_t *settings, watch_date_time 
             if (settings->bit.time_zone > 40) settings->bit.time_zone = 0;
             break;
     }
+    if (date_time.unit.day > (days_in_month[date_time.unit.month - 1] + (is_leap(date_time.unit.year) &&date_time.unit.month == 2)))
+        date_time.unit.day = 1;
     watch_rtc_set_date_time(date_time);
 }
 

--- a/movement/watch_faces/settings/set_time_face.c
+++ b/movement/watch_faces/settings/set_time_face.c
@@ -34,7 +34,6 @@ static bool _quick_ticks_running;
 
 static void _handle_alarm_button(movement_settings_t *settings, watch_date_time date_time, uint8_t current_page) {
     // handles short or long pressing of the alarm button
-    const uint8_t days_in_month[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 
     switch (current_page) {
         case 0: // hour
@@ -61,7 +60,7 @@ static void _handle_alarm_button(movement_settings_t *settings, watch_date_time 
             if (settings->bit.time_zone > 40) settings->bit.time_zone = 0;
             break;
     }
-    if (date_time.unit.day > (days_in_month[date_time.unit.month - 1] + (is_leap(date_time.unit.year) &&date_time.unit.month == 2)))
+    if (date_time.unit.day > days_in_month(date_time.unit.month, date_time.unit.year + WATCH_RTC_REFERENCE_YEAR))
         date_time.unit.day = 1;
     watch_rtc_set_date_time(date_time);
 }

--- a/movement/watch_faces/settings/set_time_face.c
+++ b/movement/watch_faces/settings/set_time_face.c
@@ -33,7 +33,7 @@ static bool _quick_ticks_running;
 
 static void _handle_alarm_button(movement_settings_t *settings, watch_date_time date_time, uint8_t current_page) {
     // handles short or long pressing of the alarm button
-    const uint8_t days_in_month[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    const uint8_t days_in_month[12] = {31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 
     switch (current_page) {
         case 0: // hour

--- a/movement/watch_faces/settings/set_time_hackwatch_face.c
+++ b/movement/watch_faces/settings/set_time_hackwatch_face.c
@@ -48,7 +48,6 @@ void set_time_hackwatch_face_activate(movement_settings_t *settings, void *conte
 
 bool set_time_hackwatch_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
     uint8_t current_page = *((uint8_t *)context);
-    const uint8_t days_in_month[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 
     if (event.subsecond == 15) // Delay displayed time update by ~0.5 seconds, to align phase exactly to main clock at 1Hz
         date_time_settings = watch_rtc_get_date_time();
@@ -121,7 +120,7 @@ bool set_time_hackwatch_face_loop(movement_event_t event, movement_settings_t *s
                 case 5: // day
                     date_time_settings.unit.day = date_time_settings.unit.day - 2;
                     if (date_time_settings.unit.day == 0) {
-                        date_time_settings.unit.day = days_in_month[date_time_settings.unit.month - 1] + (is_leap(date_time_settings.unit.year) && date_time_settings.unit.month == 2);
+                        date_time_settings.unit.day = days_in_month(date_time_settings.unit.month, date_time_settings.unit.year + WATCH_RTC_REFERENCE_YEAR);
                     } else
                         date_time_settings.unit.day++;
                     break;
@@ -172,7 +171,7 @@ bool set_time_hackwatch_face_loop(movement_event_t event, movement_settings_t *s
                     if (settings->bit.time_zone > 40) settings->bit.time_zone = 0;
                     break;
             }
-            if (date_time_settings.unit.day > (days_in_month[date_time_settings.unit.month - 1] + (is_leap(date_time_settings.unit.year) && date_time_settings.unit.month == 2)))
+            if (date_time_settings.unit.day > days_in_month(date_time_settings.unit.month, date_time_settings.unit.year + WATCH_RTC_REFERENCE_YEAR))
                 date_time_settings.unit.day = 1;
             if (current_page != 2) // Do not set time when we are at seconds, it was already set previously
                 watch_rtc_set_date_time(date_time_settings);

--- a/movement/watch_faces/settings/set_time_hackwatch_face.c
+++ b/movement/watch_faces/settings/set_time_hackwatch_face.c
@@ -47,7 +47,7 @@ void set_time_hackwatch_face_activate(movement_settings_t *settings, void *conte
 
 bool set_time_hackwatch_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
     uint8_t current_page = *((uint8_t *)context);
-    const uint8_t days_in_month[12] = {31, 28, 31, 30, 31, 30, 30, 31, 30, 31, 30, 31};
+    const uint8_t days_in_month[12] = {31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 
     if (event.subsecond == 15) // Delay displayed time update by ~0.5 seconds, to align phase exactly to main clock at 1Hz
         date_time_settings = watch_rtc_get_date_time();

--- a/movement/watch_faces/settings/set_time_hackwatch_face.c
+++ b/movement/watch_faces/settings/set_time_hackwatch_face.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include "set_time_hackwatch_face.h"
 #include "watch.h"
+#include "watch_utility.h"
 
 char set_time_hackwatch_face_titles[][3] = {"HR", "M1", "SE", "YR", "MO", "DA", "ZO"};
 #define set_time_hackwatch_face_NUM_SETTINGS (sizeof(set_time_hackwatch_face_titles) / sizeof(*set_time_hackwatch_face_titles))
@@ -47,7 +48,7 @@ void set_time_hackwatch_face_activate(movement_settings_t *settings, void *conte
 
 bool set_time_hackwatch_face_loop(movement_event_t event, movement_settings_t *settings, void *context) {
     uint8_t current_page = *((uint8_t *)context);
-    const uint8_t days_in_month[12] = {31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    const uint8_t days_in_month[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 
     if (event.subsecond == 15) // Delay displayed time update by ~0.5 seconds, to align phase exactly to main clock at 1Hz
         date_time_settings = watch_rtc_get_date_time();
@@ -119,10 +120,8 @@ bool set_time_hackwatch_face_loop(movement_event_t event, movement_settings_t *s
                     break;
                 case 5: // day
                     date_time_settings.unit.day = date_time_settings.unit.day - 2;
-                    // can't set to the 29th on a leap year. if it's february 29, set to 11:59 on the 28th.
-                    // and it should roll over.
                     if (date_time_settings.unit.day == 0) {
-                        date_time_settings.unit.day = days_in_month[date_time_settings.unit.month - 1];
+                        date_time_settings.unit.day = days_in_month[date_time_settings.unit.month - 1] + (is_leap(date_time_settings.unit.year) && date_time_settings.unit.month == 2);
                     } else
                         date_time_settings.unit.day++;
                     break;
@@ -167,17 +166,14 @@ bool set_time_hackwatch_face_loop(movement_event_t event, movement_settings_t *s
                     break;
                 case 5: // day
                     date_time_settings.unit.day = date_time_settings.unit.day + 1;
-                    // can't set to the 29th on a leap year. if it's february 29, set to 11:59 on the 28th.
-                    // and it should roll over.
-                    if (date_time_settings.unit.day > days_in_month[date_time_settings.unit.month - 1]) {
-                        date_time_settings.unit.day = 1;
-                    }
                     break;
                 case 6: // time zone
                     settings->bit.time_zone++;
                     if (settings->bit.time_zone > 40) settings->bit.time_zone = 0;
                     break;
             }
+            if (date_time_settings.unit.day > (days_in_month[date_time_settings.unit.month - 1] + (is_leap(date_time_settings.unit.year) && date_time_settings.unit.month == 2)))
+                date_time_settings.unit.day = 1;
             if (current_page != 2) // Do not set time when we are at seconds, it was already set previously
                 watch_rtc_set_date_time(date_time_settings);
             //TODO: Do not update whole RTC, just what we are changing

--- a/watch-library/shared/watch/watch_utility.c
+++ b/watch-library/shared/watch/watch_utility.c
@@ -315,3 +315,11 @@ uint32_t watch_utility_offset_timestamp(uint32_t now, int8_t hours, int8_t minut
     new += seconds;
     return new;
 }
+
+uint8_t days_in_month(uint8_t month, uint16_t year) {
+    static const uint8_t days_in_month[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    uint8_t days = days_in_month[month - 1];
+    if (month == 2 && is_leap(year))
+        days += 1;
+    return days;
+}

--- a/watch-library/shared/watch/watch_utility.h
+++ b/watch-library/shared/watch/watch_utility.h
@@ -164,4 +164,10 @@ float watch_utility_thermistor_temperature(uint16_t value, bool highside, float 
  */
 uint32_t watch_utility_offset_timestamp(uint32_t now, int8_t hours, int8_t minutes, int8_t seconds);
 
+/** @brief Returns the number of days in a month. It also handles Leap Years for February.
+ * @param month The month of the date (1-12)
+ * @param year The year of the date (ex. 2022)
+ */
+uint8_t days_in_month(uint8_t month, uint16_t year);
+
 #endif


### PR DESCRIPTION
Some of the watches have a message like this:
 > can't set to the 29th on a leap year. if it's february 29, set to 11:59 on the 28th.

This also changed July to having 31 days, rather than 30.
This change is a simple fix across all of those watches to allow Feb 29 to be set, but only on Leap Years.