### PR TITLE
bump to the newer upload-artifact github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 env:
   COLOR: BLUE
 
-jobs: 
+jobs:
   build:
     container:
       image: ghcr.io/armmbed/mbed-os-env:latest
@@ -29,7 +29,7 @@ jobs:
         run: make
         working-directory: 'movement/make'
       - name: Upload UF2
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: watch.uf2
           path: movement/make/build/watch.uf2
@@ -52,7 +52,7 @@ jobs:
           cp watch.html index.html
           tar -czf simulator.tar.gz index.html watch.wasm watch.js
       - name: Upload simulator build
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: simulator.tar.gz
           path: movement/make/build-sim/simulator.tar.gz


### PR DESCRIPTION
Discord users `jeremy` and `Joe` reported CI breakage on main, and Joe linked https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

This updates to version 4 of the deprecated action.