### PR TITLE
Daylight saving support for World Clock 2

### DIFF
--- a/movement/watch_faces/clock/world_clock2_face.h
+++ b/movement/watch_faces/clock/world_clock2_face.h
@@ -57,7 +57,10 @@
  *  * A long press on the LIGHT button selects the current time zone, and
  *    the signal indicator appears at the top left. Another long press of
  *    the LIGHT button deselects the time zone.
- *  * A long press on the ALARM button exits settings mode and returns to
+ *  * A long press on the ALARM button toggles daylight saving for the 
+ *    current time zone, and the lap indicator appears at the top right.
+ *    Another long press of the ALARM button toggles daylight saving off.
+ *  * A press on the MODE button exits settings mode and returns to
  *    display mode.
  *
  * Display mode
@@ -97,6 +100,7 @@ typedef enum {
 
 typedef struct {
     bool selected;
+    bool daylight_saving;
 } world_clock2_zone_t;
 
 typedef struct {


### PR DESCRIPTION
The world clock face 2 currently does not support daylight saving time. This results in incorrect time displays when daylight saving is active in one time zone but not in another. I have extended the watch face to support this feature:

- Added daylight saving toggle for the current time zone via long press on the ALARM button in settings mode.
- Updated the display logic to reflect the daylight saving status using the lap indicator.
- Enhanced the documentation to reflect the new behavior.

Previously, a long press on the ALARM button was used to return from the settings to the display face. This functionality has now been reassigned to the MODE button, which I consider a natural “return” action when navigating from a settings face. While this might diverge from common practice, it feels intuitive within the overall interface flow.