### PR TITLE
watch_register_extwake_callback fix (re issue #449)

### DIFF
--- a/movement/movement.c
+++ b/movement/movement.c
@@ -201,7 +201,7 @@ static void _movement_handle_scheduled_tasks(void) {
 
     for(uint8_t i = 0; i < MOVEMENT_NUM_FACES; i++) {
         if (scheduled_tasks[i].reg) {
-            if (scheduled_tasks[i].reg <= date_time.reg) {
+            if (scheduled_tasks[i].reg == date_time.reg) {
                 scheduled_tasks[i].reg = 0;
                 movement_event_t background_event = { EVENT_BACKGROUND_TASK, 0 };
                 watch_faces[i].loop(background_event, &movement_state.settings, watch_face_contexts[i]);

--- a/movement/movement.c
+++ b/movement/movement.c
@@ -201,7 +201,7 @@ static void _movement_handle_scheduled_tasks(void) {
 
     for(uint8_t i = 0; i < MOVEMENT_NUM_FACES; i++) {
         if (scheduled_tasks[i].reg) {
-            if (scheduled_tasks[i].reg == date_time.reg) {
+            if (scheduled_tasks[i].reg <= date_time.reg) {
                 scheduled_tasks[i].reg = 0;
                 movement_event_t background_event = { EVENT_BACKGROUND_TASK, 0 };
                 watch_faces[i].loop(background_event, &movement_state.settings, watch_face_contexts[i]);

--- a/watch-library/hardware/watch/watch_deepsleep.c
+++ b/watch-library/hardware/watch/watch_deepsleep.c
@@ -77,6 +77,7 @@ void watch_register_extwake_callback(uint8_t pin, ext_irq_cb_t callback, bool le
     RTC->MODE2.TAMPCTRL.reg = config;
     // re-enable the RTC
     RTC->MODE2.CTRLA.bit.ENABLE = 1;
+    while (RTC->MODE2.SYNCBUSY.bit.ENABLE); // wait for RTC to be enabled
 
     NVIC_ClearPendingIRQ(RTC_IRQn);
     NVIC_EnableIRQ(RTC_IRQn);


### PR DESCRIPTION
While working on something else, I found that if I call watch_register_extwake_callback twice in succession, to register two different callbacks, it doesn't register them both.

I think this is a race condition with the RTC - I have fixed by adding another wait for the SYNCBUSY bit. This also seems consistent with how this is done elsewhere in the code.