### PR TITLE
Fix months

### DIFF
--- a/apps/beats-time/app.c
+++ b/apps/beats-time/app.c
@@ -223,11 +223,9 @@ void set_time_mode_handle_secondary_button(void) {
             date_time.unit.month = ((date_time.unit.month + 1) % 12);
             break;
         case 5: // day
-            date_time.unit.day = date_time.unit.day + 1;
+            date_time.unit.day = ((date_time.unit.day % watch_utility_days_in_month(date_time.unit.month, date_time.unit.year + WATCH_RTC_REFERENCE_YEAR)) + 1);
             break;
     }
-    if (date_time.unit.day > watch_utility_days_in_month(date_time.unit.month, date_time.unit.year + WATCH_RTC_REFERENCE_YEAR))
-        date_time.unit.day = 1;
     watch_rtc_set_date_time(date_time);
 }
 

--- a/apps/beats-time/app.c
+++ b/apps/beats-time/app.c
@@ -226,7 +226,7 @@ void set_time_mode_handle_secondary_button(void) {
             date_time.unit.day = date_time.unit.day + 1;
             break;
     }
-    if (date_time.unit.day > days_in_month(date_time.unit.month, date_time.unit.year + WATCH_RTC_REFERENCE_YEAR))
+    if (date_time.unit.day > watch_utility_days_in_month(date_time.unit.month, date_time.unit.year + WATCH_RTC_REFERENCE_YEAR))
         date_time.unit.day = 1;
     watch_rtc_set_date_time(date_time);
 }

--- a/movement/movement_config.h
+++ b/movement/movement_config.h
@@ -29,6 +29,7 @@
 
 const watch_face_t watch_faces[] = {
     simple_clock_face,
+    time_left_face,
     world_clock_face,
     sunrise_sunset_face,
     moon_phase_face,

--- a/movement/watch_faces/complication/day_one_face.c
+++ b/movement/watch_faces/complication/day_one_face.c
@@ -69,7 +69,7 @@ static void _day_one_face_increment(day_one_state_t *state) {
         default:
             break;
     }
-    if (state->birth_day == 0 || state->birth_day > days_in_month(state->birth_month, state->birth_year))
+    if (state->birth_day == 0 || state->birth_day > watch_utility_days_in_month(state->birth_month, state->birth_year))
         state->birth_day = 1;
 }
 

--- a/movement/watch_faces/complication/day_one_face.c
+++ b/movement/watch_faces/complication/day_one_face.c
@@ -65,6 +65,9 @@ static void _day_one_face_increment(day_one_state_t *state) {
             break;
         case PAGE_DAY:
             state->birth_day = (state->birth_day % watch_utility_days_in_month(state->birth_month, state->birth_year)) + 1;
+            if (state->birth_day == 0) {
+                state->birth_day = 1;
+            }
             break;
         default:
             break;

--- a/movement/watch_faces/complication/day_one_face.c
+++ b/movement/watch_faces/complication/day_one_face.c
@@ -64,13 +64,11 @@ static void _day_one_face_increment(day_one_state_t *state) {
             state->birth_month = (state->birth_month % 12) + 1;
             break;
         case PAGE_DAY:
-            state->birth_day = state->birth_day + 1;
+            state->birth_day = (state->birth_day % watch_utility_days_in_month(state->birth_month, state->birth_year)) + 1;
             break;
         default:
             break;
     }
-    if (state->birth_day == 0 || state->birth_day > watch_utility_days_in_month(state->birth_month, state->birth_year))
-        state->birth_day = 1;
 }
 
 void day_one_face_setup(movement_settings_t *settings, uint8_t watch_face_index, void ** context_ptr) {

--- a/movement/watch_faces/complication/time_left_face.c
+++ b/movement/watch_faces/complication/time_left_face.c
@@ -168,7 +168,7 @@ static void _handle_alarm_button(time_left_state_t *state) {
             state->birth_date.bit.month = (state->birth_date.bit.month % 12) + 1;
             break;
         case TIME_LEFT_FACE_SETTINGS_STATE + 2: // birth day
-            state->birth_date.bit.day++;
+            state->birth_date.bit.day = (state->birth_date.bit.day % watch_utility_days_in_month(state->birth_date.bit.month, state->birth_date.bit.year)) + 1;
             break;
         case TIME_LEFT_FACE_SETTINGS_STATE + 3: // target year
             state->target_date.bit.year++;
@@ -178,13 +178,9 @@ static void _handle_alarm_button(time_left_state_t *state) {
             state->target_date.bit.month = (state->target_date.bit.month % 12) + 1;
             break;
         case TIME_LEFT_FACE_SETTINGS_STATE + 5: // target day
-            state->target_date.bit.day++;
+            state->target_date.bit.day = (state->target_date.bit.day % watch_utility_days_in_month(state->target_date.bit.month, state->birth_date.bit.year)) + 1;
             break;
     }
-    if (state->birth_date.bit.day > watch_utility_days_in_month(state->birth_date.bit.month, state->birth_date.bit.year))
-        state->birth_date.bit.day = 1;
-    if (state->target_date.bit.day > watch_utility_days_in_month(state->target_date.bit.month, state->birth_date.bit.year))
-        state->target_date.bit.day = 1;
 }
 
 static void _initiate_setting(time_left_state_t *state) {

--- a/movement/watch_faces/complication/time_left_face.c
+++ b/movement/watch_faces/complication/time_left_face.c
@@ -181,9 +181,9 @@ static void _handle_alarm_button(time_left_state_t *state) {
             state->target_date.bit.day++;
             break;
     }
-    if (state->birth_date.bit.day > days_in_month(state->birth_date.bit.month, state->birth_date.bit.year))
+    if (state->birth_date.bit.day > watch_utility_days_in_month(state->birth_date.bit.month, state->birth_date.bit.year))
         state->birth_date.bit.day = 1;
-    if (state->target_date.bit.day > days_in_month(state->target_date.bit.month, state->birth_date.bit.year))
+    if (state->target_date.bit.day > watch_utility_days_in_month(state->target_date.bit.month, state->birth_date.bit.year))
         state->target_date.bit.day = 1;
 }
 

--- a/movement/watch_faces/settings/set_time_face.c
+++ b/movement/watch_faces/settings/set_time_face.c
@@ -52,7 +52,7 @@ static void _handle_alarm_button(movement_settings_t *settings, watch_date_time 
             date_time.unit.month = (date_time.unit.month % 12) + 1;
             break;
         case 5: { // day
-            date_time.unit.day = date_time.unit.day + 1;
+            date_time.unit.day = (date_time.unit.day % watch_utility_days_in_month(date_time.unit.month, date_time.unit.year + WATCH_RTC_REFERENCE_YEAR)) + 1;
             break;
         }
         case 6: // time zone
@@ -60,8 +60,6 @@ static void _handle_alarm_button(movement_settings_t *settings, watch_date_time 
             if (settings->bit.time_zone > 40) settings->bit.time_zone = 0;
             break;
     }
-    if (date_time.unit.day > watch_utility_days_in_month(date_time.unit.month, date_time.unit.year + WATCH_RTC_REFERENCE_YEAR))
-        date_time.unit.day = 1;
     watch_rtc_set_date_time(date_time);
 }
 

--- a/movement/watch_faces/settings/set_time_face.c
+++ b/movement/watch_faces/settings/set_time_face.c
@@ -60,7 +60,7 @@ static void _handle_alarm_button(movement_settings_t *settings, watch_date_time 
             if (settings->bit.time_zone > 40) settings->bit.time_zone = 0;
             break;
     }
-    if (date_time.unit.day > days_in_month(date_time.unit.month, date_time.unit.year + WATCH_RTC_REFERENCE_YEAR))
+    if (date_time.unit.day > watch_utility_days_in_month(date_time.unit.month, date_time.unit.year + WATCH_RTC_REFERENCE_YEAR))
         date_time.unit.day = 1;
     watch_rtc_set_date_time(date_time);
 }

--- a/movement/watch_faces/settings/set_time_hackwatch_face.c
+++ b/movement/watch_faces/settings/set_time_hackwatch_face.c
@@ -164,15 +164,13 @@ bool set_time_hackwatch_face_loop(movement_event_t event, movement_settings_t *s
                     date_time_settings.unit.month = (date_time_settings.unit.month % 12) + 1;
                     break;
                 case 5: // day
-                    date_time_settings.unit.day = date_time_settings.unit.day + 1;
+                    date_time_settings.unit.day = (date_time_settings.unit.day % watch_utility_days_in_month(date_time_settings.unit.month, date_time_settings.unit.year + WATCH_RTC_REFERENCE_YEAR)) + 1;
                     break;
                 case 6: // time zone
                     settings->bit.time_zone++;
                     if (settings->bit.time_zone > 40) settings->bit.time_zone = 0;
                     break;
             }
-            if (date_time_settings.unit.day > watch_utility_days_in_month(date_time_settings.unit.month, date_time_settings.unit.year + WATCH_RTC_REFERENCE_YEAR))
-                date_time_settings.unit.day = 1;
             if (current_page != 2) // Do not set time when we are at seconds, it was already set previously
                 watch_rtc_set_date_time(date_time_settings);
             //TODO: Do not update whole RTC, just what we are changing

--- a/movement/watch_faces/settings/set_time_hackwatch_face.c
+++ b/movement/watch_faces/settings/set_time_hackwatch_face.c
@@ -120,7 +120,7 @@ bool set_time_hackwatch_face_loop(movement_event_t event, movement_settings_t *s
                 case 5: // day
                     date_time_settings.unit.day = date_time_settings.unit.day - 2;
                     if (date_time_settings.unit.day == 0) {
-                        date_time_settings.unit.day = days_in_month(date_time_settings.unit.month, date_time_settings.unit.year + WATCH_RTC_REFERENCE_YEAR);
+                        date_time_settings.unit.day = watch_utility_days_in_month(date_time_settings.unit.month, date_time_settings.unit.year + WATCH_RTC_REFERENCE_YEAR);
                     } else
                         date_time_settings.unit.day++;
                     break;
@@ -171,7 +171,7 @@ bool set_time_hackwatch_face_loop(movement_event_t event, movement_settings_t *s
                     if (settings->bit.time_zone > 40) settings->bit.time_zone = 0;
                     break;
             }
-            if (date_time_settings.unit.day > days_in_month(date_time_settings.unit.month, date_time_settings.unit.year + WATCH_RTC_REFERENCE_YEAR))
+            if (date_time_settings.unit.day > watch_utility_days_in_month(date_time_settings.unit.month, date_time_settings.unit.year + WATCH_RTC_REFERENCE_YEAR))
                 date_time_settings.unit.day = 1;
             if (current_page != 2) // Do not set time when we are at seconds, it was already set previously
                 watch_rtc_set_date_time(date_time_settings);

--- a/watch-library/shared/watch/watch_utility.c
+++ b/watch-library/shared/watch/watch_utility.c
@@ -316,7 +316,7 @@ uint32_t watch_utility_offset_timestamp(uint32_t now, int8_t hours, int8_t minut
     return new;
 }
 
-uint8_t days_in_month(uint8_t month, uint16_t year) {
+uint8_t watch_utility_days_in_month(uint8_t month, uint16_t year) {
     static const uint8_t days_in_month[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
     uint8_t days = days_in_month[month - 1];
     if (month == 2 && is_leap(year))

--- a/watch-library/shared/watch/watch_utility.h
+++ b/watch-library/shared/watch/watch_utility.h
@@ -168,6 +168,6 @@ uint32_t watch_utility_offset_timestamp(uint32_t now, int8_t hours, int8_t minut
  * @param month The month of the date (1-12)
  * @param year The year of the date (ex. 2022)
  */
-uint8_t days_in_month(uint8_t month, uint16_t year);
+uint8_t watch_utility_days_in_month(uint8_t month, uint16_t year);
 
 #endif


### PR DESCRIPTION
This PR does two things:
1. It renames `days_in_month` to `watch_utility_days_in_month`. This is to make the function match other functions found in `watch_utility`, and to avoid conflicts with the upcoming UTZ logic, which also includes a function called `days_in_month`.
2. There is a bug where if you roll over the current date, the day will start at 0, rather than 1 because `day` is held in a 5 bit variable. Before, we added to the day and then checked if it's larger than how many days are in a month. With October, there are 31 days, and that means that it'll write 32 to the bit before changing it to one. However, 32 will overflow to 0.

I tested `set_time_face` and `time_left_face` with October being the month to attempt an overflow and they both now work.