### PR TITLE
world_clock2_face.c bug fix

### DIFF
--- a/movement/watch_faces/clock/world_clock2_face.c
+++ b/movement/watch_faces/clock/world_clock2_face.c
@@ -249,7 +249,6 @@ static bool mode_display(movement_event_t event, movement_settings_t *settings, 
 	    /* Switch to settings mode */
 	    state->current_mode = WORLD_CLOCK2_MODE_SETTINGS;
 	    refresh_face = true;
-            movement_request_tick_frequency(1);
 
             if (settings->bit.button_should_sound)
                 watch_buzzer_play_note(BUZZER_NOTE_C8, 50);


### PR DESCRIPTION
Deleting this line removes an erroneous `movement_request_tick_frequency(1)` that prevents the `WORLD_CLOCK2_MODE_SETTINGS` `case` from keeping the tick frequency at `4` while setting the time zones. This allows the user to select their desired time zone with the intended smoothness gained with the higher tick frequency that is set on line 154