### PR TITLE
Debounce Logic

### DIFF
--- a/movement/movement.c
+++ b/movement/movement.c
@@ -23,8 +23,8 @@
  */
 
 #define MOVEMENT_LONG_PRESS_TICKS 64
-#define DEBOUNCE_TICKS_DOWN 2  // In terms of *7.8125ms
-#define DEBOUNCE_TICKS_UP   2  // In terms of *7.8125ms
+#define DEBOUNCE_TICKS_DOWN 0  // In terms of *7.8125ms
+#define DEBOUNCE_TICKS_UP   0  // In terms of *7.8125ms
 
 #include <stdio.h>
 #include <string.h>

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -668,21 +668,19 @@ static void debounce_btn_press(uint8_t pin, uint8_t *debounce_ticks, uint16_t *d
     }
     else
         *down_timestamp = 0;
+    _movement_enable_fast_tick_if_needed();
 }
 
 void cb_light_btn_interrupt(void) {
     debounce_btn_press(BTN_LIGHT, &movement_state.debounce_ticks_light, &movement_state.light_down_timestamp, light_btn_action);
-    _movement_enable_fast_tick_if_needed();
 }
 
 void cb_mode_btn_interrupt(void) {
     debounce_btn_press(BTN_MODE, &movement_state.debounce_ticks_mode, &movement_state.mode_down_timestamp, mode_btn_action);
-    _movement_enable_fast_tick_if_needed();
 }
 
 void cb_alarm_btn_interrupt(void) {
     debounce_btn_press(BTN_ALARM, &movement_state.debounce_ticks_alarm, &movement_state.alarm_down_timestamp, alarm_btn_action);
-    _movement_enable_fast_tick_if_needed();
 }
 
 void cb_alarm_btn_extwake(void) {
@@ -695,9 +693,9 @@ void cb_alarm_fired(void) {
 }
 
 void cb_fast_tick(void) {
-    if (movement_state.debounce_ticks_light > 0){{if (--movement_state.debounce_ticks_light == 0) {_movement_disable_fast_tick_if_possible();}}}
-    if (movement_state.debounce_ticks_alarm > 0){{if (--movement_state.debounce_ticks_alarm == 0) {_movement_disable_fast_tick_if_possible();}}}
-    if (movement_state.debounce_ticks_mode > 0){{if (--movement_state.debounce_ticks_mode == 0) {_movement_disable_fast_tick_if_possible();}}}
+    if (movement_state.debounce_ticks_light > 0 && --movement_state.debounce_ticks_light == 0) _movement_disable_fast_tick_if_possible();
+    if (movement_state.debounce_ticks_alarm > 0 && --movement_state.debounce_ticks_alarm == 0) _movement_disable_fast_tick_if_possible();
+    if (movement_state.debounce_ticks_mode > 0 && --movement_state.debounce_ticks_mode == 0) _movement_disable_fast_tick_if_possible();
     if (movement_state.debounce_ticks_light + movement_state.debounce_ticks_mode + movement_state.debounce_ticks_alarm  == 0)
         movement_state.fast_ticks++;
     if (movement_state.light_ticks > 0) movement_state.light_ticks--;

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -661,14 +661,14 @@ static void alarm_btn_action(bool pin_level) {
 }
 
 static void debounce_btn_press(uint8_t pin, uint8_t *debounce_ticks, uint16_t *down_timestamp, void (*function)(bool)) {
-    if (*debounce_ticks <= 1) {
+    if (*debounce_ticks == 0) {
         bool pin_level = watch_get_pin_level(pin);
         function(pin_level);
         *debounce_ticks = pin_level ? DEBOUNCE_TICKS_DOWN : DEBOUNCE_TICKS_UP;
+        if (*debounce_ticks != 0) _movement_enable_fast_tick_if_needed();
     }
     else
         *down_timestamp = 0;
-    _movement_enable_fast_tick_if_needed();
 }
 
 void cb_light_btn_interrupt(void) {

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -99,8 +99,6 @@
 #include <emscripten.h>
 #endif
 
-#define DEBOUNCE_TICKS 2  // In terms of *7.8125ms
-
 movement_state_t movement_state;
 void * watch_face_contexts[MOVEMENT_NUM_FACES];
 watch_date_time scheduled_tasks[MOVEMENT_NUM_FACES];
@@ -171,9 +169,6 @@ static inline void _movement_reset_inactivity_countdown(void) {
 static inline void _movement_enable_fast_tick_if_needed(void) {
     if (!movement_state.fast_tick_enabled) {
         movement_state.fast_ticks = 0;
-        movement_state.debounce_ticks_light = 0;
-        movement_state.debounce_ticks_alarm = 0;
-        movement_state.debounce_ticks_mode = 0;
         watch_rtc_register_periodic_callback(cb_fast_tick, 128);
         movement_state.fast_tick_enabled = true;
     }
@@ -186,6 +181,16 @@ static inline void _movement_disable_fast_tick_if_possible(void) {
         movement_state.fast_tick_enabled = false;
         watch_rtc_disable_periodic_callback(128);
     }
+}
+
+static void cb_debounce(void) {
+    movement_state.debounce_occurring = false;
+    watch_rtc_disable_periodic_callback(64);  // 64 HZ is 15.625ms
+}
+
+static inline void _movement_enable_debounce_tick(void) {
+    movement_state.debounce_occurring = true;
+    watch_rtc_register_periodic_callback(cb_debounce, 64);
 }
 
 static void _movement_handle_background_tasks(void) {
@@ -228,15 +233,15 @@ static void _movement_handle_scheduled_tasks(void) {
 }
 
 void movement_request_tick_frequency(uint8_t freq) {
-    // Movement uses the 128 Hz tick internally
-    if (freq == 128) return;
+    // Movement uses the 128 Hz tick internally; 64 is th edebounce frequency
+    if (freq == 128 || freq == 64 ) return;
 
     // Movement requires at least a 1 Hz tick.
     // If we are asked for an invalid frequency, default back to 1 Hz.
     if (freq == 0 || __builtin_popcount(freq) != 1) freq = 1;
 
     // disable all callbacks except the 128 Hz one
-    watch_rtc_disable_matching_periodic_callbacks(0xFE);
+    watch_rtc_disable_matching_periodic_callbacks(0xFC);
 
     movement_state.subsecond = 0;
     movement_state.tick_frequency = freq;
@@ -620,6 +625,8 @@ bool app_loop(void) {
 static movement_event_type_t _figure_out_button_event(bool pin_level, movement_event_type_t button_down_event_type, uint16_t *down_timestamp) {
     // force alarm off if the user pressed a button.
     if (movement_state.alarm_ticks) movement_state.alarm_ticks = 0;
+    if ( movement_state.debounce_occurring)
+        return EVENT_NONE;
 
     if (pin_level) {
         // handle rising edge
@@ -634,49 +641,36 @@ static movement_event_type_t _figure_out_button_event(bool pin_level, movement_e
         uint16_t diff = movement_state.fast_ticks - *down_timestamp;
         *down_timestamp = 0;
         _movement_disable_fast_tick_if_possible();
+        _movement_enable_debounce_tick();
         // any press over a half second is considered a long press. Fire the long-up event
         if (diff > MOVEMENT_LONG_PRESS_TICKS) return button_down_event_type + 3;
         else return button_down_event_type + 1;
     }
 }
 
-static void light_btn_action(void) {
+void cb_light_btn_interrupt(void) {
     bool pin_level = watch_get_pin_level(BTN_LIGHT);
     _movement_reset_inactivity_countdown();
     event.event_type = _figure_out_button_event(pin_level, EVENT_LIGHT_BUTTON_DOWN, &movement_state.light_down_timestamp);
 }
 
-static void mode_btn_action(void) { 
+void cb_mode_btn_interrupt(void) {
     bool pin_level = watch_get_pin_level(BTN_MODE);
     _movement_reset_inactivity_countdown();
     event.event_type = _figure_out_button_event(pin_level, EVENT_MODE_BUTTON_DOWN, &movement_state.mode_down_timestamp);
 }
 
-static void alarm_btn_action(void) {
+void cb_alarm_btn_interrupt(void) {
     bool pin_level = watch_get_pin_level(BTN_ALARM);
     _movement_reset_inactivity_countdown();
     uint8_t event_type = _figure_out_button_event(pin_level, EVENT_ALARM_BUTTON_DOWN, &movement_state.alarm_down_timestamp);
     if  (movement_state.ignore_alarm_btn_after_sleep){
-        if (event_type == EVENT_ALARM_BUTTON_UP || event_type == EVENT_ALARM_LONG_UP) movement_state.ignore_alarm_btn_after_sleep = false;
+        if (event_type == EVENT_ALARM_BUTTON_UP) movement_state.ignore_alarm_btn_after_sleep = false;
         return;
     }
     event.event_type = event_type;
 }
 
-void cb_light_btn_interrupt(void) {
-    movement_state.debounce_btn_trig_light = true;
-    _movement_enable_fast_tick_if_needed();
-}
-
-void cb_mode_btn_interrupt(void) {
-    movement_state.debounce_btn_trig_mode = true;
-    _movement_enable_fast_tick_if_needed();
-}
-
-void cb_alarm_btn_interrupt(void) {
-    movement_state.debounce_btn_trig_alarm = true;
-    _movement_enable_fast_tick_if_needed();
-}
 
 void cb_alarm_btn_extwake(void) {
     // wake up!
@@ -688,59 +682,23 @@ void cb_alarm_fired(void) {
 }
 
 void cb_fast_tick(void) {
-    // printf("%d \r\n", movement_state.fast_ticks);
-    if (movement_state.debounce_ticks_light > 0) movement_state.debounce_ticks_light--;
-    if (movement_state.debounce_ticks_alarm > 0) movement_state.debounce_ticks_alarm--;
-    if (movement_state.debounce_ticks_mode > 0) movement_state.debounce_ticks_mode--;
-    if (movement_state.debounce_btn_trig_light) {
-        movement_state.debounce_btn_trig_light = false;
-        if (movement_state.debounce_ticks_light == 0) {
-            light_btn_action();
-            movement_state.debounce_ticks_light = DEBOUNCE_TICKS;
-        }
-        else {
-            movement_state.light_down_timestamp = 0;
-            _movement_disable_fast_tick_if_possible();
-        }
+    movement_state.fast_ticks++;
+    if (!movement_state.debounce_occurring) {
+        if (movement_state.light_ticks > 0) movement_state.light_ticks--;
+        if (movement_state.alarm_ticks > 0) movement_state.alarm_ticks--;
+        // check timestamps and auto-fire the long-press events
+        // Notice: is it possible that two or more buttons have an identical timestamp? In this case
+        // only one of these buttons would receive the long press event. Don't bother for now...
+        if (movement_state.light_down_timestamp > 0)
+            if (movement_state.fast_ticks - movement_state.light_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
+                event.event_type = EVENT_LIGHT_LONG_PRESS;
+        if (movement_state.mode_down_timestamp > 0)
+            if (movement_state.fast_ticks - movement_state.mode_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
+                event.event_type = EVENT_MODE_LONG_PRESS;
+        if (movement_state.alarm_down_timestamp > 0)
+            if (movement_state.fast_ticks - movement_state.alarm_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
+                event.event_type = EVENT_ALARM_LONG_PRESS;
     }
-    if (movement_state.debounce_btn_trig_alarm) {
-        movement_state.debounce_btn_trig_alarm = false;
-        if (movement_state.debounce_ticks_alarm == 0) {
-            alarm_btn_action();
-            movement_state.debounce_ticks_alarm = DEBOUNCE_TICKS;
-        }
-        else {
-            movement_state.alarm_down_timestamp = 0;
-            _movement_disable_fast_tick_if_possible();
-        }
-    }
-    if (movement_state.debounce_btn_trig_mode) {
-        movement_state.debounce_btn_trig_mode = false;
-        if (movement_state.debounce_ticks_mode == 0) {
-            mode_btn_action();
-            movement_state.debounce_ticks_mode = DEBOUNCE_TICKS;
-        }
-        else {
-            movement_state.mode_down_timestamp = 0;
-            _movement_disable_fast_tick_if_possible();
-        }
-    }
-    if (movement_state.debounce_ticks_light + movement_state.debounce_ticks_mode + movement_state.debounce_ticks_alarm  == 0)
-        movement_state.fast_ticks++;
-    if (movement_state.light_ticks > 0) movement_state.light_ticks--;
-    if (movement_state.alarm_ticks > 0) movement_state.alarm_ticks--;
-    // check timestamps and auto-fire the long-press events
-    // Notice: is it possible that two or more buttons have an identical timestamp? In this case
-    // only one of these buttons would receive the long press event. Don't bother for now...
-    if (movement_state.light_down_timestamp > 0)
-        if (movement_state.fast_ticks - movement_state.light_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
-            event.event_type = EVENT_LIGHT_LONG_PRESS;
-    if (movement_state.mode_down_timestamp > 0)
-        if (movement_state.fast_ticks - movement_state.mode_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
-            event.event_type = EVENT_MODE_LONG_PRESS;
-    if (movement_state.alarm_down_timestamp > 0)
-        if (movement_state.fast_ticks - movement_state.alarm_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
-            event.event_type = EVENT_ALARM_LONG_PRESS;
     // this is just a fail-safe; fast tick should be disabled as soon as the button is up, the LED times out, and/or the alarm finishes.
     // but if for whatever reason it isn't, this forces the fast tick off after 20 seconds.
     if (movement_state.fast_ticks >= 128 * 20) {

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -23,8 +23,16 @@
  */
 
 #define MOVEMENT_LONG_PRESS_TICKS 64
-#define DEBOUNCE_TICKS_DOWN 0  // In terms of *7.8125ms
-#define DEBOUNCE_TICKS_UP   0  // In terms of *7.8125ms
+#define DEBOUNCE_TICKS_DOWN 0
+#define DEBOUNCE_TICKS_UP   0
+/*
+DEBOUNCE_TICKS_DOWN and DEBOUNCE_TICKS_UP are in terms of fast_cb ticks after a button is pressed.
+The logic is that pressed of a button are ignored until the cb_fast_tick function runs this variable amount of times.
+Without modifying the code, the cb_fast_tick frequency is 128Hz, or 7.8125ms.
+It is not suggested to set this value to one for debouncing, as the callback occurs asynchronously of the button's press,
+meaning that if a button was pressed and 7ms passed since th elast time cb_fast_tick was called, then there will be only 812.5us
+of debounce time.
+*/
 
 #include <stdio.h>
 #include <string.h>
@@ -640,19 +648,21 @@ static movement_event_type_t _figure_out_button_event(bool pin_level, movement_e
     }
 }
 
-static void light_btn_action(bool pin_level) {
-    _movement_reset_inactivity_countdown();
-    event.event_type = _figure_out_button_event(pin_level, EVENT_LIGHT_BUTTON_DOWN, &movement_state.light_down_timestamp);
+static movement_event_type_t btn_action(bool pin_level, int code, uint16_t *timestamp) {
+    _movement_reset_inactivity_countdown(); 
+    return _figure_out_button_event(pin_level, code, timestamp);
 }
 
-static void mode_btn_action(bool pin_level) { 
-    _movement_reset_inactivity_countdown();
-    event.event_type = _figure_out_button_event(pin_level, EVENT_MODE_BUTTON_DOWN, &movement_state.mode_down_timestamp);
+static void light_btn_action(bool pin_level) {
+    event.event_type = btn_action(pin_level, EVENT_LIGHT_BUTTON_DOWN, &movement_state.light_down_timestamp);
+}
+
+static void mode_btn_action(bool pin_level) {
+    event.event_type = btn_action(pin_level, EVENT_MODE_BUTTON_DOWN, &movement_state.mode_down_timestamp);
 }
 
 static void alarm_btn_action(bool pin_level) {
-    _movement_reset_inactivity_countdown();
-    uint8_t event_type = _figure_out_button_event(pin_level, EVENT_ALARM_BUTTON_DOWN, &movement_state.alarm_down_timestamp);
+    uint8_t event_type = btn_action(pin_level, EVENT_ALARM_BUTTON_DOWN, &movement_state.alarm_down_timestamp);
     if  (movement_state.ignore_alarm_btn_after_sleep){
         if (event_type == EVENT_ALARM_BUTTON_UP || event_type == EVENT_ALARM_LONG_UP) movement_state.ignore_alarm_btn_after_sleep = false;
         return;
@@ -669,6 +679,12 @@ static void debounce_btn_press(uint8_t pin, uint8_t *debounce_ticks, uint16_t *d
     }
     else
         *down_timestamp = 0;
+}
+
+static void movement_disable_if_debounce_complete(void) {
+    if (movement_state.debounce_ticks_light > 0 && --movement_state.debounce_ticks_light == 0) _movement_disable_fast_tick_if_possible();
+    if (movement_state.debounce_ticks_alarm > 0 && --movement_state.debounce_ticks_alarm == 0) _movement_disable_fast_tick_if_possible();
+    if (movement_state.debounce_ticks_mode > 0 && --movement_state.debounce_ticks_mode == 0) _movement_disable_fast_tick_if_possible();
 }
 
 void cb_light_btn_interrupt(void) {
@@ -693,9 +709,7 @@ void cb_alarm_fired(void) {
 }
 
 void cb_fast_tick(void) {
-    if (movement_state.debounce_ticks_light > 0 && --movement_state.debounce_ticks_light == 0) _movement_disable_fast_tick_if_possible();
-    if (movement_state.debounce_ticks_alarm > 0 && --movement_state.debounce_ticks_alarm == 0) _movement_disable_fast_tick_if_possible();
-    if (movement_state.debounce_ticks_mode > 0 && --movement_state.debounce_ticks_mode == 0) _movement_disable_fast_tick_if_possible();
+    movement_disable_if_debounce_complete();
     if (movement_state.debounce_ticks_light + movement_state.debounce_ticks_mode + movement_state.debounce_ticks_alarm  == 0)
         movement_state.fast_ticks++;
     if (movement_state.light_ticks > 0) movement_state.light_ticks--;

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -23,7 +23,8 @@
  */
 
 #define MOVEMENT_LONG_PRESS_TICKS 64
-#define DEBOUNCE_TICKS 1  // In terms of *7.8125ms
+#define DEBOUNCE_TICKS_DOWN 2  // In terms of *7.8125ms
+#define DEBOUNCE_TICKS_UP   2  // In terms of *7.8125ms
 
 #include <stdio.h>
 #include <string.h>
@@ -170,6 +171,9 @@ static inline void _movement_reset_inactivity_countdown(void) {
 static inline void _movement_enable_fast_tick_if_needed(void) {
     if (!movement_state.fast_tick_enabled) {
         movement_state.fast_ticks = 0;
+        movement_state.debounce_ticks_light = 0;
+        movement_state.debounce_ticks_alarm = 0;
+        movement_state.debounce_ticks_mode = 0;
         watch_rtc_register_periodic_callback(cb_fast_tick, 128);
         movement_state.fast_tick_enabled = true;
     }
@@ -388,9 +392,6 @@ void app_init(void) {
     movement_state.settings.bit.led_duration = MOVEMENT_DEFAULT_LED_DURATION;
     movement_state.light_ticks = -1;
     movement_state.alarm_ticks = -1;
-    movement_state.debounce_ticks_light = 0;
-    movement_state.debounce_ticks_alarm = 0;
-    movement_state.debounce_ticks_mode = 0;
     movement_state.next_available_backup_register = 4;
     _movement_reset_inactivity_countdown();
 
@@ -633,29 +634,25 @@ static movement_event_type_t _figure_out_button_event(bool pin_level, movement_e
         // now that that's out of the way, handle falling edge
         uint16_t diff = movement_state.fast_ticks - *down_timestamp;
         *down_timestamp = 0;
-        _movement_disable_fast_tick_if_possible();
         // any press over a half second is considered a long press. Fire the long-up event
         if (diff > MOVEMENT_LONG_PRESS_TICKS) return button_down_event_type + 3;
         else return button_down_event_type + 1;
     }
 }
 
-static void light_btn_action(void) {
-    bool pin_level = watch_get_pin_level(BTN_LIGHT);
+static void light_btn_action(bool pin_level) {
     _movement_reset_inactivity_countdown();
     event.event_type = _figure_out_button_event(pin_level, EVENT_LIGHT_BUTTON_DOWN, &movement_state.light_down_timestamp);
 }
 
-static void mode_btn_action(void) {
-    bool pin_level = watch_get_pin_level(BTN_MODE);
+static void mode_btn_action(bool pin_level) { 
     _movement_reset_inactivity_countdown();
     event.event_type = _figure_out_button_event(pin_level, EVENT_MODE_BUTTON_DOWN, &movement_state.mode_down_timestamp);
 }
 
-static void alarm_btn_action(void) {
-    bool pin_level = watch_get_pin_level(BTN_ALARM);
-    uint8_t event_type = _figure_out_button_event(pin_level, EVENT_ALARM_BUTTON_DOWN, &movement_state.alarm_down_timestamp);
+static void alarm_btn_action(bool pin_level) {
     _movement_reset_inactivity_countdown();
+    uint8_t event_type = _figure_out_button_event(pin_level, EVENT_ALARM_BUTTON_DOWN, &movement_state.alarm_down_timestamp);
     if  (movement_state.ignore_alarm_btn_after_sleep){
         if (event_type == EVENT_ALARM_BUTTON_UP || event_type == EVENT_ALARM_LONG_UP) movement_state.ignore_alarm_btn_after_sleep = false;
         return;
@@ -663,19 +660,27 @@ static void alarm_btn_action(void) {
     event.event_type = event_type;
 }
 
-void cb_light_btn_interrupt(void) {
-    movement_state.debounce_ticks_light = DEBOUNCE_TICKS;
+static void debounce_btn_press(uint8_t pin, uint8_t *debounce_ticks, uint16_t *down_timestamp, void (*function)(bool)) {
+    if (*debounce_ticks <= 1) {
+        bool pin_level = watch_get_pin_level(pin);
+        function(pin_level);
+        *debounce_ticks = pin_level ? DEBOUNCE_TICKS_DOWN : DEBOUNCE_TICKS_UP;
+    }
+    else
+        *down_timestamp = 0;
     _movement_enable_fast_tick_if_needed();
+}
+
+void cb_light_btn_interrupt(void) {
+    debounce_btn_press(BTN_LIGHT, &movement_state.debounce_ticks_light, &movement_state.light_down_timestamp, light_btn_action);
 }
 
 void cb_mode_btn_interrupt(void) {
-    movement_state.debounce_ticks_mode = DEBOUNCE_TICKS;
-    _movement_enable_fast_tick_if_needed();
+    debounce_btn_press(BTN_MODE, &movement_state.debounce_ticks_mode, &movement_state.mode_down_timestamp, mode_btn_action);
 }
 
 void cb_alarm_btn_interrupt(void) {
-    movement_state.debounce_ticks_alarm = DEBOUNCE_TICKS;
-    _movement_enable_fast_tick_if_needed();
+    debounce_btn_press(BTN_ALARM, &movement_state.debounce_ticks_alarm, &movement_state.alarm_down_timestamp, alarm_btn_action);
 }
 
 void cb_alarm_btn_extwake(void) {
@@ -688,12 +693,9 @@ void cb_alarm_fired(void) {
 }
 
 void cb_fast_tick(void) {
-    if (movement_state.debounce_ticks_light > 0 && --movement_state.debounce_ticks_light == 0)
-        light_btn_action();
-    if (movement_state.debounce_ticks_alarm > 0 && --movement_state.debounce_ticks_alarm == 0)
-        alarm_btn_action();
-    if (movement_state.debounce_ticks_mode > 0 && --movement_state.debounce_ticks_mode == 0)
-        mode_btn_action();
+    if (movement_state.debounce_ticks_light > 0 && --movement_state.debounce_ticks_light == 0) _movement_disable_fast_tick_if_possible();
+    if (movement_state.debounce_ticks_alarm > 0 && --movement_state.debounce_ticks_alarm == 0) _movement_disable_fast_tick_if_possible();
+    if (movement_state.debounce_ticks_mode > 0 && --movement_state.debounce_ticks_mode == 0) _movement_disable_fast_tick_if_possible();
     if (movement_state.debounce_ticks_light + movement_state.debounce_ticks_mode + movement_state.debounce_ticks_alarm  == 0)
         movement_state.fast_ticks++;
     if (movement_state.light_ticks > 0) movement_state.light_ticks--;

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -222,28 +222,16 @@ static void _movement_handle_scheduled_tasks(void) {
     }
 }
 
-static uint8_t swap_endian(uint8_t num) {
-    uint8_t result = 0;
-    int i;
-    for (i = 0; i < 8; i++) {
-        result <<= 1;
-        result |= (num & 1);
-        num >>= 1;
-    }
-    return result;
-}
-
 void movement_request_tick_frequency(uint8_t freq) {
     // Movement uses the 128 Hz tick internally
-    if (freq == 128 || freq == DEBOUNCE_FREQ ) return;
+    if (freq == 128) return;
 
     // Movement requires at least a 1 Hz tick.
     // If we are asked for an invalid frequency, default back to 1 Hz.
     if (freq == 0 || __builtin_popcount(freq) != 1) freq = 1;
 
     // disable all callbacks except the 128 Hz one
-    int disable_mask = 0xFE ^ swap_endian(DEBOUNCE_FREQ);
-    watch_rtc_disable_matching_periodic_callbacks(disable_mask);
+    watch_rtc_disable_matching_periodic_callbacks(0xFE);
 
     movement_state.subsecond = 0;
     movement_state.tick_frequency = freq;

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -183,17 +183,6 @@ static inline void _movement_disable_fast_tick_if_possible(void) {
     }
 }
 
-#define DEBOUNCE_FREQ 64 // 64 HZ is 15.625ms
-static void cb_debounce(void) {
-    movement_state.debounce_occurring = false;
-    watch_rtc_disable_periodic_callback(DEBOUNCE_FREQ);
-}
-
-static inline void _movement_enable_debounce_tick(void) {
-    movement_state.debounce_occurring = true;
-    watch_rtc_register_periodic_callback(cb_debounce, DEBOUNCE_FREQ);
-}
-
 static void _movement_handle_background_tasks(void) {
     for(uint8_t i = 0; i < MOVEMENT_NUM_FACES; i++) {
         // For each face, if the watch face wants a background task...
@@ -409,6 +398,9 @@ void app_init(void) {
     movement_state.settings.bit.led_duration = MOVEMENT_DEFAULT_LED_DURATION;
     movement_state.light_ticks = -1;
     movement_state.alarm_ticks = -1;
+    movement_state.debounce_ticks_light = -1;
+    movement_state.debounce_ticks_alarm = -1;
+    movement_state.debounce_ticks_mode = -1;
     movement_state.next_available_backup_register = 4;
     _movement_reset_inactivity_countdown();
 
@@ -485,12 +477,12 @@ void app_wake_from_standby(void) {
 
 static void _sleep_mode_app_loop(void) {
     movement_state.needs_wake = false;
+    movement_state.ignore_alarm_btn_after_sleep = true;
     // as long as le_mode_ticks is -1 (i.e. we are in low energy mode), we wake up here, update the screen, and go right back to sleep.
     while (movement_state.le_mode_ticks == -1) {
         // we also have to handle background tasks here in the mini-runloop
         if (movement_state.needs_background_tasks_handled) _movement_handle_background_tasks();
 
-        movement_state.ignore_alarm_after_sleep = true;
         event.event_type = EVENT_LOW_ENERGY_UPDATE;
         watch_faces[movement_state.current_face_idx].loop(event, &movement_state.settings, watch_face_contexts[movement_state.current_face_idx]);
 
@@ -638,8 +630,6 @@ bool app_loop(void) {
 static movement_event_type_t _figure_out_button_event(bool pin_level, movement_event_type_t button_down_event_type, uint16_t *down_timestamp) {
     // force alarm off if the user pressed a button.
     if (movement_state.alarm_ticks) movement_state.alarm_ticks = 0;
-    if ( movement_state.debounce_occurring)
-        return EVENT_NONE;
 
     if (pin_level) {
         // handle rising edge
@@ -654,36 +644,49 @@ static movement_event_type_t _figure_out_button_event(bool pin_level, movement_e
         uint16_t diff = movement_state.fast_ticks - *down_timestamp;
         *down_timestamp = 0;
         _movement_disable_fast_tick_if_possible();
-        _movement_enable_debounce_tick();
         // any press over a half second is considered a long press. Fire the long-up event
         if (diff > MOVEMENT_LONG_PRESS_TICKS) return button_down_event_type + 3;
         else return button_down_event_type + 1;
     }
 }
 
-void cb_light_btn_interrupt(void) {
-    bool pin_level = watch_get_pin_level(BTN_LIGHT);
+static void light_btn_action(bool pin_level) {
     _movement_reset_inactivity_countdown();
     event.event_type = _figure_out_button_event(pin_level, EVENT_LIGHT_BUTTON_DOWN, &movement_state.light_down_timestamp);
 }
 
-void cb_mode_btn_interrupt(void) {
-    bool pin_level = watch_get_pin_level(BTN_MODE);
+static void mode_btn_action(bool pin_level) { 
     _movement_reset_inactivity_countdown();
     event.event_type = _figure_out_button_event(pin_level, EVENT_MODE_BUTTON_DOWN, &movement_state.mode_down_timestamp);
 }
 
-void cb_alarm_btn_interrupt(void) {
-    bool pin_level = watch_get_pin_level(BTN_ALARM);
+static void alarm_btn_action(bool pin_level) {
     _movement_reset_inactivity_countdown();
     uint8_t event_type = _figure_out_button_event(pin_level, EVENT_ALARM_BUTTON_DOWN, &movement_state.alarm_down_timestamp);
-    if  (movement_state.ignore_alarm_after_sleep){
-        if (event_type == EVENT_ALARM_BUTTON_UP) movement_state.ignore_alarm_after_sleep = false;
+    if  (movement_state.ignore_alarm_btn_after_sleep){
+        if (event_type == EVENT_ALARM_BUTTON_UP || event_type == EVENT_ALARM_LONG_UP) movement_state.ignore_alarm_btn_after_sleep = false;
         return;
     }
     event.event_type = event_type;
 }
 
+void cb_light_btn_interrupt(void) {
+    movement_state.debounce_prev_pin_light = watch_get_pin_level(BTN_LIGHT);
+    movement_state.debounce_ticks_light = 1;
+    _movement_enable_fast_tick_if_needed();
+}
+
+void cb_mode_btn_interrupt(void) {
+    movement_state.debounce_prev_pin_mode = watch_get_pin_level(BTN_MODE);
+    movement_state.debounce_ticks_mode = 1;
+    _movement_enable_fast_tick_if_needed();
+}
+
+void cb_alarm_btn_interrupt(void) {
+    movement_state.debounce_prev_pin_alarm = watch_get_pin_level(BTN_ALARM);
+    movement_state.debounce_ticks_alarm = 1;
+    _movement_enable_fast_tick_if_needed();
+}
 
 void cb_alarm_btn_extwake(void) {
     // wake up!
@@ -695,23 +698,48 @@ void cb_alarm_fired(void) {
 }
 
 void cb_fast_tick(void) {
-    movement_state.fast_ticks++;
-    if (!movement_state.debounce_occurring) {
-        if (movement_state.light_ticks > 0) movement_state.light_ticks--;
-        if (movement_state.alarm_ticks > 0) movement_state.alarm_ticks--;
-        // check timestamps and auto-fire the long-press events
-        // Notice: is it possible that two or more buttons have an identical timestamp? In this case
-        // only one of these buttons would receive the long press event. Don't bother for now...
-        if (movement_state.light_down_timestamp > 0)
-            if (movement_state.fast_ticks - movement_state.light_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
-                event.event_type = EVENT_LIGHT_LONG_PRESS;
-        if (movement_state.mode_down_timestamp > 0)
-            if (movement_state.fast_ticks - movement_state.mode_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
-                event.event_type = EVENT_MODE_LONG_PRESS;
-        if (movement_state.alarm_down_timestamp > 0)
-            if (movement_state.fast_ticks - movement_state.alarm_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
-                event.event_type = EVENT_ALARM_LONG_PRESS;
+    if (movement_state.debounce_ticks_light == 0) {
+        if (movement_state.debounce_prev_pin_light == watch_get_pin_level(BTN_LIGHT))
+            light_btn_action(movement_state.debounce_prev_pin_light);
+        movement_state.debounce_ticks_light = -1;
     }
+    else if (movement_state.debounce_ticks_light > 0) {
+        movement_state.debounce_ticks_light--;
+        return;
+    }
+    if (movement_state.debounce_ticks_alarm == 0) {
+        if (movement_state.debounce_prev_pin_alarm == watch_get_pin_level(BTN_ALARM))
+            alarm_btn_action(movement_state.debounce_prev_pin_alarm);
+        movement_state.debounce_ticks_alarm = -1;
+    }
+    else if (movement_state.debounce_ticks_alarm > 0) {
+        movement_state.debounce_ticks_alarm--;
+        return;
+    }
+    if (movement_state.debounce_ticks_mode == 0) {
+        if (movement_state.debounce_prev_pin_mode == watch_get_pin_level(BTN_MODE))
+            mode_btn_action(movement_state.debounce_prev_pin_mode);
+        movement_state.debounce_ticks_mode = -1;
+    }
+    else if (movement_state.debounce_ticks_mode > 0) {
+        movement_state.debounce_ticks_mode--;
+        return;
+    }
+    movement_state.fast_ticks++;
+    if (movement_state.light_ticks > 0) movement_state.light_ticks--;
+    if (movement_state.alarm_ticks > 0) movement_state.alarm_ticks--;
+    // check timestamps and auto-fire the long-press events
+    // Notice: is it possible that two or more buttons have an identical timestamp? In this case
+    // only one of these buttons would receive the long press event. Don't bother for now...
+    if (movement_state.light_down_timestamp > 0)
+        if (movement_state.fast_ticks - movement_state.light_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
+            event.event_type = EVENT_LIGHT_LONG_PRESS;
+    if (movement_state.mode_down_timestamp > 0)
+        if (movement_state.fast_ticks - movement_state.mode_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
+            event.event_type = EVENT_MODE_LONG_PRESS;
+    if (movement_state.alarm_down_timestamp > 0)
+        if (movement_state.fast_ticks - movement_state.alarm_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
+            event.event_type = EVENT_ALARM_LONG_PRESS;
     // this is just a fail-safe; fast tick should be disabled as soon as the button is up, the LED times out, and/or the alarm finishes.
     // but if for whatever reason it isn't, this forces the fast tick off after 20 seconds.
     if (movement_state.fast_ticks >= 128 * 20) {

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -171,9 +171,6 @@ static inline void _movement_reset_inactivity_countdown(void) {
 static inline void _movement_enable_fast_tick_if_needed(void) {
     if (!movement_state.fast_tick_enabled) {
         movement_state.fast_ticks = 0;
-        movement_state.debounce_ticks_light = 0;
-        movement_state.debounce_ticks_alarm = 0;
-        movement_state.debounce_ticks_mode = 0;
         watch_rtc_register_periodic_callback(cb_fast_tick, 128);
         movement_state.fast_tick_enabled = true;
     }
@@ -392,6 +389,9 @@ void app_init(void) {
     movement_state.settings.bit.led_duration = MOVEMENT_DEFAULT_LED_DURATION;
     movement_state.light_ticks = -1;
     movement_state.alarm_ticks = -1;
+    movement_state.debounce_ticks_light = 0;
+    movement_state.debounce_ticks_alarm = 0;
+    movement_state.debounce_ticks_mode = 0;
     movement_state.next_available_backup_register = 4;
     _movement_reset_inactivity_countdown();
 
@@ -634,24 +634,28 @@ static movement_event_type_t _figure_out_button_event(bool pin_level, movement_e
         // now that that's out of the way, handle falling edge
         uint16_t diff = movement_state.fast_ticks - *down_timestamp;
         *down_timestamp = 0;
+        _movement_disable_fast_tick_if_possible();
         // any press over a half second is considered a long press. Fire the long-up event
         if (diff > MOVEMENT_LONG_PRESS_TICKS) return button_down_event_type + 3;
         else return button_down_event_type + 1;
     }
 }
 
-static void light_btn_action(bool pin_level) {
+static void light_btn_action(void) {
     _movement_reset_inactivity_countdown();
+    bool pin_level = watch_get_pin_level(BTN_LIGHT);
     event.event_type = _figure_out_button_event(pin_level, EVENT_LIGHT_BUTTON_DOWN, &movement_state.light_down_timestamp);
 }
 
-static void mode_btn_action(bool pin_level) { 
+static void mode_btn_action(void) {
     _movement_reset_inactivity_countdown();
+    bool pin_level = watch_get_pin_level(BTN_MODE);
     event.event_type = _figure_out_button_event(pin_level, EVENT_MODE_BUTTON_DOWN, &movement_state.mode_down_timestamp);
 }
 
-static void alarm_btn_action(bool pin_level) {
+static void alarm_btn_action(void) {
     _movement_reset_inactivity_countdown();
+    bool pin_level = watch_get_pin_level(BTN_ALARM);
     uint8_t event_type = _figure_out_button_event(pin_level, EVENT_ALARM_BUTTON_DOWN, &movement_state.alarm_down_timestamp);
     if  (movement_state.ignore_alarm_btn_after_sleep){
         if (event_type == EVENT_ALARM_BUTTON_UP || event_type == EVENT_ALARM_LONG_UP) movement_state.ignore_alarm_btn_after_sleep = false;
@@ -660,27 +664,19 @@ static void alarm_btn_action(bool pin_level) {
     event.event_type = event_type;
 }
 
-static void debounce_btn_press(uint8_t pin, uint8_t *debounce_ticks, uint16_t *down_timestamp, void (*function)(bool)) {
-    bool pin_level = watch_get_pin_level(pin);
-    if (*debounce_ticks <= 1) {
-        function(pin_level);
-        *debounce_ticks = DEBOUNCE_TICKS;
-    }
-    else
-        *down_timestamp = 0;
+void cb_light_btn_interrupt(void) {
+    movement_state.debounce_ticks_light = DEBOUNCE_TICKS;
     _movement_enable_fast_tick_if_needed();
 }
 
-void cb_light_btn_interrupt(void) {
-    debounce_btn_press(BTN_LIGHT, &movement_state.debounce_ticks_light, &movement_state.light_down_timestamp, light_btn_action);
-}
-
 void cb_mode_btn_interrupt(void) {
-    debounce_btn_press(BTN_MODE, &movement_state.debounce_ticks_mode, &movement_state.mode_down_timestamp, mode_btn_action);
+    movement_state.debounce_ticks_mode = DEBOUNCE_TICKS;
+    _movement_enable_fast_tick_if_needed();
 }
 
 void cb_alarm_btn_interrupt(void) {
-    debounce_btn_press(BTN_ALARM, &movement_state.debounce_ticks_alarm, &movement_state.alarm_down_timestamp, alarm_btn_action);
+    movement_state.debounce_ticks_alarm = DEBOUNCE_TICKS;
+    _movement_enable_fast_tick_if_needed();
 }
 
 void cb_alarm_btn_extwake(void) {
@@ -693,9 +689,12 @@ void cb_alarm_fired(void) {
 }
 
 void cb_fast_tick(void) {
-    if (movement_state.debounce_ticks_light > 0 && --movement_state.debounce_ticks_light == 0) _movement_disable_fast_tick_if_possible();
-    if (movement_state.debounce_ticks_alarm > 0 && --movement_state.debounce_ticks_alarm == 0) _movement_disable_fast_tick_if_possible();
-    if (movement_state.debounce_ticks_mode > 0 && --movement_state.debounce_ticks_mode == 0) _movement_disable_fast_tick_if_possible();
+    if (movement_state.debounce_ticks_light > 0 && --movement_state.debounce_ticks_light == 0)
+        light_btn_action();
+    if (movement_state.debounce_ticks_alarm > 0 && --movement_state.debounce_ticks_alarm == 0)
+        alarm_btn_action();
+    if (movement_state.debounce_ticks_mode > 0 && --movement_state.debounce_ticks_mode == 0)
+        mode_btn_action();
     if (movement_state.debounce_ticks_light + movement_state.debounce_ticks_mode + movement_state.debounce_ticks_alarm  == 0)
         movement_state.fast_ticks++;
     if (movement_state.light_ticks > 0) movement_state.light_ticks--;

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -99,6 +99,8 @@
 #include <emscripten.h>
 #endif
 
+#define DEBOUNCE_TICKS 20  // In terms of *7.8125ms
+
 movement_state_t movement_state;
 void * watch_face_contexts[MOVEMENT_NUM_FACES];
 watch_date_time scheduled_tasks[MOVEMENT_NUM_FACES];
@@ -169,6 +171,9 @@ static inline void _movement_reset_inactivity_countdown(void) {
 static inline void _movement_enable_fast_tick_if_needed(void) {
     if (!movement_state.fast_tick_enabled) {
         movement_state.fast_ticks = 0;
+        movement_state.debounce_ticks_light = 0;
+        movement_state.debounce_ticks_alarm = 0;
+        movement_state.debounce_ticks_mode = 0;
         watch_rtc_register_periodic_callback(cb_fast_tick, 128);
         movement_state.fast_tick_enabled = true;
     }
@@ -181,16 +186,6 @@ static inline void _movement_disable_fast_tick_if_possible(void) {
         movement_state.fast_tick_enabled = false;
         watch_rtc_disable_periodic_callback(128);
     }
-}
-
-static void cb_debounce(void) {
-    movement_state.debounce_occurring = false;
-    watch_rtc_disable_periodic_callback(64);  // 64 HZ is 15.625ms
-}
-
-static inline void _movement_enable_debounce_tick(void) {
-    movement_state.debounce_occurring = true;
-    watch_rtc_register_periodic_callback(cb_debounce, 64);
 }
 
 static void _movement_handle_background_tasks(void) {
@@ -233,15 +228,15 @@ static void _movement_handle_scheduled_tasks(void) {
 }
 
 void movement_request_tick_frequency(uint8_t freq) {
-    // Movement uses the 128 Hz tick internally; 64 is th edebounce frequency
-    if (freq == 128 || freq == 64 ) return;
+    // Movement uses the 128 Hz tick internally
+    if (freq == 128) return;
 
     // Movement requires at least a 1 Hz tick.
     // If we are asked for an invalid frequency, default back to 1 Hz.
     if (freq == 0 || __builtin_popcount(freq) != 1) freq = 1;
 
     // disable all callbacks except the 128 Hz one
-    watch_rtc_disable_matching_periodic_callbacks(0xFC);
+    watch_rtc_disable_matching_periodic_callbacks(0xFE);
 
     movement_state.subsecond = 0;
     movement_state.tick_frequency = freq;
@@ -625,8 +620,6 @@ bool app_loop(void) {
 static movement_event_type_t _figure_out_button_event(bool pin_level, movement_event_type_t button_down_event_type, uint16_t *down_timestamp) {
     // force alarm off if the user pressed a button.
     if (movement_state.alarm_ticks) movement_state.alarm_ticks = 0;
-    if ( movement_state.debounce_occurring)
-        return EVENT_NONE;
 
     if (pin_level) {
         // handle rising edge
@@ -641,36 +634,46 @@ static movement_event_type_t _figure_out_button_event(bool pin_level, movement_e
         uint16_t diff = movement_state.fast_ticks - *down_timestamp;
         *down_timestamp = 0;
         _movement_disable_fast_tick_if_possible();
-        _movement_enable_debounce_tick();
         // any press over a half second is considered a long press. Fire the long-up event
         if (diff > MOVEMENT_LONG_PRESS_TICKS) return button_down_event_type + 3;
         else return button_down_event_type + 1;
     }
 }
 
-void cb_light_btn_interrupt(void) {
-    bool pin_level = watch_get_pin_level(BTN_LIGHT);
+static void light_btn_action(bool pin_level) {
     _movement_reset_inactivity_countdown();
     event.event_type = _figure_out_button_event(pin_level, EVENT_LIGHT_BUTTON_DOWN, &movement_state.light_down_timestamp);
 }
 
-void cb_mode_btn_interrupt(void) {
-    bool pin_level = watch_get_pin_level(BTN_MODE);
+static void mode_btn_action(bool pin_level) { 
     _movement_reset_inactivity_countdown();
     event.event_type = _figure_out_button_event(pin_level, EVENT_MODE_BUTTON_DOWN, &movement_state.mode_down_timestamp);
 }
 
-void cb_alarm_btn_interrupt(void) {
-    bool pin_level = watch_get_pin_level(BTN_ALARM);
+static void alarm_btn_action(bool pin_level) {
     _movement_reset_inactivity_countdown();
     uint8_t event_type = _figure_out_button_event(pin_level, EVENT_ALARM_BUTTON_DOWN, &movement_state.alarm_down_timestamp);
     if  (movement_state.ignore_alarm_btn_after_sleep){
-        if (event_type == EVENT_ALARM_BUTTON_UP) movement_state.ignore_alarm_btn_after_sleep = false;
+        if (event_type == EVENT_ALARM_BUTTON_UP || event_type == EVENT_ALARM_LONG_UP) movement_state.ignore_alarm_btn_after_sleep = false;
         return;
     }
     event.event_type = event_type;
 }
 
+void cb_light_btn_interrupt(void) {
+    movement_state.debounce_btn_trig_light = true;
+    _movement_enable_fast_tick_if_needed();
+}
+
+void cb_mode_btn_interrupt(void) {
+    movement_state.debounce_btn_trig_mode = true;
+    _movement_enable_fast_tick_if_needed();
+}
+
+void cb_alarm_btn_interrupt(void) {
+    movement_state.debounce_btn_trig_alarm = true;
+    _movement_enable_fast_tick_if_needed();
+}
 
 void cb_alarm_btn_extwake(void) {
     // wake up!
@@ -682,23 +685,70 @@ void cb_alarm_fired(void) {
 }
 
 void cb_fast_tick(void) {
-    movement_state.fast_ticks++;
-    if (!movement_state.debounce_occurring) {
-        if (movement_state.light_ticks > 0) movement_state.light_ticks--;
-        if (movement_state.alarm_ticks > 0) movement_state.alarm_ticks--;
-        // check timestamps and auto-fire the long-press events
-        // Notice: is it possible that two or more buttons have an identical timestamp? In this case
-        // only one of these buttons would receive the long press event. Don't bother for now...
-        if (movement_state.light_down_timestamp > 0)
-            if (movement_state.fast_ticks - movement_state.light_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
-                event.event_type = EVENT_LIGHT_LONG_PRESS;
-        if (movement_state.mode_down_timestamp > 0)
-            if (movement_state.fast_ticks - movement_state.mode_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
-                event.event_type = EVENT_MODE_LONG_PRESS;
-        if (movement_state.alarm_down_timestamp > 0)
-            if (movement_state.fast_ticks - movement_state.alarm_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
-                event.event_type = EVENT_ALARM_LONG_PRESS;
+    if (movement_state.debounce_ticks_light > 0) movement_state.debounce_ticks_light--;
+    if (movement_state.debounce_ticks_alarm > 0) movement_state.debounce_ticks_alarm--;
+    if (movement_state.debounce_ticks_mode > 0) movement_state.debounce_ticks_mode--;
+    if (movement_state.debounce_btn_trig_light) {
+        bool pin_level = watch_get_pin_level(BTN_LIGHT);
+        movement_state.debounce_btn_trig_light = false;
+        if (pin_level) {
+            light_btn_action(pin_level);
+        }
+        else if (movement_state.debounce_ticks_light == 0) {
+            light_btn_action(pin_level);
+            movement_state.debounce_ticks_light = DEBOUNCE_TICKS;
+        }
+        else {
+            movement_state.light_down_timestamp = 0;
+            _movement_disable_fast_tick_if_possible();
+        }
     }
+    if (movement_state.debounce_btn_trig_alarm) {
+        bool pin_level = watch_get_pin_level(BTN_ALARM);
+        movement_state.debounce_btn_trig_alarm = false;
+        if (pin_level) {
+            alarm_btn_action(pin_level);
+        }
+        else if (movement_state.debounce_ticks_alarm == 0) {
+            alarm_btn_action(pin_level);
+            movement_state.debounce_ticks_alarm = DEBOUNCE_TICKS;
+        }
+        else {
+            movement_state.alarm_down_timestamp = 0;
+            _movement_disable_fast_tick_if_possible();
+        }
+    }
+    if (movement_state.debounce_btn_trig_mode) {
+        bool pin_level = watch_get_pin_level(BTN_MODE);
+        movement_state.debounce_btn_trig_mode = false;
+        if (pin_level) {
+            mode_btn_action(pin_level);
+        }
+        else if (movement_state.debounce_ticks_mode == 0) {
+            mode_btn_action(pin_level);
+            movement_state.debounce_ticks_mode = DEBOUNCE_TICKS;
+        }
+        else {
+            movement_state.mode_down_timestamp = 0;
+            _movement_disable_fast_tick_if_possible();
+        }
+    }
+    if (movement_state.debounce_ticks_light + movement_state.debounce_ticks_mode + movement_state.debounce_ticks_alarm  == 0)
+        movement_state.fast_ticks++;
+    if (movement_state.light_ticks > 0) movement_state.light_ticks--;
+    if (movement_state.alarm_ticks > 0) movement_state.alarm_ticks--;
+    // check timestamps and auto-fire the long-press events
+    // Notice: is it possible that two or more buttons have an identical timestamp? In this case
+    // only one of these buttons would receive the long press event. Don't bother for now...
+    if (movement_state.light_down_timestamp > 0)
+        if (movement_state.fast_ticks - movement_state.light_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
+            event.event_type = EVENT_LIGHT_LONG_PRESS;
+    if (movement_state.mode_down_timestamp > 0)
+        if (movement_state.fast_ticks - movement_state.mode_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
+            event.event_type = EVENT_MODE_LONG_PRESS;
+    if (movement_state.alarm_down_timestamp > 0)
+        if (movement_state.fast_ticks - movement_state.alarm_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
+            event.event_type = EVENT_ALARM_LONG_PRESS;
     // this is just a fail-safe; fast tick should be disabled as soon as the button is up, the LED times out, and/or the alarm finishes.
     // but if for whatever reason it isn't, this forces the fast tick off after 20 seconds.
     if (movement_state.fast_ticks >= 128 * 20) {

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -23,6 +23,7 @@
  */
 
 #define MOVEMENT_LONG_PRESS_TICKS 64
+#define DEBOUNCE_TICKS 1  // In terms of *7.8125ms
 
 #include <stdio.h>
 #include <string.h>
@@ -98,8 +99,6 @@
 #if __EMSCRIPTEN__
 #include <emscripten.h>
 #endif
-
-#define DEBOUNCE_TICKS 2  // In terms of *7.8125ms
 
 movement_state_t movement_state;
 void * watch_face_contexts[MOVEMENT_NUM_FACES];

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -642,21 +642,21 @@ static movement_event_type_t _figure_out_button_event(bool pin_level, movement_e
 }
 
 static void light_btn_action(void) {
-    _movement_reset_inactivity_countdown();
     bool pin_level = watch_get_pin_level(BTN_LIGHT);
+    _movement_reset_inactivity_countdown();
     event.event_type = _figure_out_button_event(pin_level, EVENT_LIGHT_BUTTON_DOWN, &movement_state.light_down_timestamp);
 }
 
 static void mode_btn_action(void) {
-    _movement_reset_inactivity_countdown();
     bool pin_level = watch_get_pin_level(BTN_MODE);
+    _movement_reset_inactivity_countdown();
     event.event_type = _figure_out_button_event(pin_level, EVENT_MODE_BUTTON_DOWN, &movement_state.mode_down_timestamp);
 }
 
 static void alarm_btn_action(void) {
-    _movement_reset_inactivity_countdown();
     bool pin_level = watch_get_pin_level(BTN_ALARM);
     uint8_t event_type = _figure_out_button_event(pin_level, EVENT_ALARM_BUTTON_DOWN, &movement_state.alarm_down_timestamp);
+    _movement_reset_inactivity_countdown();
     if  (movement_state.ignore_alarm_btn_after_sleep){
         if (event_type == EVENT_ALARM_BUTTON_UP || event_type == EVENT_ALARM_LONG_UP) movement_state.ignore_alarm_btn_after_sleep = false;
         return;

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -183,6 +183,17 @@ static inline void _movement_disable_fast_tick_if_possible(void) {
     }
 }
 
+#define DEBOUNCE_FREQ 64 // 64 HZ is 15.625ms
+static void cb_debounce(void) {
+    movement_state.debounce_occurring = false;
+    watch_rtc_disable_periodic_callback(DEBOUNCE_FREQ);
+}
+
+static inline void _movement_enable_debounce_tick(void) {
+    movement_state.debounce_occurring = true;
+    watch_rtc_register_periodic_callback(cb_debounce, DEBOUNCE_FREQ);
+}
+
 static void _movement_handle_background_tasks(void) {
     for(uint8_t i = 0; i < MOVEMENT_NUM_FACES; i++) {
         // For each face, if the watch face wants a background task...
@@ -222,16 +233,28 @@ static void _movement_handle_scheduled_tasks(void) {
     }
 }
 
+static uint8_t swap_endian(uint8_t num) {
+    uint8_t result = 0;
+    int i;
+    for (i = 0; i < 8; i++) {
+        result <<= 1;
+        result |= (num & 1);
+        num >>= 1;
+    }
+    return result;
+}
+
 void movement_request_tick_frequency(uint8_t freq) {
     // Movement uses the 128 Hz tick internally
-    if (freq == 128) return;
+    if (freq == 128 || freq == DEBOUNCE_FREQ ) return;
 
     // Movement requires at least a 1 Hz tick.
     // If we are asked for an invalid frequency, default back to 1 Hz.
     if (freq == 0 || __builtin_popcount(freq) != 1) freq = 1;
 
     // disable all callbacks except the 128 Hz one
-    watch_rtc_disable_matching_periodic_callbacks(0xFE);
+    int disable_mask = 0xFE ^ swap_endian(DEBOUNCE_FREQ);
+    watch_rtc_disable_matching_periodic_callbacks(disable_mask);
 
     movement_state.subsecond = 0;
     movement_state.tick_frequency = freq;
@@ -614,6 +637,8 @@ bool app_loop(void) {
 static movement_event_type_t _figure_out_button_event(bool pin_level, movement_event_type_t button_down_event_type, uint16_t *down_timestamp) {
     // force alarm off if the user pressed a button.
     if (movement_state.alarm_ticks) movement_state.alarm_ticks = 0;
+    if ( movement_state.debounce_occurring)
+        return EVENT_NONE;
 
     if (pin_level) {
         // handle rising edge
@@ -628,6 +653,7 @@ static movement_event_type_t _figure_out_button_event(bool pin_level, movement_e
         uint16_t diff = movement_state.fast_ticks - *down_timestamp;
         *down_timestamp = 0;
         _movement_disable_fast_tick_if_possible();
+        _movement_enable_debounce_tick();
         // any press over a half second is considered a long press. Fire the long-up event
         if (diff > MOVEMENT_LONG_PRESS_TICKS) return button_down_event_type + 3;
         else return button_down_event_type + 1;
@@ -663,20 +689,22 @@ void cb_alarm_fired(void) {
 
 void cb_fast_tick(void) {
     movement_state.fast_ticks++;
-    if (movement_state.light_ticks > 0) movement_state.light_ticks--;
-    if (movement_state.alarm_ticks > 0) movement_state.alarm_ticks--;
-    // check timestamps and auto-fire the long-press events
-    // Notice: is it possible that two or more buttons have an identical timestamp? In this case
-    // only one of these buttons would receive the long press event. Don't bother for now...
-    if (movement_state.light_down_timestamp > 0)
-        if (movement_state.fast_ticks - movement_state.light_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
-            event.event_type = EVENT_LIGHT_LONG_PRESS;
-    if (movement_state.mode_down_timestamp > 0)
-        if (movement_state.fast_ticks - movement_state.mode_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
-            event.event_type = EVENT_MODE_LONG_PRESS;
-    if (movement_state.alarm_down_timestamp > 0)
-        if (movement_state.fast_ticks - movement_state.alarm_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
-            event.event_type = EVENT_ALARM_LONG_PRESS;
+    if (!movement_state.debounce_occurring) {
+        if (movement_state.light_ticks > 0) movement_state.light_ticks--;
+        if (movement_state.alarm_ticks > 0) movement_state.alarm_ticks--;
+        // check timestamps and auto-fire the long-press events
+        // Notice: is it possible that two or more buttons have an identical timestamp? In this case
+        // only one of these buttons would receive the long press event. Don't bother for now...
+        if (movement_state.light_down_timestamp > 0)
+            if (movement_state.fast_ticks - movement_state.light_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
+                event.event_type = EVENT_LIGHT_LONG_PRESS;
+        if (movement_state.mode_down_timestamp > 0)
+            if (movement_state.fast_ticks - movement_state.mode_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
+                event.event_type = EVENT_MODE_LONG_PRESS;
+        if (movement_state.alarm_down_timestamp > 0)
+            if (movement_state.fast_ticks - movement_state.alarm_down_timestamp == MOVEMENT_LONG_PRESS_TICKS + 1)
+                event.event_type = EVENT_ALARM_LONG_PRESS;
+    }
     // this is just a fail-safe; fast tick should be disabled as soon as the button is up, the LED times out, and/or the alarm finishes.
     // but if for whatever reason it isn't, this forces the fast tick off after 20 seconds.
     if (movement_state.fast_ticks >= 128 * 20) {

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -99,7 +99,7 @@
 #include <emscripten.h>
 #endif
 
-#define DEBOUNCE_TICKS 20  // In terms of *7.8125ms
+#define DEBOUNCE_TICKS 2  // In terms of *7.8125ms
 
 movement_state_t movement_state;
 void * watch_face_contexts[MOVEMENT_NUM_FACES];
@@ -633,7 +633,6 @@ static movement_event_type_t _figure_out_button_event(bool pin_level, movement_e
         // now that that's out of the way, handle falling edge
         uint16_t diff = movement_state.fast_ticks - *down_timestamp;
         *down_timestamp = 0;
-        _movement_disable_fast_tick_if_possible();
         // any press over a half second is considered a long press. Fire the long-up event
         if (diff > MOVEMENT_LONG_PRESS_TICKS) return button_down_event_type + 3;
         else return button_down_event_type + 1;
@@ -685,21 +684,20 @@ void cb_alarm_fired(void) {
 }
 
 static void debounce_btn_press(uint8_t pin, uint8_t *debounce_ticks, bool *debounce_btn_trig, uint16_t *down_timestamp, void (*function)(bool)) {
-    if (*debounce_ticks > 0) (*debounce_ticks)--;
+    if (*debounce_ticks > 0)
+    {
+        if (--(*debounce_ticks) == 0)
+            _movement_disable_fast_tick_if_possible();
+    }
     if (*debounce_btn_trig) {
         bool pin_level = watch_get_pin_level(pin);
         *debounce_btn_trig = false;
-        if (pin_level) {
-            function(pin_level);
-        }
-        else if (*debounce_ticks == 0) {
+        if (*debounce_ticks == 0) {
             function(pin_level);
             *debounce_ticks = DEBOUNCE_TICKS;
         }
-        else {
+        else
             *down_timestamp = 0;
-            _movement_disable_fast_tick_if_possible();
-        }
     }
 }
 

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -681,10 +681,15 @@ static void debounce_btn_press(uint8_t pin, uint8_t *debounce_ticks, uint16_t *d
         *down_timestamp = 0;
 }
 
+static void disable_if_needed(uint8_t *ticks) {
+    if (*ticks > 0 && --*ticks == 0)
+        _movement_disable_fast_tick_if_possible();
+}
+
 static void movement_disable_if_debounce_complete(void) {
-    if (movement_state.debounce_ticks_light > 0 && --movement_state.debounce_ticks_light == 0) _movement_disable_fast_tick_if_possible();
-    if (movement_state.debounce_ticks_alarm > 0 && --movement_state.debounce_ticks_alarm == 0) _movement_disable_fast_tick_if_possible();
-    if (movement_state.debounce_ticks_mode > 0 && --movement_state.debounce_ticks_mode == 0) _movement_disable_fast_tick_if_possible();
+    disable_if_needed(&movement_state.debounce_ticks_light);
+    disable_if_needed(&movement_state.debounce_ticks_alarm);
+    disable_if_needed(&movement_state.debounce_ticks_mode);
 }
 
 void cb_light_btn_interrupt(void) {

--- a/movement/movement.h
+++ b/movement/movement.h
@@ -267,11 +267,16 @@ typedef struct {
     bool needs_background_tasks_handled;
     bool has_scheduled_background_task;
     bool needs_wake;
-    bool debounce_occurring;
 
     // low energy mode countdown
     int32_t le_mode_ticks;
-    bool ignore_alarm_after_sleep;
+    int8_t debounce_ticks_light;
+    int8_t debounce_ticks_alarm;
+    int8_t debounce_ticks_mode;
+    bool debounce_prev_pin_light;
+    bool debounce_prev_pin_alarm;
+    bool debounce_prev_pin_mode;
+    bool ignore_alarm_btn_after_sleep;
 
     // app resignation countdown (TODO: consolidate with LE countdown?)
     int16_t timeout_ticks;

--- a/movement/movement.h
+++ b/movement/movement.h
@@ -270,12 +270,12 @@ typedef struct {
 
     // low energy mode countdown
     int32_t le_mode_ticks;
-    int8_t debounce_ticks_light;
-    int8_t debounce_ticks_alarm;
-    int8_t debounce_ticks_mode;
-    bool debounce_prev_pin_light;
-    bool debounce_prev_pin_alarm;
-    bool debounce_prev_pin_mode;
+    uint8_t debounce_ticks_light;
+    uint8_t debounce_ticks_alarm;
+    uint8_t debounce_ticks_mode;
+    bool debounce_btn_trig_light;
+    bool debounce_btn_trig_alarm;
+    bool debounce_btn_trig_mode;
     bool ignore_alarm_btn_after_sleep;
 
     // app resignation countdown (TODO: consolidate with LE countdown?)

--- a/movement/movement.h
+++ b/movement/movement.h
@@ -267,15 +267,10 @@ typedef struct {
     bool needs_background_tasks_handled;
     bool has_scheduled_background_task;
     bool needs_wake;
+    bool debounce_occurring;
 
     // low energy mode countdown
     int32_t le_mode_ticks;
-    uint8_t debounce_ticks_light;
-    uint8_t debounce_ticks_alarm;
-    uint8_t debounce_ticks_mode;
-    bool debounce_btn_trig_light;
-    bool debounce_btn_trig_alarm;
-    bool debounce_btn_trig_mode;
     bool ignore_alarm_btn_after_sleep;
 
     // app resignation countdown (TODO: consolidate with LE countdown?)

--- a/movement/movement.h
+++ b/movement/movement.h
@@ -271,6 +271,7 @@ typedef struct {
 
     // low energy mode countdown
     int32_t le_mode_ticks;
+    bool ignore_alarm_after_sleep;
 
     // app resignation countdown (TODO: consolidate with LE countdown?)
     int16_t timeout_ticks;

--- a/movement/movement.h
+++ b/movement/movement.h
@@ -273,9 +273,6 @@ typedef struct {
     uint8_t debounce_ticks_light;
     uint8_t debounce_ticks_alarm;
     uint8_t debounce_ticks_mode;
-    bool debounce_btn_trig_light;
-    bool debounce_btn_trig_alarm;
-    bool debounce_btn_trig_mode;
     bool ignore_alarm_btn_after_sleep;
 
     // app resignation countdown (TODO: consolidate with LE countdown?)

--- a/movement/movement.h
+++ b/movement/movement.h
@@ -267,10 +267,15 @@ typedef struct {
     bool needs_background_tasks_handled;
     bool has_scheduled_background_task;
     bool needs_wake;
-    bool debounce_occurring;
 
     // low energy mode countdown
     int32_t le_mode_ticks;
+    uint8_t debounce_ticks_light;
+    uint8_t debounce_ticks_alarm;
+    uint8_t debounce_ticks_mode;
+    bool debounce_btn_trig_light;
+    bool debounce_btn_trig_alarm;
+    bool debounce_btn_trig_mode;
     bool ignore_alarm_btn_after_sleep;
 
     // app resignation countdown (TODO: consolidate with LE countdown?)

--- a/movement/movement.h
+++ b/movement/movement.h
@@ -267,6 +267,7 @@ typedef struct {
     bool needs_background_tasks_handled;
     bool has_scheduled_background_task;
     bool needs_wake;
+    bool debounce_occurring;
 
     // low energy mode countdown
     int32_t le_mode_ticks;


### PR DESCRIPTION
# Debounce Logic
For Some, their watch buttons may trigger more than one press when clicked. This PR is used to compensate for that.  
What it does is ignore button presses after the first one for a set amount of ticks in `cb_fast_tick` (which uses a frequency of 128Hz).  


The amount of ticks to wait before registering a button is set by `DEBOUNCE_TICKS_DOWN` and `DEBOUNCE_TICKS_UP`.  Since the `cb_fast_tick` counts the ticks, and it's 128Hz, each tick is 7.8125ms.
* `DEBOUNCE_TICKS_DOWN`: How many ticks after pressing a button before another press of that button is registered.
* `DEBOUNCE_TICKS_UP`: How many ticks after depressing a button before another depress of that button is registered.

If both are set to 0, then the watch will behave the same as the stock firmware. Each of the three buttons has their own timer.

This does slow down button-press reactions, but it's only been seen as an issue on watch faces that require fast and precise presses, such as the [endless runner face](https://github.com/joeycastillo/Sensor-Watch/pull/419). In testing with 2 being the `DEBOUNCE_TICKS_DOWN` and `DEBOUNCE_TICKS_UP`, no other faces' usability was seen as affected.

`cb_fast_tick` is used for where the logic is handled to avoid introducing new timers when a button is pressed, but causes an issue, where that callback occurs asynchronous to when a button is pressed. If `DEBOUNCE_TICKS_DOWN` is set to 1 and the button is pressed when `cb_fast_tick` is 7ms into acting on its next callback, the debounce time is instead 0.8125 ms, not 7,8125. Due to this, setting the `DEBOUNCE_TICKS_DOWN` or `DEBOUNCE_TICKS_UP` to 1 is not recommended.

# Ignore Alarm Button After Sleep

This PR also includes logic that ignores the next time the Alarm button is depressed after waking from sleep. I have found it annoying that pressing the alarm button to wake the watch also triggers common behaviors on many faces at the same time.

# Diagram of the Debounce Method
![Debounce Method](https://github.com/user-attachments/assets/010da34d-df40-44f3-8cb8-a2b6fe24d826)
