### PR TITLE
sleep light function

### DIFF
--- a/movement/movement.h
+++ b/movement/movement.h
@@ -269,7 +269,7 @@ typedef struct {
     bool needs_background_tasks_handled;
     bool has_scheduled_background_task;
     bool needs_wake;
-
+ 
     // low energy mode countdown
     int32_t le_mode_ticks;
     uint8_t debounce_ticks_light;
@@ -287,6 +287,11 @@ typedef struct {
 
     // backup register stuff
     uint8_t next_available_backup_register;
+
+    // tracking when the LIGHT button was pressed while in sleep mode
+    // so that we can disregard further LIGHT presses in this period
+    int16_t sleep_light_timestamp;
+
 } movement_state_t;
 
 void movement_move_to_face(uint8_t watch_face_index);

--- a/movement/movement_config.h
+++ b/movement/movement_config.h
@@ -111,4 +111,10 @@ const watch_face_t watch_faces[] = {
 #define MOVEMENT_DEFAULT_BIRTHDATE_MONTH 0
 #define MOVEMENT_DEFAULT_BIRTHDATE_DAY 0
 
+/* If the watch is physically modified to tie the LIGHT
+* button to the A4 input, defining this will enable the
+* watch to wake, and light up, on the LIGHT button
+*/
+#define MOVEMENT_SLEEP_LIGHT_A4 1
+
 #endif // MOVEMENT_CONFIG_H_


### PR DESCRIPTION
This enables the LIGHT button to wake the watch, if the watch has been physically modified to connect the LIGHT button to the A4 input. The watch cannot physically wake from the LIGHT input without this modification. However the A4 input does support external wake.

So, this patch adds an additional "external wake" callback on the A4 button.

The feature is configurable in movement_config.h by defining MOVEMENT_SLEEP_LIGHT_A4

The use-case is "checking the watch in the middle of the night". In order to preserve watch battery, the watch only wakes for 5 seconds. In order to accomplish this, there's some logic to disregard the LIGHT button for a few seconds after this special wake - otherwise, the "normal" LIGHT button action is triggered in addition to the A4 wake, which resets the low-energy countdown, which we don't want.

Room for improvement:

 * Perhaps this "don't respond" logic could be combined with the new debounce logic somehow?
 * Maybe the "don't respond" logic is just complicating things and it's okay to wake the watch up completely? (It does seem like potentially a lot of battery life though if you check the time a few times each night and it wakes up for an hour each time).
 * In movement.h there is no support for movement_config and so the additional struct field is not wrapped in in #ifdef

