### PR TITLE
make sure we don't miss our scheduled tasks

### DIFF
--- a/movement/movement.c
+++ b/movement/movement.c
@@ -201,7 +201,7 @@ static void _movement_handle_scheduled_tasks(void) {
 
     for(uint8_t i = 0; i < MOVEMENT_NUM_FACES; i++) {
         if (scheduled_tasks[i].reg) {
-            if (scheduled_tasks[i].reg == date_time.reg) {
+            if (scheduled_tasks[i].reg <= date_time.reg) {
                 scheduled_tasks[i].reg = 0;
                 movement_event_t background_event = { EVENT_BACKGROUND_TASK, 0 };
                 watch_faces[i].loop(background_event, &movement_state.settings, watch_face_contexts[i]);


### PR DESCRIPTION
In testing a feature I'm adding, I was repeatedly pressing the "mode" button. I found that if I pressed the mode button just as a background task was supposed to fire, it didn't fire.

On the Discord, user tahnok suggested maybe the background task only checks for an exact time to fire, and indeed this seems to be the case. Changing this check from "is the correct time" to "is the correct time, or after" has fixed the errant behaviour I was seeing.