### PR TITLE
Countdown autorepeat

### DIFF
--- a/movement/watch_faces/complication/countdown_face.h
+++ b/movement/watch_faces/complication/countdown_face.h
@@ -62,6 +62,8 @@ typedef struct {
     uint8_t set_seconds;
     uint8_t selection;
     countdown_mode_t mode;
+    bool repeat;
+    uint8_t watch_face_index;
 } countdown_state_t;
 
 


### PR DESCRIPTION
Add an "autorepeat" mode to the Countdown face.

On the countdown setting face, hold "alarm" to toggle autorepeat. When the countdown is set to autorepeat, it will automatically restart when it reaches zero. Useful to e.g. remind you to check on something every twenty minutes.

Changed to use the newer movement_schedule_background_task_for_face method, since we potentially need to schedule the new alarm when the Countdown face is not itself active.

Changed the use of indicators within the Countdown face. Formerly, the "bell" indicator was used to indicate an active countdown. Now, we use the "signal" indicator for this, and the "bell" indicates autorepeat mode. This seems more consistent with those icons' traditional purpose - the "bell" indicates a repeating alarm, the "signal" indicates a one-off.