### PR TITLE
Countdown fix

### DIFF
--- a/movement/watch_faces/complication/countdown_face.c
+++ b/movement/watch_faces/complication/countdown_face.c
@@ -87,7 +87,10 @@ static void draw(countdown_state_t *state, uint8_t subsecond) {
 
     switch (state->mode) {
         case cd_running:
-            delta = state->target_ts - state->now_ts;
+            if (state->target_ts <= state->now_ts)
+                delta = 0;
+            else
+                delta = state->target_ts - state->now_ts;
             result = div(delta, 60);
             state->seconds = result.rem;
             result = div(result.quot, 60);

--- a/movement/watch_faces/complication/countdown_face.c
+++ b/movement/watch_faces/complication/countdown_face.c
@@ -100,6 +100,7 @@ static void draw(countdown_state_t *state, uint8_t subsecond) {
             break;
         case cd_reset:
         case cd_paused:
+            watch_clear_indicator(WATCH_INDICATOR_BELL);
             sprintf(buf, "CD  %2d%02d%02d", state->hours, state->minutes, state->seconds);
             break;
         case cd_setting:
@@ -133,7 +134,6 @@ static void pause(countdown_state_t *state) {
 static void reset(countdown_state_t *state) {
     state->mode = cd_reset;
     movement_cancel_background_task();
-    watch_clear_indicator(WATCH_INDICATOR_BELL);
     load_countdown(state);
 }
 


### PR DESCRIPTION
A couple of fixes to the Countdown face:

i) There's a race condition on calculating the delta - if we miss the moment when target_ts == now_ts, then we can get a negative delta, which we're storing as an unsigned int, so it overflows and things get weird. Instead, clamp it to 0.

ii) When the background task is called to indicate "time is up", it sounds the alarm and calls reset(), which clears the bell indicator. But it's a background task, so we shouldn't be changing the indicators - another face might be active. Instead, don't clear the indicator in reset(), clear it in draw().

