### PR TITLE
Update discgolf_face.c

### DIFF
--- a/movement/watch_faces/complication/discgolf_face.c
+++ b/movement/watch_faces/complication/discgolf_face.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
-#include "discgolf_face.h"
-#include "watch.h"          // Remember to change number of courses in this file
+#include "discgolf_face.h"　　　　// Remember to change number of courses in this file
+#include "watch.h"          
 #include "watch_utility.h"
 
 /* 


### PR DESCRIPTION
It seems that the `courses` variable should be defined in `discgolf.h` rather than in `watch.h`, so the comment in `discgolf.c` appears to be misplaced by one line.