### PR TITLE
Update TOTP Face Documentation

### DIFF
--- a/movement/watch_faces/complication/totp_face.h
+++ b/movement/watch_faces/complication/totp_face.h
@@ -48,15 +48,19 @@
  *  o SHA512
  *
  * Instructions:
- *  o Find your secret key(s) and convert them to the required format.
- *      o Use https://cryptii.com/pipes/base32-to-hex to convert base32 to hex
- *      o Use https://github.com/susam/mintotp to generate test codes for verification
- *  o Edit global variables in "totp_face.c" to configure your stored keys:
- *      o "keys", "key_sizes", "timesteps", and "algorithms" set the
- *        cryptographic parameters for each secret key.
- *      o "labels" sets the two-letter label for each key
- *        (This replaces the day-of-week indicator)
- *      o Once finished, remove the two provided examples.
+ *  o Find your secret key(s).
+ *      o Use https://github.com/susam/mintotp to generate test codes for
+ *        verification
+ *  o Edit global `credentials` variable in "totp_face.c" to configure your
+ *    TOTP credentials. The file includes two examples that you can use as a
+ *    reference. Credentials are added with the `CREDENTIAL` macro in the form
+ *    `CREDENTIAL(label, key, algorithm, timestep)` where:
+ *      o `label` is a 2 character label that is displayed in the weekday digits
+ *        to identify the TOTP credential.
+ *      o `key` is a string with the base32 encoded secret.
+ *      o `algorithm` is one of the supported hashing algorithms listed above.
+ *      o `timestep` is how often the TOTP refreshes in seconds. This is usually
+ *        30 seconds.
  *
  * If you have more than one secret key, press ALARM to cycle through them.
  * Press LIGHT to cycle in the other direction or keep it pressed longer to


### PR DESCRIPTION
The TOTP face header file documentation contained outdated instructions for configuring the complication with TOTP credentials. This PR updates the documentation to match what is expected in `totp_face.c`.