### PR TITLE
timer face - missing colon after leaving settings fix

### DIFF
--- a/movement/watch_faces/complication/timer_face.c
+++ b/movement/watch_faces/complication/timer_face.c
@@ -109,6 +109,7 @@ static void _draw(timer_state_t *state, uint8_t subsecond) {
             sprintf(buf, " %02u%02u%02u", state->timers[state->current_timer].unit.hours,
                     state->timers[state->current_timer].unit.minutes,
                     state->timers[state->current_timer].unit.seconds);
+                watch_set_colon();
             break;
     }
     buf[0] = 49 + state->current_timer;


### PR DESCRIPTION
This commit fixes the issue, where holding the light mode to leave settings at the 'Clear' or 'Loop' dialog doesn't re-enable the colon until going through settings or loading the face again.

Before:


https://github.com/user-attachments/assets/96522398-ceca-474f-91f4-121b0ba37b7d



After:

https://github.com/user-attachments/assets/f9f9910d-27d0-46e7-8f6b-c25ed716ede3



