### PR TITLE
Fix copy paste error

### DIFF
--- a/movement/watch_faces/clock/weeknumber_clock_face.h
+++ b/movement/watch_faces/clock/weeknumber_clock_face.h
@@ -58,4 +58,4 @@ bool weeknumber_clock_face_wants_background_task(movement_settings_t *settings, 
     weeknumber_clock_face_wants_background_task, \
 })
 
-#endif // SIMPLE_CLOCK_FACE_H_
+#endif // WEEKNUMBER_CLOCK_FACE_H_


### PR DESCRIPTION
Not that it matters for functionality but there seems to be a leftover artifact from copy pasting from simple watch face to the week number face 